### PR TITLE
[TEST] MySQL 테스트 환경 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI Build
 on:
-  push:
+  pull_request:
     branches:
       - '**'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - '**'
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: 저장소 Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI Build
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 저장소 Checkout
+        uses: actions/checkout@v3
+
+      - name: 자바 17 설정
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: 빌드
+        run: SPRING_PROFILES_ACTIVE=ci ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
+    // TestContainer
     testImplementation "org.testcontainers:testcontainers:1.19.3"
     testImplementation "org.testcontainers:junit-jupiter:1.19.3"
     testImplementation "org.testcontainers:mysql:1.19.3"

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
     // monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    testImplementation "org.testcontainers:testcontainers:1.19.3"
+    testImplementation "org.testcontainers:junit-jupiter:1.19.3"
+    testImplementation "org.testcontainers:mysql:1.19.3"
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8.0:///test_container_test
+    username: root
+    password: password
+  jpa:
+      hibernate:
+        format_sql: true
+        show_sql: true
+
+report-check-origin: fake-origin.com
+cors-allow-origins: http://localhost:3000

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,6 +29,13 @@ spring:
 spring:
   config:
     activate:
+      on-profile: ci
+    import: application-ci.yml
+
+---
+spring:
+  config:
+    activate:
       on-profile: prod
     import:
       - classpath:be-config/application-prod.yml

--- a/src/test/java/com/sports/server/support/isolation/DatabaseManager.java
+++ b/src/test/java/com/sports/server/support/isolation/DatabaseManager.java
@@ -40,10 +40,10 @@ public class DatabaseManager {
     }
 
     public void truncateTables() {
-        entityManager.createNativeQuery("SET foreign_key_checks = 0").executeUpdate();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
         for (String tableName : tableNames) {
             entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
         }
-        entityManager.createNativeQuery("SET foreign_key_checks = 1").executeUpdate();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
     }
 }

--- a/src/test/java/com/sports/server/support/isolation/DatabaseManager.java
+++ b/src/test/java/com/sports/server/support/isolation/DatabaseManager.java
@@ -40,10 +40,10 @@ public class DatabaseManager {
     }
 
     public void truncateTables() {
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        entityManager.createNativeQuery("SET foreign_key_checks = 0").executeUpdate();
         for (String tableName : tableNames) {
             entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
         }
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        entityManager.createNativeQuery("SET foreign_key_checks = 1").executeUpdate();
     }
 }

--- a/src/test/java/com/sports/server/support/isolation/DatabaseManager.java
+++ b/src/test/java/com/sports/server/support/isolation/DatabaseManager.java
@@ -12,8 +12,6 @@ import java.util.List;
 @Transactional
 public class DatabaseManager {
 
-    private static final String SYS_CONFIG_TABLE_NAME = "sys_config";
-
     private final EntityManager entityManager;
     private final List<String> tableNames;
 
@@ -38,14 +36,14 @@ public class DatabaseManager {
         String replacement = "$1_$2";
         return entityType.getName()
                 .replaceAll(regex, replacement)
-                .toUpperCase() + "S";
+                .toLowerCase() + "s";
     }
 
     public void truncateTables() {
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        entityManager.createNativeQuery("SET foreign_key_checks = 0").executeUpdate();
         for (String tableName : tableNames) {
             entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
         }
-        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+        entityManager.createNativeQuery("SET foreign_key_checks = 1").executeUpdate();
     }
 }


### PR DESCRIPTION
## 🌍 이슈 번호
closed #95 

## 📝 구현 내용
- TestContainer 의존성을 추가
- active profile이 local일 때는 h2로 테스트가 돌고 ci일 때는 도커 컨테이너로 mysql을 구동시켜서 테스트를 진행
- PR을 날리면 `active profile = ci` 환경에서 테스트가 돌면서 mysql 환경 테스트를 수행
- 평소 로컬에서 개발할 때는 h2 테스트 수행

### 로컬 테스트 환경과 CI 테스트 환경을 나눈 이유
사실 TestContainer를 사용하면 MySQL 컨테이너가 자동으로 구동되어 MySQL DB를 세팅해주기 때문에 로컬에서도 사용할 수 있습니다. 하지만 로컬 테스트에 적용할 때 아래와 같은 단점이 존재합니다.

- 도커를 켜야 한다.
- 테스트 속도가 느리다.

도커를 띄어서 테스트를 진행하게 되면 제 맥북 기준 12초가 걸리고 H2를 사용할 때는 2초밖에 안 걸립니다. 전체 테스트를 돌릴 경우가 많을텐데 매번 12초 이상 걸린다면 답답할 거라 생각해요. (인텔리제이에서 표시해주는 시간만 12초이지 실제 시간은 더 걸립니다. 스프링 컨텍스트를 띄우는 중에는 시간이 측정 안되기 때문에..)

그래서 로컬에서 개발할 때는 H2 데이터베이스를 사용해서 빠른 테스트 속도를 누리도록 했습니다. 단 MySQL 테스트가 최소 한 번 이상은 필요하기 때문에 필요할 때 application.yml에 profile을 `ci`로 변경하면 MySQL 테스트를 진행할 수 있습니다.

MySQL 테스트를 안하고 머지하는 휴먼 에러를 방지하기 위해 ci.yml을 추가했습니다. 기능 개발이 완료되고 PR을 날리게 되면 깃헙 액션에서 mysql 테스트를 대신 진행합니다. 테스트가 실패하면 머지를 막도록 설정했습니다.
++ 슬랙 메시지에서 깃헙액션 체크가 통과했는지 여부를 알려주네요

## 🍀 확인해야 할 부분
테스트 플로우 다 이해 되셨을까요? 이해 안되신거 질문해주세요!