### PR TITLE
[FEAT] 스포츠 전체 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -56,7 +56,7 @@ operation::report-controller-test/응원톡을_신고한다[snippets='http-reque
 
 operation::league-query-controller-test/리그_전체를_조회한다[snippets='http-request,http-response,response-fields']
 
-=== 리그에 해당하는 스포츠 종목 조회
+=== 리그에 해당하는 스포츠 전체 조회
 
 operation::league-query-controller-test/리그의_해당하는_스포츠_전체를_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
 
@@ -64,7 +64,7 @@ operation::league-query-controller-test/리그의_해당하는_스포츠_전체�
 
 === 게임의 타임라인 조회
 
-operation::timeline-query-controller-test/타임라인을_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
+// operation::timeline-query-controller-test/타임라인을_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
 
 == 스포츠 API
 

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -61,5 +61,13 @@ operation::league-query-controller-test/리그_전체를_조회한다[snippets='
 operation::league-query-controller-test/리그의_해당하는_스포츠_전체를_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
 
 == 타임라인 API
+
 === 게임의 타임라인 조회
+
 operation::timeline-query-controller-test/타임라인을_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
+
+== 스포츠 API
+
+=== 스포츠 전체 조회
+
+operation::sport-query-controller-test/종목을_전체_조회한다[snippets='http-request,http-response,response-fields']

--- a/src/main/java/com/sports/server/query/application/SportQueryService.java
+++ b/src/main/java/com/sports/server/query/application/SportQueryService.java
@@ -1,0 +1,20 @@
+package com.sports.server.query.application;
+
+import com.sports.server.query.dto.response.SportResponse;
+import com.sports.server.query.repository.SportQueryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SportQueryService {
+
+    private final SportQueryRepository sportQueryRepository;
+
+    public List<SportResponse> findAll() {
+        return sportQueryRepository.findAll().stream().map(SportResponse::new).toList();
+    }
+}

--- a/src/main/java/com/sports/server/query/dto/response/SportResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/SportResponse.java
@@ -1,0 +1,16 @@
+package com.sports.server.query.dto.response;
+
+import com.sports.server.command.sport.domain.Sport;
+
+public record SportResponse(
+        Long id,
+        String name
+
+) {
+    public SportResponse(Sport sport) {
+        this(
+                sport.getId(),
+                sport.getName()
+        );
+    }
+}

--- a/src/main/java/com/sports/server/query/presentation/SportQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/SportQueryController.java
@@ -1,0 +1,21 @@
+package com.sports.server.query.presentation;
+
+import com.sports.server.query.application.SportQueryService;
+import com.sports.server.query.dto.response.SportResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sports")
+public class SportQueryController {
+
+    private SportQueryService sportQueryService;
+
+    public ResponseEntity<List<SportResponse>> findAll() {
+        return ResponseEntity.ok(sportQueryService.findAll());
+    }
+}

--- a/src/main/java/com/sports/server/query/presentation/SportQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/SportQueryController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/sports" )
 public class SportQueryController {
 
-    private SportQueryService sportQueryService;
+    private final SportQueryService sportQueryService;
 
     @GetMapping
     public ResponseEntity<List<SportResponse>> findAll() {

--- a/src/main/java/com/sports/server/query/presentation/SportQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/SportQueryController.java
@@ -5,16 +5,18 @@ import com.sports.server.query.dto.response.SportResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/sports")
+@RequestMapping("/sports" )
 public class SportQueryController {
 
     private SportQueryService sportQueryService;
 
+    @GetMapping
     public ResponseEntity<List<SportResponse>> findAll() {
         return ResponseEntity.ok(sportQueryService.findAll());
     }

--- a/src/main/java/com/sports/server/query/repository/SportQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/SportQueryRepository.java
@@ -1,10 +1,9 @@
 package com.sports.server.query.repository;
 
-import com.sports.server.command.record.domain.Record;
 import com.sports.server.command.sport.domain.Sport;
 import java.util.List;
 import org.springframework.data.repository.Repository;
 
-public interface SportQueryRepository extends Repository<Record, Long> {
+public interface SportQueryRepository extends Repository<Sport, Long> {
     List<Sport> findAll();
 }

--- a/src/main/java/com/sports/server/query/repository/SportQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/SportQueryRepository.java
@@ -1,0 +1,10 @@
+package com.sports.server.query.repository;
+
+import com.sports.server.command.record.domain.Record;
+import com.sports.server.command.sport.domain.Sport;
+import java.util.List;
+import org.springframework.data.repository.Repository;
+
+public interface SportQueryRepository extends Repository<Record, Long> {
+    List<Sport> findAll();
+}

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -475,12 +475,17 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_리그_api">리그 API</a>
 <ul class="sectlevel2">
 <li><a href="#_리그_전체_조회">리그 전체 조회</a></li>
-<li><a href="#_리그에_해당하는_스포츠_종목_조회">리그에 해당하는 스포츠 종목 조회</a></li>
+<li><a href="#_리그에_해당하는_스포츠_전체_조회">리그에 해당하는 스포츠 전체 조회</a></li>
 </ul>
 </li>
 <li><a href="#_타임라인_api">타임라인 API</a>
 <ul class="sectlevel2">
 <li><a href="#_게임의_타임라인_조회">게임의 타임라인 조회</a></li>
+</ul>
+</li>
+<li><a href="#_스포츠_api">스포츠 API</a>
+<ul class="sectlevel2">
+<li><a href="#_스포츠_전체_조회">스포츠 전체 조회</a></li>
 </ul>
 </li>
 </ul>
@@ -499,7 +504,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /cheer-talks HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 53
-Host: localhost:8080
+Host: www.api.hufstreaming.site
 
 {
   "content" : "응원해요~",
@@ -557,7 +562,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /games/1/cheer-talks?cursor=1&amp;size=2 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Host: localhost:8080</code></pre>
+Host: www.api.hufstreaming.site</code></pre>
 </div>
 </div>
 </div>
@@ -700,7 +705,7 @@ Content-Length: 303
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /games/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Host: localhost:8080</code></pre>
+Host: www.api.hufstreaming.site</code></pre>
 </div>
 </div>
 </div>
@@ -843,7 +848,7 @@ Content-Length: 414
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /games/1/video HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Host: localhost:8080</code></pre>
+Host: www.api.hufstreaming.site</code></pre>
 </div>
 </div>
 </div>
@@ -919,7 +924,7 @@ Content-Length: 27
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /games?league_id=1&amp;status=PLAYING&amp;sport_id=1&amp;sport_id=2&amp;cursor=12&amp;size=10 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Host: localhost:8080</code></pre>
+Host: www.api.hufstreaming.site</code></pre>
 </div>
 </div>
 </div>
@@ -1091,7 +1096,7 @@ Content-Length: 813
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /games/1/cheer HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Host: localhost:8080</code></pre>
+Host: www.api.hufstreaming.site</code></pre>
 </div>
 </div>
 </div>
@@ -1183,7 +1188,7 @@ Content-Length: 124
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /games/1/lineup HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Host: localhost:8080</code></pre>
+Host: www.api.hufstreaming.site</code></pre>
 </div>
 </div>
 </div>
@@ -1323,7 +1328,7 @@ Content-Length: 832
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /games/1/cheer HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 42
-Host: localhost:8080
+Host: www.api.hufstreaming.site
 
 {
   "gameTeamId" : 1,
@@ -1387,7 +1392,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /reports HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 23
-Host: localhost:8080
+Host: www.api.hufstreaming.site
 
 {
   "cheerTalkId" : 1
@@ -1444,7 +1449,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /leagues HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Host: localhost:8080</code></pre>
+Host: www.api.hufstreaming.site</code></pre>
 </div>
 </div>
 </div>
@@ -1500,19 +1505,19 @@ Content-Length: 108
 </div>
 </div>
 <div class="sect2">
-<h3 id="_리그에_해당하는_스포츠_종목_조회"><a class="link" href="#_리그에_해당하는_스포츠_종목_조회">리그에 해당하는 스포츠 종목 조회</a></h3>
+<h3 id="_리그에_해당하는_스포츠_전체_조회"><a class="link" href="#_리그에_해당하는_스포츠_전체_조회">리그에 해당하는 스포츠 전체 조회</a></h3>
 <div class="sect3">
-<h4 id="_리그에_해당하는_스포츠_종목_조회_http_request"><a class="link" href="#_리그에_해당하는_스포츠_종목_조회_http_request">HTTP request</a></h4>
+<h4 id="_리그에_해당하는_스포츠_전체_조회_http_request"><a class="link" href="#_리그에_해당하는_스포츠_전체_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /leagues/1/sports HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Host: localhost:8080</code></pre>
+Host: www.api.hufstreaming.site</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_리그에_해당하는_스포츠_종목_조회_path_parameters"><a class="link" href="#_리그에_해당하는_스포츠_종목_조회_path_parameters">Path parameters</a></h4>
+<h4 id="_리그에_해당하는_스포츠_전체_조회_path_parameters"><a class="link" href="#_리그에_해당하는_스포츠_전체_조회_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 1. /leagues/{leagueId}/sports</caption>
 <colgroup>
@@ -1534,7 +1539,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_리그에_해당하는_스포츠_종목_조회_http_response"><a class="link" href="#_리그에_해당하는_스포츠_종목_조회_http_response">HTTP response</a></h4>
+<h4 id="_리그에_해당하는_스포츠_전체_조회_http_response"><a class="link" href="#_리그에_해당하는_스포츠_전체_조회_http_response">HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1555,7 +1560,7 @@ Content-Length: 86
 </div>
 </div>
 <div class="sect3">
-<h4 id="_리그에_해당하는_스포츠_종목_조회_response_fields"><a class="link" href="#_리그에_해당하는_스포츠_종목_조회_response_fields">Response fields</a></h4>
+<h4 id="_리그에_해당하는_스포츠_전체_조회_response_fields"><a class="link" href="#_리그에_해당하는_스포츠_전체_조회_response_fields">Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1591,40 +1596,27 @@ Content-Length: 86
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_게임의_타임라인_조회"><a class="link" href="#_게임의_타임라인_조회">게임의 타임라인 조회</a></h3>
+
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_스포츠_api"><a class="link" href="#_스포츠_api">스포츠 API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_스포츠_전체_조회"><a class="link" href="#_스포츠_전체_조회">스포츠 전체 조회</a></h3>
 <div class="sect3">
-<h4 id="_게임의_타임라인_조회_http_request"><a class="link" href="#_게임의_타임라인_조회_http_request">HTTP request</a></h4>
+<h4 id="_스포츠_전체_조회_http_request"><a class="link" href="#_스포츠_전체_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /games/1/timeline HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /sports HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Host: localhost:8080</code></pre>
+Host: www.api.hufstreaming.site</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_게임의_타임라인_조회_path_parameters"><a class="link" href="#_게임의_타임라인_조회_path_parameters">Path parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /games/{gameId}/timeline</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>gameId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">게임의 ID</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_게임의_타임라인_조회_http_response"><a class="link" href="#_게임의_타임라인_조회_http_response">HTTP response</a></h4>
+<h4 id="_스포츠_전체_조회_http_response"><a class="link" href="#_스포츠_전체_조회_http_response">HTTP response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1632,40 +1624,20 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 540
+Content-Length: 82
 
 [ {
-  "gameQuarter" : "쿼터1",
-  "records" : [ {
-    "scoredAt" : 25,
-    "playerName" : "선수이름",
-    "teamName" : "팀이름",
-    "score" : 1
-  }, {
-    "scoredAt" : 30,
-    "playerName" : "선수이름",
-    "teamName" : "팀이름",
-    "score" : 1
-  } ]
+  "id" : 1,
+  "name" : "농구"
 }, {
-  "gameQuarter" : "쿼터2",
-  "records" : [ {
-    "scoredAt" : 25,
-    "playerName" : "선수이름",
-    "teamName" : "팀이름",
-    "score" : 1
-  }, {
-    "scoredAt" : 30,
-    "playerName" : "선수이름",
-    "teamName" : "팀이름",
-    "score" : 1
-  } ]
+  "id" : 2,
+  "name" : "루미큐브"
 } ]</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_게임의_타임라인_조회_response_fields"><a class="link" href="#_게임의_타임라인_조회_response_fields">Response fields</a></h4>
+<h4 id="_스포츠_전체_조회_response_fields"><a class="link" href="#_스포츠_전체_조회_response_fields">Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1681,29 +1653,14 @@ Content-Length: 540
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].gameQuarter</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">쿼터의 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].scoredAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].id</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">득점한 시간</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종목의 ID</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].playerName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">득점한 선수의 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].teamName</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">팀 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].score</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">득점한 점수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종목의 이름</p></td>
 </tr>
 </tbody>
 </table>
@@ -1715,7 +1672,7 @@ Content-Length: 540
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-23 18:44:36 +0900
+Last updated 2024-02-14 18:59:40 UTC
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/sports/server/command/cheertalk/presentation/CheerTalkControllerTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/presentation/CheerTalkControllerTest.java
@@ -27,7 +27,7 @@ class CheerTalkControllerTest extends DocumentationTest {
         );
 
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         requestFields(
                                 fieldWithPath("content").type(JsonFieldType.STRING).description("응원톡의 내용"),
                                 fieldWithPath("gameTeamId").type(JsonFieldType.NUMBER).description("응원하는 게임팀")

--- a/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
+++ b/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
@@ -32,7 +32,7 @@ public class GameControllerTest extends DocumentationTest {
 
         //then
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         pathParameters(
                                 parameterWithName("gameId").description("게임의 ID")
                         ),

--- a/src/test/java/com/sports/server/command/report/presentation/ReportControllerTest.java
+++ b/src/test/java/com/sports/server/command/report/presentation/ReportControllerTest.java
@@ -28,7 +28,7 @@ public class ReportControllerTest extends DocumentationTest {
 
         //then
         result.andExpect((status().isNoContent()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         requestFields(
                                 fieldWithPath("cheerTalkId").type(JsonFieldType.NUMBER).description("신고하는 응원톡의 ID")
                         )

--- a/src/test/java/com/sports/server/query/acceptance/SportQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/SportQueryAcceptanceTest.java
@@ -1,0 +1,43 @@
+package com.sports.server.query.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.sports.server.query.dto.response.SportResponse;
+import com.sports.server.support.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql("/game-fixture.sql")
+public class SportQueryAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 모든_종목을_조회한다() {
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/sports")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<SportResponse> actual = toResponses(response, SportResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual)
+                        .map(SportResponse::id)
+                        .containsExactly(1L, 2L),
+                () -> assertThat(actual)
+                        .map(SportResponse::name)
+                        .containsExactly("농구", "루미큐브"));
+    }
+
+}

--- a/src/test/java/com/sports/server/query/acceptance/SportQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/SportQueryAcceptanceTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.jdbc.Sql;
 public class SportQueryAcceptanceTest extends AcceptanceTest {
 
     @Test
-    void 모든_종목을_조회한다() {
+    void 모든_스포츠를_조회한다() {
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()

--- a/src/test/java/com/sports/server/query/presentation/CheerTalkQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/CheerTalkQueryControllerTest.java
@@ -51,7 +51,7 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
         );
 
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         queryParameters(
                                 parameterWithName("cursor").description("마지막 응원톡의 ID"),
                                 parameterWithName("size").description("조회하고자 하는 응원톡의 개수")

--- a/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
@@ -44,7 +44,7 @@ class GameQueryControllerTest extends DocumentationTest {
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         pathParameters(
                                 parameterWithName("gameId").description("게임의 ID")
                         ),
@@ -78,7 +78,7 @@ class GameQueryControllerTest extends DocumentationTest {
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         pathParameters(
                                 parameterWithName("gameId").description("게임의 ID")
                         ),
@@ -121,7 +121,7 @@ class GameQueryControllerTest extends DocumentationTest {
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         queryParameters(
                                 parameterWithName("league_id").description("대회의 ID"),
                                 parameterWithName("status").description("게임의 상태"),
@@ -161,7 +161,7 @@ class GameQueryControllerTest extends DocumentationTest {
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         pathParameters(
                                 parameterWithName("gameId").description("게임의 ID")
                         ),
@@ -205,7 +205,7 @@ class GameQueryControllerTest extends DocumentationTest {
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         pathParameters(
                                 parameterWithName("gameId").description("게임의 ID")
                         ),

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -38,7 +38,7 @@ public class LeagueQueryControllerTest extends DocumentationTest {
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         responseFields(
                                 fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("리그의 ID"),
                                 fieldWithPath("[].name").type(JsonFieldType.STRING).description("리그의 이름")
@@ -67,7 +67,7 @@ public class LeagueQueryControllerTest extends DocumentationTest {
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         pathParameters(
                                 parameterWithName("leagueId").description("리그의 ID")
                         ),

--- a/src/test/java/com/sports/server/query/presentation/SportQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/SportQueryControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 public class SportQueryControllerTest extends DocumentationTest {
 
     @Test
-    void 종목을_전체_조회한다() throws Exception {
+    void 스포츠를_전체_조회한다() throws Exception {
 
         // given
         List<SportResponse> responses = List.of(
@@ -37,11 +37,10 @@ public class SportQueryControllerTest extends DocumentationTest {
         result.andExpect((status().isOk()))
                 .andDo(restDocsHandler.document(
                         responseFields(
-                                fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("종목의 ID"),
-                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("종목의 이름")
+                                fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("스포츠의 ID"),
+                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("스포츠의 이름")
                         )
                 ));
 
     }
-
 }

--- a/src/test/java/com/sports/server/query/presentation/SportQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/SportQueryControllerTest.java
@@ -35,7 +35,7 @@ public class SportQueryControllerTest extends DocumentationTest {
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         responseFields(
                                 fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("종목의 ID"),
                                 fieldWithPath("[].name").type(JsonFieldType.STRING).description("종목의 이름")

--- a/src/test/java/com/sports/server/query/presentation/SportQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/SportQueryControllerTest.java
@@ -1,0 +1,47 @@
+package com.sports.server.query.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sports.server.query.dto.response.SportResponse;
+import com.sports.server.support.DocumentationTest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class SportQueryControllerTest extends DocumentationTest {
+
+    @Test
+    void 종목을_전체_조회한다() throws Exception {
+
+        // given
+        List<SportResponse> responses = List.of(
+                new SportResponse(1L, "농구"),
+                new SportResponse(2L, "루미큐브")
+        );
+
+        given(sportQueryService.findAll())
+                .willReturn(responses);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/sports")
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(RESULT_HANDLER.document(
+                        responseFields(
+                                fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("종목의 ID"),
+                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("종목의 이름")
+                        )
+                ));
+
+    }
+
+}

--- a/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
@@ -49,7 +49,7 @@ public class TimelineQueryControllerTest extends DocumentationTest {
 
         // then
         result.andExpect((status().isOk()))
-                .andDo(RESULT_HANDLER.document(
+                .andDo(restDocsHandler.document(
                         pathParameters(
                                 parameterWithName("gameId").description("게임의 ID")
                         ),

--- a/src/test/java/com/sports/server/support/DocumentationTest.java
+++ b/src/test/java/com/sports/server/support/DocumentationTest.java
@@ -19,10 +19,12 @@ import com.sports.server.query.application.GameQueryService;
 import com.sports.server.query.application.GameTeamQueryService;
 import com.sports.server.query.application.LeagueQueryService;
 import com.sports.server.query.application.LineupPlayerQueryService;
+import com.sports.server.query.application.SportQueryService;
 import com.sports.server.query.application.TimelineQueryService;
 import com.sports.server.query.presentation.CheerTalkQueryController;
 import com.sports.server.query.presentation.GameQueryController;
 import com.sports.server.query.presentation.LeagueQueryController;
+import com.sports.server.query.presentation.SportQueryController;
 import com.sports.server.query.presentation.TimelineQueryController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -40,7 +42,8 @@ import org.springframework.test.web.servlet.MockMvc;
         CheerTalkQueryController.class,
         GameQueryController.class,
         LeagueQueryController.class,
-        TimelineQueryController.class
+        TimelineQueryController.class,
+        SportQueryController.class
 })
 @Import({
         TimeLogTemplate.class
@@ -49,8 +52,8 @@ import org.springframework.test.web.servlet.MockMvc;
 public class DocumentationTest {
 
     private static final OperationRequestPreprocessor HOST_INFO = preprocessRequest(modifyUris()
-            .scheme("https")
-            .host("www.api.hufstreaming.site")
+            .scheme("https" )
+            .host("www.api.hufstreaming.site" )
             .removePort(), prettyPrint()
     );
 
@@ -92,4 +95,7 @@ public class DocumentationTest {
 
     @MockBean
     protected TimelineQueryService timelineQueryService;
+
+    @MockBean
+    protected SportQueryService sportQueryService;
 }

--- a/src/test/java/com/sports/server/support/DocumentationTest.java
+++ b/src/test/java/com/sports/server/support/DocumentationTest.java
@@ -1,11 +1,5 @@
 package com.sports.server.support;
 
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sports.server.command.cheertalk.application.CheerTalkService;
 import com.sports.server.command.cheertalk.presentation.CheerTalkController;
@@ -14,25 +8,14 @@ import com.sports.server.command.game.presentation.GameController;
 import com.sports.server.command.report.application.ReportService;
 import com.sports.server.command.report.presentation.ReportController;
 import com.sports.server.common.log.TimeLogTemplate;
-import com.sports.server.query.application.CheerTalkQueryService;
-import com.sports.server.query.application.GameQueryService;
-import com.sports.server.query.application.GameTeamQueryService;
-import com.sports.server.query.application.LeagueQueryService;
-import com.sports.server.query.application.LineupPlayerQueryService;
-import com.sports.server.query.application.SportQueryService;
-import com.sports.server.query.application.TimelineQueryService;
-import com.sports.server.query.presentation.CheerTalkQueryController;
-import com.sports.server.query.presentation.GameQueryController;
-import com.sports.server.query.presentation.LeagueQueryController;
-import com.sports.server.query.presentation.SportQueryController;
-import com.sports.server.query.presentation.TimelineQueryController;
+import com.sports.server.query.application.*;
+import com.sports.server.query.presentation.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {
@@ -46,22 +29,14 @@ import org.springframework.test.web.servlet.MockMvc;
         SportQueryController.class
 })
 @Import({
-        TimeLogTemplate.class
+        TimeLogTemplate.class,
+        RestDocsConfig.class
 })
 @AutoConfigureRestDocs
 public class DocumentationTest {
 
-    private static final OperationRequestPreprocessor HOST_INFO = preprocessRequest(modifyUris()
-            .scheme("https" )
-            .host("www.api.hufstreaming.site" )
-            .removePort(), prettyPrint()
-    );
-
-    protected static final RestDocumentationResultHandler RESULT_HANDLER = document(
-            "{class-name}/{method-name}",
-            HOST_INFO,
-            preprocessResponse(prettyPrint())
-    );
+    @Autowired
+    protected RestDocumentationResultHandler restDocsHandler;
 
     @Autowired
     protected MockMvc mockMvc;

--- a/src/test/java/com/sports/server/support/RestDocsConfig.java
+++ b/src/test/java/com/sports/server/support/RestDocsConfig.java
@@ -1,0 +1,28 @@
+package com.sports.server.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+    private static final OperationRequestPreprocessor HOST_INFO = preprocessRequest(modifyUris()
+            .scheme("https" )
+            .host("www.api.hufstreaming.site" )
+            .removePort(), prettyPrint()
+    );
+
+    @Bean
+    public RestDocumentationResultHandler restDocsMockMvcConfigurationCustomizer() {
+        return MockMvcRestDocumentation.document(
+                "{class-name}/{method-name}",
+                HOST_INFO,
+                preprocessResponse(prettyPrint())
+        );
+    }
+}


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #102 

## 📝 구현 내용
- 스포츠 종목 전체 조회 기능 구현

## 🍀 확인해야 할 부분
- 도메인 용어 통일 필요하다고 생각
   - 종목 / 스포츠 / 스포츠 종목 / 대회 종목..
- 문서화 테스트까지 작성했는데, 뭐가 문제인지 테스트 부분 롤백해보고,  새로 클론 받아서 main 브랜치 build 를 해봐도 스니펫이 일부만 생성되네요.. 짚이는 구석이 없어서 문제 해결 못하고 우선 pr 올립니당..
