### PR TITLE
[FEAT] 리그 조회 시 연도 별 필터링 기능 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: CI TEST
 on:
   pull_request:
     branches:
@@ -17,4 +17,4 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: 빌드
-        run: SPRING_PROFILES_ACTIVE=ci ./gradlew build
+        run: SPRING_PROFILES_ACTIVE=ci ./gradlew test

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -54,7 +54,7 @@ operation::report-controller-test/응원톡을_신고한다[snippets='http-reque
 
 === 리그 전체 조회
 
-operation::league-query-controller-test/리그_전체를_조회한다[snippets='http-request,http-response,response-fields']
+operation::league-query-controller-test/리그_전체를_조회한다[snippets='http-request,query-parameters,http-response,response-fields']
 
 === 리그에 해당하는 스포츠 전체 조회
 

--- a/src/main/java/com/sports/server/command/league/domain/League.java
+++ b/src/main/java/com/sports/server/command/league/domain/League.java
@@ -39,6 +39,12 @@ public class League extends BaseEntity<League> {
     @Column(name = "end_at", nullable = false)
     private LocalDateTime endAt;
 
+    @Column(name = "max_round")
+    private Integer maxRound;
+
+    @Column(name = "in_progress_round")
+    private Integer inProgressRound;
+
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
 }

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -1,9 +1,9 @@
 package com.sports.server.query.application;
 
-import com.sports.server.query.repository.LeagueQueryRepository;
-import com.sports.server.query.repository.LeagueSportQueryRepository;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
+import com.sports.server.query.repository.LeagueQueryRepository;
+import com.sports.server.query.repository.LeagueSportQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,8 +18,8 @@ public class LeagueQueryService {
     private final LeagueQueryRepository leagueQueryRepository;
     private final LeagueSportQueryRepository leagueSportQueryRepository;
 
-    public List<LeagueResponse> findAll() {
-        return leagueQueryRepository.findAll()
+    public List<LeagueResponse> findLeagues(Integer year) {
+        return leagueQueryRepository.findByYear(year)
                 .stream()
                 .map(LeagueResponse::new)
                 .toList();

--- a/src/main/java/com/sports/server/query/dto/response/LeagueResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueResponse.java
@@ -4,9 +4,11 @@ import com.sports.server.command.league.domain.League;
 
 public record LeagueResponse(
         Long leagueId,
-        String name
+        String name,
+        Integer maxRound,
+        Integer inProgressRound
 ) {
     public LeagueResponse(League league) {
-        this(league.getId(), league.getName());
+        this(league.getId(), league.getName(), league.getMaxRound(), league.getInProgressRound());
     }
 }

--- a/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
@@ -5,10 +5,7 @@ import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,8 +17,8 @@ public class LeagueQueryController {
     private final LeagueQueryService leagueQueryService;
 
     @GetMapping
-    public ResponseEntity<List<LeagueResponse>> findAll() {
-        return ResponseEntity.ok(leagueQueryService.findAll());
+    public ResponseEntity<List<LeagueResponse>> findLeagues(@RequestParam(required = false) Integer year) {
+        return ResponseEntity.ok(leagueQueryService.findLeagues(year));
     }
 
     @GetMapping("/{leagueId}/sports")

--- a/src/main/java/com/sports/server/query/repository/LeagueQueryDynamicRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueQueryDynamicRepository.java
@@ -1,0 +1,10 @@
+package com.sports.server.query.repository;
+
+import com.sports.server.command.league.domain.League;
+
+import java.util.List;
+
+public interface LeagueQueryDynamicRepository {
+
+    List<League> findByYear(Integer year);
+}

--- a/src/main/java/com/sports/server/query/repository/LeagueQueryDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueQueryDynamicRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.sports.server.query.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sports.server.command.league.domain.League;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.sports.server.command.league.domain.QLeague.league;
+
+@Repository
+@RequiredArgsConstructor
+public class LeagueQueryDynamicRepositoryImpl implements LeagueQueryDynamicRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<League> findByYear(Integer year) {
+        return queryFactory
+                .selectFrom(league)
+                .where(DynamicBooleanBuilder.builder()
+                        .and(() -> league.startAt.dayOfYear().eq(year))
+                        .build())
+                .orderBy(league.startAt.desc(), league.endAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/sports/server/query/repository/LeagueQueryDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueQueryDynamicRepositoryImpl.java
@@ -20,7 +20,7 @@ public class LeagueQueryDynamicRepositoryImpl implements LeagueQueryDynamicRepos
         return queryFactory
                 .selectFrom(league)
                 .where(DynamicBooleanBuilder.builder()
-                        .and(() -> league.startAt.dayOfYear().eq(year))
+                        .and(() -> league.startAt.year().eq(year))
                         .build())
                 .orderBy(league.startAt.desc(), league.endAt.desc())
                 .fetch();

--- a/src/main/java/com/sports/server/query/repository/LeagueQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueQueryRepository.java
@@ -1,13 +1,7 @@
 package com.sports.server.query.repository;
 
 import com.sports.server.command.league.domain.League;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
-import java.util.List;
-
-public interface LeagueQueryRepository extends Repository<League, Long> {
-
-    @Query("select l from League l order by l.startAt desc, l.endAt desc")
-    List<League> findAll();
+public interface LeagueQueryRepository extends Repository<League, Long>, LeagueQueryDynamicRepository {
 }

--- a/src/main/resources/db/migration/V7__league-round.sql
+++ b/src/main/resources/db/migration/V7__league-round.sql
@@ -1,0 +1,2 @@
+ALTER TABLE leagues ADD COLUMN max_round INT;
+ALTER TABLE leagues ADD COLUMN in_progress_round INT;

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -1447,11 +1447,32 @@ Vary: Access-Control-Request-Headers</code></pre>
 <h4 id="_리그_전체_조회_http_request"><a class="link" href="#_리그_전체_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /leagues HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /leagues?year=2024 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Host: www.api.hufstreaming.site</code></pre>
 </div>
 </div>
+</div>
+<div class="sect3">
+<h4 id="_리그_전체_조회_query_parameters"><a class="link" href="#_리그_전체_조회_query_parameters">Query parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>year</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리그의 연도</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_리그_전체_조회_http_response"><a class="link" href="#_리그_전체_조회_http_response">HTTP response</a></h4>
@@ -1462,14 +1483,18 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 108
+Content-Length: 197
 
 [ {
   "leagueId" : 1,
-  "name" : "리그 첫번쨰"
+  "name" : "리그 첫번쨰",
+  "maxRound" : 16,
+  "inProgressRound" : 4
 }, {
   "leagueId" : 2,
-  "name" : "리그 두번째"
+  "name" : "리그 두번째",
+  "maxRound" : 32,
+  "inProgressRound" : 32
 } ]</code></pre>
 </div>
 </div>
@@ -1499,6 +1524,16 @@ Content-Length: 108
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">리그의 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].maxRound</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리그의 최대 라운드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].inProgressRound</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 진행 중인 라운드</p></td>
 </tr>
 </tbody>
 </table>
@@ -1607,63 +1642,21 @@ Content-Length: 86
 <h3 id="_스포츠_전체_조회"><a class="link" href="#_스포츠_전체_조회">스포츠 전체 조회</a></h3>
 <div class="sect3">
 <h4 id="_스포츠_전체_조회_http_request"><a class="link" href="#_스포츠_전체_조회_http_request">HTTP request</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /sports HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Host: www.api.hufstreaming.site</code></pre>
-</div>
+<div class="paragraph">
+<p>Snippet http-request not found for operation::sport-query-controller-test/종목을_전체_조회한다</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_스포츠_전체_조회_http_response"><a class="link" href="#_스포츠_전체_조회_http_response">HTTP response</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-Content-Type: application/json
-Content-Length: 82
-
-[ {
-  "id" : 1,
-  "name" : "농구"
-}, {
-  "id" : 2,
-  "name" : "루미큐브"
-} ]</code></pre>
-</div>
+<div class="paragraph">
+<p>Snippet http-response not found for operation::sport-query-controller-test/종목을_전체_조회한다</p>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_스포츠_전체_조회_response_fields"><a class="link" href="#_스포츠_전체_조회_response_fields">Response fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].id</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">종목의 ID</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].name</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">종목의 이름</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Snippet response-fields not found for operation::sport-query-controller-test/종목을_전체_조회한다</p>
+</div>
 </div>
 </div>
 </div>
@@ -1672,7 +1665,7 @@ Content-Length: 82
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-14 18:59:40 UTC
+Last updated 2024-02-22 14:10:11 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
@@ -38,8 +38,14 @@ public class LeagueQueryAcceptanceTest extends AcceptanceTest {
                         .containsExactly(3L, 2L, 1L),
                 () -> assertThat(actual)
                         .map(LeagueResponse::name)
-                        .containsExactly("롤 대회", "농구대잔치", "삼건물 대회")
-        );
+                        .containsExactly("롤 대회", "농구대잔치", "삼건물 대회"),
+                () -> assertThat(actual)
+                        .map(LeagueResponse::maxRound)
+                        .containsExactly(8, 8, 16),
+                () -> assertThat(actual)
+                        .map(LeagueResponse::inProgressRound)
+                        .containsExactly(8, 2, 8)
+                );
     }
 
     @Test

--- a/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
@@ -35,17 +35,38 @@ public class LeagueQueryAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(actual)
                         .map(LeagueResponse::leagueId)
-                        .containsExactly(3L, 2L, 1L),
+                        .containsExactly(3L, 2L, 1L, 7L, 6L, 5L),
                 () -> assertThat(actual)
                         .map(LeagueResponse::name)
-                        .containsExactly("롤 대회", "농구대잔치", "삼건물 대회"),
+                        .containsExactly("롤 대회", "농구대잔치", "삼건물 대회", "롤 대회", "농구대잔치", "삼건물 대회"),
                 () -> assertThat(actual)
                         .map(LeagueResponse::maxRound)
-                        .containsExactly(8, 8, 16),
+                        .containsExactly(8, 8, 16, 8, 8, 16),
                 () -> assertThat(actual)
                         .map(LeagueResponse::inProgressRound)
-                        .containsExactly(8, 2, 8)
+                        .containsExactly(8, 2, 8, 8, 2, 8)
                 );
+    }
+
+    @Test
+    void 특정_연도의_리그를_조회한다() {
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .param("year", 2022)
+                .get("/leagues")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<LeagueResponse> actual = toResponses(response, LeagueResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual)
+                        .map(LeagueResponse::leagueId)
+                        .containsExactly(7L, 6L, 5L)
+        );
     }
 
     @Test

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -24,8 +24,8 @@ public class LeagueQueryControllerTest extends DocumentationTest {
 
         // given
         List<LeagueResponse> responses = List.of(
-                new LeagueResponse(1L, "리그 첫번쨰"),
-                new LeagueResponse(2L, "리그 두번째")
+                new LeagueResponse(1L, "리그 첫번쨰", 16, 4),
+                new LeagueResponse(2L, "리그 두번째", 32, 32)
         );
 
         given(leagueQueryService.findAll())
@@ -41,7 +41,9 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                 .andDo(restDocsHandler.document(
                         responseFields(
                                 fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("리그의 ID"),
-                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("리그의 이름")
+                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("리그의 이름"),
+                                fieldWithPath("[].maxRound").type(JsonFieldType.NUMBER).description("리그의 최대 라운드"),
+                                fieldWithPath("[].inProgressRound").type(JsonFieldType.NUMBER).description("현재 진행 중인 라운드")
                         )
                 ));
     }

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -4,14 +4,15 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
 import com.sports.server.support.DocumentationTest;
+
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -28,17 +29,22 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                 new LeagueResponse(2L, "리그 두번째", 32, 32)
         );
 
-        given(leagueQueryService.findAll())
+        int year = 2024;
+        given(leagueQueryService.findLeagues(year))
                 .willReturn(responses);
 
         // when
         ResultActions result = mockMvc.perform(get("/leagues")
+                .queryParam("year", String.valueOf(year))
                 .contentType(MediaType.APPLICATION_JSON)
         );
 
         // then
         result.andExpect((status().isOk()))
                 .andDo(restDocsHandler.document(
+                        queryParameters(
+                                parameterWithName("year").description("리그의 연도")
+                        ),
                         responseFields(
                                 fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("리그의 ID"),
                                 fieldWithPath("[].name").type(JsonFieldType.STRING).description("리그의 이름"),

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -8,14 +8,14 @@ INSERT INTO sports (id, name) VALUES (4, '루미큐브');
 
 
 -- 리그
-INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted)
-VALUES (1, 1, 1, '삼건물 대회', '2023-11-09 00:00:00', '2023-11-20 00:00:00', false);
+INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)
+VALUES (1, 1, 1, '삼건물 대회', '2023-11-09 00:00:00', '2023-11-20 00:00:00', false, 16, 8);
 
-INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted)
-VALUES (2, 1, 1, '농구대잔치', '2023-11-10 00:00:00', '2023-11-15 00:00:00', false);
+INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)
+VALUES (2, 1, 1, '농구대잔치', '2023-11-10 00:00:00', '2023-11-15 00:00:00', false, 8, 2);
 
-INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted)
-VALUES (3, 1, 1, '롤 대회', '2023-11-10 00:00:00', '2023-11-20 00:00:00', false);
+INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)
+VALUES (3, 1, 1, '롤 대회', '2023-11-10 00:00:00', '2023-11-20 00:00:00', false, 8, 8);
 
 INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted)
 VALUES (4, 1, 1, '루미큐브 대회', '2023-11-01 00:00:00', '2023-11-05 00:00:00', true);

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -20,6 +20,15 @@ VALUES (3, 1, 1, '롤 대회', '2023-11-10 00:00:00', '2023-11-20 00:00:00', fal
 INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted)
 VALUES (4, 1, 1, '루미큐브 대회', '2023-11-01 00:00:00', '2023-11-05 00:00:00', true);
 
+INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)
+VALUES (5, 1, 1, '삼건물 대회', '2022-11-09 00:00:00', '2022-11-20 00:00:00', false, 16, 8);
+
+INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)
+VALUES (6, 1, 1, '농구대잔치', '2022-11-10 00:00:00', '2022-11-15 00:00:00', false, 8, 2);
+
+INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)
+VALUES (7, 1, 1, '롤 대회', '2022-11-10 00:00:00', '2022-11-20 00:00:00', false, 8, 8);
+
 -- 리그의 스포츠
 INSERT INTO league_sports (id, league_id, sport_id) VALUES (1, 1, 1);
 INSERT INTO league_sports (id, league_id, sport_id) VALUES (2, 2, 2);


### PR DESCRIPTION
## 🌍 이슈 번호
-  closed #108 

## 📝 구현 내용
- 연도별 필터링 기능 추가
- 응답 본문에 라운드 정보 추가

## 🍀 확인해야 할 부분
기능 구현 외에 PR 시 깃허브 액션에서 CI 과정을 진행 시 build 명령어가 아닌 test 명령어를 통해 테스트만 확인하도록 변경했습니다. 이유는 속도가 build 보다 test가 빠르고 mysql 환경에서 테스트가 다 도는지 확인이 필요한 것이기에 build까지는 필요없다고 생각해서입니다
