### PR TITLE
[FEAT] 리그 조회 시 진행 중 여부 추가

### DIFF
--- a/src/main/java/com/sports/server/query/application/InProgressLeagueChecker.java
+++ b/src/main/java/com/sports/server/query/application/InProgressLeagueChecker.java
@@ -1,0 +1,18 @@
+package com.sports.server.query.application;
+
+import com.sports.server.command.league.domain.League;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class InProgressLeagueChecker {
+
+    public static boolean check(LocalDate today, League league) {
+        LocalDate startAt = league.getStartAt().toLocalDate();
+        LocalDate endAt = league.getEndAt().toLocalDate();
+        return (today.isEqual(startAt) || today.isAfter(startAt))
+                && (today.isBefore(endAt)) || today.isEqual(endAt);
+    }
+}

--- a/src/main/java/com/sports/server/query/dto/response/LeagueResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueResponse.java
@@ -1,14 +1,24 @@
 package com.sports.server.query.dto.response;
 
 import com.sports.server.command.league.domain.League;
+import com.sports.server.query.application.InProgressLeagueChecker;
+
+import java.time.LocalDate;
 
 public record LeagueResponse(
         Long leagueId,
         String name,
         Integer maxRound,
-        Integer inProgressRound
+        Integer inProgressRound,
+        Boolean isInProgress
 ) {
     public LeagueResponse(League league) {
-        this(league.getId(), league.getName(), league.getMaxRound(), league.getInProgressRound());
+        this(
+                league.getId(),
+                league.getName(),
+                league.getMaxRound(),
+                league.getInProgressRound(),
+                InProgressLeagueChecker.check(LocalDate.now(), league)
+        );
     }
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -1513,18 +1513,20 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 197
+Content-Length: 248
 
 [ {
   "leagueId" : 1,
   "name" : "리그 첫번쨰",
   "maxRound" : 16,
-  "inProgressRound" : 4
+  "inProgressRound" : 4,
+  "isInProgress" : false
 }, {
   "leagueId" : 2,
   "name" : "리그 두번째",
   "maxRound" : 32,
-  "inProgressRound" : 32
+  "inProgressRound" : 32,
+  "isInProgress" : true
 } ]</code></pre>
 </div>
 </div>
@@ -1564,6 +1566,11 @@ Content-Length: 197
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].inProgressRound</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">현재 진행 중인 라운드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].isInProgress</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 진행 중인지 여부</p></td>
 </tr>
 </tbody>
 </table>
@@ -1695,7 +1702,7 @@ Content-Length: 86
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-22 14:10:11 +0900
+Last updated 2024-02-22 22:05:40 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/sports/server/query/application/InProgressLeagueCheckerTest.java
+++ b/src/test/java/com/sports/server/query/application/InProgressLeagueCheckerTest.java
@@ -1,0 +1,56 @@
+package com.sports.server.query.application;
+
+import com.sports.server.command.league.domain.League;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class InProgressLeagueCheckerTest {
+
+    @Mock
+    private League league;
+
+    @BeforeEach
+    void init() {
+        given(league.getStartAt())
+                .willReturn(LocalDateTime.of(2024, 2, 24, 0, 0, 0));
+        given(league.getEndAt())
+                .willReturn(LocalDateTime.of(2024, 2, 28, 0, 0, 0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {24, 25, 26, 27, 28})
+    void 리그가_진행_중임을_확인_한다(int dayOfMonth) {
+        // given
+        LocalDate now = LocalDate.of(2024, 2, dayOfMonth);
+
+        // when
+        boolean actual = InProgressLeagueChecker.check(now, league);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {23, 29})
+    void 리그가_진행_중이_아님을_확인_한다(int dayOfMonth) {
+        // given
+        LocalDate now = LocalDate.of(2024, 2, dayOfMonth);
+
+        // when
+        boolean actual = InProgressLeagueChecker.check(now, league);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+}

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -25,8 +25,8 @@ public class LeagueQueryControllerTest extends DocumentationTest {
 
         // given
         List<LeagueResponse> responses = List.of(
-                new LeagueResponse(1L, "리그 첫번쨰", 16, 4),
-                new LeagueResponse(2L, "리그 두번째", 32, 32)
+                new LeagueResponse(1L, "리그 첫번쨰", 16, 4, false),
+                new LeagueResponse(2L, "리그 두번째", 32, 32, true)
         );
 
         int year = 2024;
@@ -49,7 +49,8 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("리그의 ID"),
                                 fieldWithPath("[].name").type(JsonFieldType.STRING).description("리그의 이름"),
                                 fieldWithPath("[].maxRound").type(JsonFieldType.NUMBER).description("리그의 최대 라운드"),
-                                fieldWithPath("[].inProgressRound").type(JsonFieldType.NUMBER).description("현재 진행 중인 라운드")
+                                fieldWithPath("[].inProgressRound").type(JsonFieldType.NUMBER).description("현재 진행 중인 라운드"),
+                                fieldWithPath("[].isInProgress").type(JsonFieldType.BOOLEAN).description("현재 진행 중인지 여부")
                         )
                 ));
     }


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #113 

## 📝 구현 내용
- 리그 조회 api 응답에 `isInProgress` 응답 추가

## 🍀 확인해야 할 부분
현재 진행 여부 판단 로직을 제 3의 클래스에게 위임했습니다.
``` java 
public class InProgressLeagueChecker {

    public static boolean check(LocalDate today, League league) {
        LocalDate startAt = league.getStartAt().toLocalDate();
        LocalDate endAt = league.getEndAt().toLocalDate();
        return (today.isEqual(startAt) || today.isAfter(startAt))
                && (today.isBefore(endAt)) || today.isEqual(endAt);
    }
}
```
또 다른 방법으로는 `League` 도메인에게 로직을 위임하면 클래스 추가 없이 더 깔끔하게 구현할 수 있습니다.

``` java
public class League extends BaseEntity<League> {
// ...

    @Column(name = "start_at", nullable = false)
    private LocalDateTime startAt;

    @Column(name = "end_at", nullable = false)
    private LocalDateTime endAt;

///...

    public boolean isInProgress(LocalDate today) {
        LocalDate startDate = startAt.toLocalDate();
        LocalDate endDate = endAt.toLocalDate();
        return (today.isEqual(startDate) || today.isAfter(startDate))
                && (today.isBefore(endDate)) || today.isEqual(endDate);
    }
}
```

`League` 도메인에 로직을 추가하지 않고 제 3의 클래스를 쓴 이유는 화면의 요구 때문에 command 패키지를 건드리고 싶지 않아서입니다. 그래서 결과적으로 query 패키지에 제 3의 클래스를 만들고 getter를 써서 로직을 구현했습니다. 트레이드오프가 있는데 어느쪽이 더 적절한 것 같나요?