### PR TITLE
[FEAT] 타임라인 조회에 필드 추가

### DIFF
--- a/src/main/java/com/sports/server/query/dto/mapper/RecordMapper.java
+++ b/src/main/java/com/sports/server/query/dto/mapper/RecordMapper.java
@@ -23,31 +23,37 @@ public class RecordMapper {
 
     public RecordResponse toRecordResponse(ReplacementRecord replacementRecord) {
         Record record = replacementRecord.getRecord();
-        LeagueTeam team = record.getGameTeam().getLeagueTeam();
+        GameTeam gameTeam = record.getGameTeam();
+        LeagueTeam team = gameTeam.getLeagueTeam();
         return new RecordResponse(
                 record.getRecordedQuarter(),
+                record.getId(),
                 record.getRecordType().name(),
                 record.getRecordedAt(),
                 replacementRecord.getOriginLineupPlayer().getName(),
+                gameTeam.getId(),
                 team.getName(),
                 team.getLogoImageUrl(),
                 null,
-                new ReplacementRecordResponse(replacementRecord.getReplacedLineupPlayer().getName())
+                new ReplacementRecordResponse(replacementRecord.getId(), replacementRecord.getReplacedLineupPlayer().getName())
         );
     }
 
     public RecordResponse toRecordResponse(ScoreRecord scoreRecord, ScoreSnapshot snapshot) {
         Record record = scoreRecord.getRecord();
         int score = scoreRecord.getScore();
-        LeagueTeam team = record.getGameTeam().getLeagueTeam();
+        GameTeam gameTeam = record.getGameTeam();
+        LeagueTeam team = gameTeam.getLeagueTeam();
         return new RecordResponse(
                 record.getRecordedQuarter(),
+                record.getId(),
                 record.getRecordType().name(),
                 record.getRecordedAt(),
                 scoreRecord.getLineupPlayer().getName(),
+                gameTeam.getId(),
                 team.getName(),
                 team.getLogoImageUrl(),
-                new ScoreRecordResponse(score, toSnapshotResponses(snapshot)),
+                new ScoreRecordResponse(scoreRecord.getId(), score, toSnapshotResponses(snapshot)),
                 null
         );
     }

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -6,9 +6,11 @@ import com.sports.server.command.sport.domain.Quarter;
 public record RecordResponse(
         @JsonIgnore
         Quarter quarter,
+        Long recordId,
         String type,
         Integer recordedAt,
         String playerName,
+        Long gameTeamId,
         String teamName,
         String teamImageUrl,
         ScoreRecordResponse scoreRecord,

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -1,9 +1,6 @@
 package com.sports.server.query.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.sports.server.command.leagueteam.LeagueTeam;
-import com.sports.server.command.record.domain.Record;
-import com.sports.server.command.record.domain.ScoreRecord;
 import com.sports.server.command.sport.domain.Quarter;
 
 public record RecordResponse(
@@ -17,19 +14,4 @@ public record RecordResponse(
         ScoreRecordResponse scoreRecord,
         ReplacementRecordResponse replacementRecord
 ) {
-
-    public static RecordResponse from(ScoreRecord scoreRecord, ScoreRecordResponse scoreRecordResponse) {
-        Record record = scoreRecord.getRecord();
-        LeagueTeam team = record.getGameTeam().getLeagueTeam();
-        return new RecordResponse(
-                record.getRecordedQuarter(),
-                record.getRecordType().name(),
-                record.getRecordedAt(),
-                scoreRecord.getLineupPlayer().getName(),
-                team.getName(),
-                team.getLogoImageUrl(),
-                scoreRecordResponse,
-                null
-        );
-    }
 }

--- a/src/main/java/com/sports/server/query/dto/response/ReplacementRecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/ReplacementRecordResponse.java
@@ -1,6 +1,7 @@
 package com.sports.server.query.dto.response;
 
 public record ReplacementRecordResponse(
+        Long replacementRecordId,
         String replacedPlayerName
 ) {
 }

--- a/src/main/java/com/sports/server/query/dto/response/ScoreRecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/ScoreRecordResponse.java
@@ -3,6 +3,7 @@ package com.sports.server.query.dto.response;
 import java.util.List;
 
 public record ScoreRecordResponse(
+        Long scoreRecordId,
         Integer score,
         List<Snapshot> snapshot
 ) {

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -1766,17 +1766,20 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 1140
+Content-Length: 1344
 
 [ {
   "gameQuarter" : "2쿼터",
   "records" : [ {
+    "recordId" : 1,
     "type" : "SCORE",
     "recordedAt" : 13,
     "playerName" : "선수10",
+    "gameTeamId" : 1,
     "teamName" : "팀B",
     "teamImageUrl" : "http://example.com/logo_b.png",
     "scoreRecord" : {
+      "scoreRecordId" : 1,
       "score" : 3,
       "snapshot" : [ {
         "teamName" : "팀A",
@@ -1789,15 +1792,19 @@ Content-Length: 1140
       } ]
     },
     "replacementRecord" : {
+      "replacementRecordId" : 1,
       "replacedPlayerName" : "선수3"
     }
   }, {
+    "recordId" : 1,
     "type" : "REPLACEMENT",
     "recordedAt" : 10,
     "playerName" : "선수2",
+    "gameTeamId" : 1,
     "teamName" : "팀A",
     "teamImageUrl" : "http://example.com/logo_a.png",
     "scoreRecord" : {
+      "scoreRecordId" : 1,
       "score" : 2,
       "snapshot" : [ {
         "teamName" : "팀A",
@@ -1810,6 +1817,7 @@ Content-Length: 1140
       } ]
     },
     "replacementRecord" : {
+      "replacementRecordId" : 1,
       "replacedPlayerName" : "선수3"
     }
   } ]
@@ -1839,6 +1847,11 @@ Content-Length: 1140
 <td class="tableblock halign-left valign-top"><p class="tableblock">쿼터의 이름</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].recordId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">기록의 ID</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].type</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">기록의 타입</p></td>
@@ -1852,6 +1865,11 @@ Content-Length: 1140
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].playerName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">기록의 대상 선수 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].gameTeamId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">기록의 대상 게임 팀 ID</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].teamName</code></p></td>
@@ -1869,6 +1887,11 @@ Content-Length: 1140
 <td class="tableblock halign-left valign-top"><p class="tableblock">SCORE 타입일 때 득점한 점수</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].scoreRecord.scoreRecordId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SCORE 타입 기록의 ID</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].scoreRecord.snapshot[].teamName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">SCORE 타입일 때 점수 스냅샷에 표시할 팀 이름</p></td>
@@ -1882,6 +1905,11 @@ Content-Length: 1140
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].scoreRecord.snapshot[].score</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">SCORE 타입일 때 점수 스냅샷에 표시할 점수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].replacementRecord.replacementRecordId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">REPLACEMENT 타입 기록의  ID</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].records[].replacementRecord.replacedPlayerName</code></p></td>
@@ -1924,7 +1952,7 @@ Content-Length: 1140
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-03-02 13:40:19 UTC
+Last updated 2024-02-27 23:30:31 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/sports/server/query/acceptance/TimelineQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/TimelineQueryAcceptanceTest.java
@@ -54,12 +54,13 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                         new TimelineResponse(
                                 QUARTER2, List.of(
                                 new RecordResponse(
-                                        null, SCORE_TYPE,
+                                        null, 4L, SCORE_TYPE,
                                         13,
                                         "선수10",
+                                        2L,
                                         TEAM_B,
                                         TEAM_B_IMAGE_URL,
-                                        new ScoreRecordResponse(3, List.of(
+                                        new ScoreRecordResponse(2L, 3, List.of(
                                                 new ScoreRecordResponse.Snapshot(
                                                         TEAM_A, TEAM_A_IMAGE_URL, 2),
                                                 new ScoreRecordResponse.Snapshot(
@@ -68,33 +69,36 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                         null
                                 ),
                                 new RecordResponse(
-                                        null, REPLACEMENT_TYPE,
+                                        null, 3L, REPLACEMENT_TYPE,
                                         10,
                                         "선수2",
+                                        1L,
                                         TEAM_A,
                                         TEAM_A_IMAGE_URL,
                                         null,
-                                        new ReplacementRecordResponse("선수3")
+                                        new ReplacementRecordResponse(2L,"선수3")
                                 )
                         )),
                         new TimelineResponse(
                                 QUARTER1, List.of(
                                 new RecordResponse(
-                                        null, REPLACEMENT_TYPE,
+                                        null, 2L, REPLACEMENT_TYPE,
                                         4,
                                         "선수6",
+                                        2L,
                                         TEAM_B,
                                         TEAM_B_IMAGE_URL,
                                         null,
-                                        new ReplacementRecordResponse("선수7")
+                                        new ReplacementRecordResponse(1L,"선수7")
                                 ),
                                 new RecordResponse(
-                                        null, SCORE_TYPE,
+                                        null, 1L, SCORE_TYPE,
                                         2,
                                         "선수2",
+                                        1L,
                                         TEAM_A,
                                         TEAM_A_IMAGE_URL,
-                                        new ScoreRecordResponse(2, List.of(
+                                        new ScoreRecordResponse(1L, 2, List.of(
                                                 new ScoreRecordResponse.Snapshot(
                                                         TEAM_A, TEAM_A_IMAGE_URL, 2),
                                                 new ScoreRecordResponse.Snapshot(

--- a/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
@@ -42,32 +42,34 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                         new TimelineResponse(
                                 QUARTER2, List.of(
                                 new RecordResponse(
-                                        null, SCORE_TYPE,
+                                        null, 1L,  SCORE_TYPE,
                                         13,
                                         "선수10",
+                                        1L,
                                         TEAM_B,
                                         TEAM_B_IMAGE_URL,
-                                        new ScoreRecordResponse(3, List.of(
+                                        new ScoreRecordResponse(1L, 3, List.of(
                                                 new ScoreRecordResponse.Snapshot(
                                                         TEAM_A, TEAM_A_IMAGE_URL, 2),
                                                 new ScoreRecordResponse.Snapshot(
                                                         TEAM_B, TEAM_B_IMAGE_URL, 3)
                                         )),
-                                        new ReplacementRecordResponse("선수3")
+                                        new ReplacementRecordResponse(1L, "선수3")
                                 ),
                                 new RecordResponse(
-                                        null, REPLACEMENT_TYPE,
+                                        null, 1L,  REPLACEMENT_TYPE,
                                         10,
                                         "선수2",
+                                        1L,
                                         TEAM_A,
                                         TEAM_A_IMAGE_URL,
-                                        new ScoreRecordResponse(2, List.of(
+                                        new ScoreRecordResponse(1L, 2, List.of(
                                                 new ScoreRecordResponse.Snapshot(
                                                         TEAM_A, TEAM_A_IMAGE_URL, 2),
                                                 new ScoreRecordResponse.Snapshot(
                                                         TEAM_B, TEAM_B_IMAGE_URL, 0)
                                         )),
-                                        new ReplacementRecordResponse("선수3")
+                                        new ReplacementRecordResponse(1L, "선수3")
                                 )
                         ))
                 ));
@@ -85,18 +87,24 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                         ),
                         responseFields(
                                 fieldWithPath("[].gameQuarter").type(JsonFieldType.STRING).description("쿼터의 이름"),
+                                fieldWithPath("[].records[].recordId").type(JsonFieldType.NUMBER).description("기록의 ID"),
                                 fieldWithPath("[].records[].type").type(JsonFieldType.STRING).description("기록의 타입"),
                                 fieldWithPath("[].records[].recordedAt").type(JsonFieldType.NUMBER).description("기록된 시간"),
                                 fieldWithPath("[].records[].playerName").type(JsonFieldType.STRING).description("기록의 대상 선수 이름"),
+                                fieldWithPath("[].records[].gameTeamId").type(JsonFieldType.NUMBER).description("기록의 대상 게임 팀 ID"),
                                 fieldWithPath("[].records[].teamName").type(JsonFieldType.STRING).description("기록의 대상 팀 이름"),
                                 fieldWithPath("[].records[].teamImageUrl").type(JsonFieldType.STRING).description("기록의 대상 팀 이미지"),
                                 fieldWithPath("[].records[].scoreRecord.score").type(JsonFieldType.NUMBER).description("SCORE 타입일 때 득점한 점수"),
+                                fieldWithPath("[].records[].scoreRecord.scoreRecordId").type(JsonFieldType.NUMBER)
+                                        .description("SCORE 타입 기록의 ID"),
                                 fieldWithPath("[].records[].scoreRecord.snapshot[].teamName").type(JsonFieldType.STRING)
                                         .description("SCORE 타입일 때 점수 스냅샷에 표시할 팀 이름"),
                                 fieldWithPath("[].records[].scoreRecord.snapshot[].teamImageUrl").type(JsonFieldType.STRING)
                                         .description("SCORE 타입일 때 점수 스냅샷에 표시할 팀 이미지"),
                                 fieldWithPath("[].records[].scoreRecord.snapshot[].score").type(JsonFieldType.NUMBER)
                                         .description("SCORE 타입일 때 점수 스냅샷에 표시할 점수"),
+                                fieldWithPath("[].records[].replacementRecord.replacementRecordId").type(JsonFieldType.NUMBER)
+                                        .description("REPLACEMENT 타입 기록의  ID"),
                                 fieldWithPath("[].records[].replacementRecord.replacedPlayerName").type(JsonFieldType.STRING)
                                         .description("REPLACEMENT 타입일 때 교체되어 IN 되는 선수")
                         )


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #121 

## 📝 구현 내용
- 타임라인 조회에 게임팀 ID 추가 (클라이언트의 요구)
- Record 응답에 ID 추가 (매니저 서버의 요구)

## 🍀 확인해야 할 부분
