### PR TITLE
[FIX] 서버 시간 Asia/Seoul로 변경

### DIFF
--- a/src/main/java/com/sports/server/ServerApplication.java
+++ b/src/main/java/com/sports/server/ServerApplication.java
@@ -1,12 +1,20 @@
 package com.sports.server;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
 public class ServerApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);
+	}
+
+	@PostConstruct
+	void started(){
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 	}
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
 <configuration>
     <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
     <property name="CONSOLE_LOG_PATTERN"
-              value="%magenta([%X{CORRELATION_ID:-NO CORRELATION ID}]) %yellow([%d{yyyy-MM-dd HH:mm:ss}]) %green(%thread) %highlight(%-5level) %boldWhite([%C.%M:%L]) %n : %msg%n"/>
+              value="%magenta([%X{CORRELATION_ID:-NO CORRELATION ID}]) %yellow([%d{yyyy-MM-dd HH:mm:ss, ${logback.timezone:-Asia/Seoul}}]) %green(%thread) %highlight(%-5level) %boldWhite([%C.%M:%L]) %n : %msg%n"/>
     <property name="FILE_LOG_PATTERN"
               value=": %msg %n %magenta([%X{CORRELATION_ID:-NO CORRELATION ID}]) %yellow([%d{yyyy-MM-dd HH:mm:ss}]) %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%L]) %n"/>
 


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #123

## 📝 구현 내용
- 디폴트 타임존을 Asia/Seoul로 변경

## 🍀 확인해야 할 부분
- 관객 서버 타임존을 변경했는데도 뭔가 시간이 이상하다면 RDS나 매니저 서버도 확인해봐야 할 듯?