### PR TITLE
[ADD] 타임라인 관련 테이블 재생성 스크립트 작성 #127

### DIFF
--- a/src/main/resources/db/migration/V9__regenerate-record.sql
+++ b/src/main/resources/db/migration/V9__regenerate-record.sql
@@ -1,0 +1,67 @@
+CREATE TABLE records
+(
+    id                  BIGINT AUTO_INCREMENT NOT NULL,
+    game_id             BIGINT                NULL,
+    game_team_id        BIGINT                NULL,
+    game_team_player_id BIGINT                NULL,
+    score               INT                   NOT NULL,
+    scored_quarter      VARCHAR(255)          NOT NULL,
+    scored_at           datetime              NOT NULL,
+    CONSTRAINT pk_records PRIMARY KEY (id)
+);
+
+ALTER TABLE records
+    ADD CONSTRAINT FK_RECORDS_ON_GAME FOREIGN KEY (game_id) REFERENCES games (id);
+
+ALTER TABLE records
+    ADD CONSTRAINT FK_RECORDS_ON_GAME_TEAM FOREIGN KEY (game_team_id) REFERENCES game_teams (id);
+
+ALTER TABLE records
+    ADD CONSTRAINT FK_RECORDS_ON_GAME_TEAM_PLAYER FOREIGN KEY (game_team_player_id) REFERENCES game_team_players (id);
+
+ALTER TABLE records
+    DROP COLUMN scored_quarter;
+ALTER TABLE records
+    ADD COLUMN scored_quarter_id BIGINT NOT NULL;
+
+ALTER TABLE records
+    MODIFY scored_at INT;
+
+ALTER TABLE records
+    ADD CONSTRAINT FK_RECORDS_ON_SCORED_QUARTER FOREIGN KEY (scored_quarter_id) REFERENCES quarters (id);
+
+ALTER TABLE records
+    CHANGE game_team_player_id lineup_player_id BIGINT;
+
+ALTER TABLE records
+    RENAME COLUMN scored_quarter_id TO recorded_quarter_id;
+
+ALTER TABLE records
+    RENAME COLUMN scored_at TO recorded_at;
+
+ALTER TABLE records
+    ADD COLUMN record_type VARCHAR(255);
+
+CREATE TABLE score_records
+(
+    id               BIGINT AUTO_INCREMENT NOT NULL,
+    record_id        BIGINT                NOT NULL,
+    lineup_player_id BIGINT                NOT NULL,
+    score            INT                   NOT NULL,
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE score_records
+    ADD CONSTRAINT FK_RECORDS_IN_SCORE_RECORDS FOREIGN KEY (record_id) REFERENCES records (id);
+
+ALTER TABLE score_records
+    ADD CONSTRAINT FK_LINEUP_PLAYER_ID FOREIGN KEY (lineup_player_id) REFERENCES lineup_players (id);
+
+CREATE TABLE replacement_records
+(
+    id                        BIGINT AUTO_INCREMENT NOT NULL,
+    record_id                 BIGINT                NOT NULL,
+    origin_lineup_player_id   BIGINT                NOT NULL,
+    replaced_lineup_player_id BIGINT                NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/main/resources/db/migration/V9__regenerate-record.sql
+++ b/src/main/resources/db/migration/V9__regenerate-record.sql
@@ -1,12 +1,16 @@
+DROP TABLE IF EXISTS score_records;
+DROP TABLE IF EXISTS replacement_records;
+DROP TABLE IF EXISTS records;
+
 CREATE TABLE records
 (
-    id                  BIGINT AUTO_INCREMENT NOT NULL,
-    game_id             BIGINT                NULL,
-    game_team_id        BIGINT                NULL,
-    game_team_player_id BIGINT                NULL,
-    score               INT                   NOT NULL,
-    scored_quarter      VARCHAR(255)          NOT NULL,
-    scored_at           datetime              NOT NULL,
+    id               BIGINT AUTO_INCREMENT NOT NULL,
+    game_id          BIGINT                NULL,
+    game_team_id     BIGINT                NULL,
+    lineup_player_id BIGINT                NULL,
+    score            INT                   NOT NULL,
+    scored_quarter   VARCHAR(255)          NOT NULL,
+    scored_at        datetime              NOT NULL,
     CONSTRAINT pk_records PRIMARY KEY (id)
 );
 
@@ -15,9 +19,6 @@ ALTER TABLE records
 
 ALTER TABLE records
     ADD CONSTRAINT FK_RECORDS_ON_GAME_TEAM FOREIGN KEY (game_team_id) REFERENCES game_teams (id);
-
-ALTER TABLE records
-    ADD CONSTRAINT FK_RECORDS_ON_GAME_TEAM_PLAYER FOREIGN KEY (game_team_player_id) REFERENCES game_team_players (id);
 
 ALTER TABLE records
     DROP COLUMN scored_quarter;
@@ -29,9 +30,6 @@ ALTER TABLE records
 
 ALTER TABLE records
     ADD CONSTRAINT FK_RECORDS_ON_SCORED_QUARTER FOREIGN KEY (scored_quarter_id) REFERENCES quarters (id);
-
-ALTER TABLE records
-    CHANGE game_team_player_id lineup_player_id BIGINT;
 
 ALTER TABLE records
     RENAME COLUMN scored_quarter_id TO recorded_quarter_id;


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #127 

## 문제 상황
- `No enum constant com.sports.server.command.record.domain.RecordType.score` 와 같은 에러 발생
   - 이전에도 이러한 에러를 봤을 때 table drop 하고 재생성했을 때 오류가 해결됐기 때문에 데이터가 어차피 없으니 drop 해도 될 것이라고 생각.
   - 직접 워크벤치로  record, replacement_records, score_records  테이블 드랍
   - 그러나 재빌드 해도 테이블 생성되지 않음. (DB 상태와 스크립트가 일치하지 않게 됨.......)
 - 찾아본 결과, 수동으로 테이블을 만들거나 테이블 재생성 스크립트를 추가할 것을 권유
    - 수동으로 테이블을 만드는 것은 스크립트와 조금이라도 일치하지 않게 되면 감지되지 않을 것 같아서 위험하다고 생각
    - 두번째 방법 선택..
- 지금 생각해보니, score_type 이 enum 에 맞게 대문자가 아닌 소문자 (SCORE 이 아닌 score로 저장되고 있었음) 로 저장되는 것의 문제인듯..

### 결론
- 테이블 얼른 복구하고, 매니저 서버 측에 대문자로 저장할 것을 요청해야 할듯

섣부른 판단 죄송합니댜 ㅠ
