### PR TITLE
[FIX] 시간 반환시의 오류 수정

### DIFF
--- a/src/main/java/com/sports/server/query/dto/response/CheerTalkResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/CheerTalkResponse.java
@@ -2,6 +2,7 @@ package com.sports.server.query.dto.response;
 
 import com.sports.server.command.cheertalk.domain.CheerTalk;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public record CheerTalkResponse(
         Long cheerTalkId,
@@ -15,7 +16,7 @@ public record CheerTalkResponse(
                 cheerTalk.getId(),
                 checkCheerTalkIsBlocked(cheerTalk),
                 cheerTalk.getGameTeamId(),
-                cheerTalk.getCreatedAt(),
+                cheerTalk.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
                 cheerTalk.isBlocked()
         );
     }

--- a/src/main/java/com/sports/server/query/dto/response/GameDetailResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/GameDetailResponse.java
@@ -3,6 +3,7 @@ package com.sports.server.query.dto.response;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.GameTeam;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public record GameDetailResponse(
 
     public GameDetailResponse(Game game, List<GameTeam> gameTeams) {
         this(
-                game.getStartTime(),
+                game.getStartTime().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
                 game.getVideoId(),
                 game.getGameQuarter(),
                 game.getName(),

--- a/src/main/java/com/sports/server/query/dto/response/GameResponseDto.java
+++ b/src/main/java/com/sports/server/query/dto/response/GameResponseDto.java
@@ -4,6 +4,7 @@ import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.sport.domain.Sport;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
 
@@ -19,7 +20,7 @@ public record GameResponseDto(
     public GameResponseDto(final Game game, final List<GameTeam> gameTeams, final Sport sport) {
         this(
                 game.getId(),
-                game.getStartTime(),
+                game.getStartTime().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
                 game.getGameQuarter(),
                 game.getName(),
                 game.getRound(),

--- a/src/test/java/com/sports/server/query/acceptance/CheerTalkQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/CheerTalkQueryAcceptanceTest.java
@@ -45,7 +45,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                                     5L,
                                     "응원톡5",
                                     1L,
-                                    LocalDateTime.of(2023, 1, 2, 14, 55, 0),
+                                    LocalDateTime.of(2023, 1, 2, 14, 55, 0).plusHours(9),
                                     false
                             )),
                     () -> assertThat(actual)

--- a/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
@@ -1,5 +1,8 @@
 package com.sports.server.query.acceptance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.sports.server.query.dto.response.GameDetailResponse;
 import com.sports.server.query.dto.response.GameResponseDto;
 import com.sports.server.query.dto.response.LineupPlayerResponse;
@@ -7,16 +10,12 @@ import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Sql(scripts = "/game-fixture.sql")
 public class GameQueryAcceptanceTest extends AcceptanceTest {
@@ -43,7 +42,7 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(game.videoId()).isEqualTo("abc123"),
                 () -> assertThat(game.sportName()).isEqualTo("농구"),
                 () -> assertThat(game.startTime()).isEqualTo(
-                        LocalDateTime.of(2023, 11, 12, 10, 0, 0)
+                        LocalDateTime.of(2023, 11, 12, 10, 0, 0).plusHours(9)
                 ),
 
                 () -> assertThat(teams).hasSize(2),
@@ -87,7 +86,7 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                         .filteredOn(game -> game.id().equals(1L))
                         .containsExactly(
                                 new GameResponseDto(
-                                        1L, LocalDateTime.of(2023, 11, 12, 10, 0, 0),
+                                        1L, LocalDateTime.of(2023, 11, 12, 10, 0, 0).plusHours(9),
                                         "1st Quarter", "농구 대전", 4,
                                         List.of(new GameResponseDto.TeamResponse(
                                                         1L, "팀 A", "http://example.com/logo_a.png", 1
@@ -101,7 +100,7 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                         .filteredOn(game -> game.id().equals(2L))
                         .containsExactly(
                                 new GameResponseDto(
-                                        2L, LocalDateTime.of(2023, 11, 12, 10, 10, 0),
+                                        2L, LocalDateTime.of(2023, 11, 12, 10, 10, 0).plusHours(9),
                                         "1st Quarter", "두번째로 빠른 경기", 4,
                                         List.of(new GameResponseDto.TeamResponse(
                                                         3L, "팀 B", "http://example.com/logo_b.png", 0),


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #129 

## 📝 구현 내용
- 게임 상세 조회 시 타임존을 서울로 사용하도록 변경
- 게임 전체 조회 시 타임존을 서울로 사용하도록 변경
- 응원톡 조회 시 타임존을 서울로 사용하도록 변경

## 🍀 확인해야 할 부분
- 추가적으로 시간을 사용하는 api 가 있는지 한번 체크 부탁드립니당