### PR TITLE
[ADD] 게임 전체 조회 시 영상 관련 컬럼 추가

### DIFF
--- a/src/main/java/com/sports/server/query/dto/response/GameResponseDto.java
+++ b/src/main/java/com/sports/server/query/dto/response/GameResponseDto.java
@@ -13,6 +13,7 @@ public record GameResponseDto(
         String gameQuarter,
         String gameName,
         Integer round,
+        String videoId,
         List<TeamResponse> gameTeams,
         String sportsName
 ) {
@@ -23,6 +24,7 @@ public record GameResponseDto(
                 game.getGameQuarter(),
                 game.getName(),
                 game.getRound(),
+                game.getVideoId(),
                 gameTeams.stream()
                         .sorted(Comparator.comparingLong(GameTeam::getId))
                         .map(TeamResponse::new)

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -969,7 +969,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 775
+Content-Length: 823
 
 [ {
   "id" : 1,
@@ -977,6 +977,7 @@ Content-Length: 775
   "gameQuarter" : "전반전",
   "gameName" : "4강",
   "round" : 4,
+  "videoId" : "abc123",
   "gameTeams" : [ {
     "gameTeamId" : 1,
     "gameTeamName" : "A팀",
@@ -995,6 +996,7 @@ Content-Length: 775
   "gameQuarter" : "1쿼터",
   "gameName" : "결승전",
   "round" : 2,
+  "videoId" : "abc123",
   "gameTeams" : [ {
     "gameTeamId" : 3,
     "gameTeamName" : "C팀",
@@ -1050,7 +1052,12 @@ Content-Length: 775
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].round</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">게임 라운</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게임 라운드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].videoId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">경기 영상 ID</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].sportsName</code></p></td>
@@ -1959,7 +1966,7 @@ Content-Length: 1344
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-27 23:30:31 +0900
+Last updated 2024-03-23 15:31:15 UTC
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/sports/server/query/acceptance/CheerTalkQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/CheerTalkQueryAcceptanceTest.java
@@ -45,7 +45,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                                     5L,
                                     "응원톡5",
                                     1L,
-                                    LocalDateTime.of(2023, 1, 2, 14, 55, 0).plusHours(9),
+                                    LocalDateTime.of(2023, 1, 2, 14, 55, 0),
                                     false
                             )),
                     () -> assertThat(actual)

--- a/src/test/java/com/sports/server/query/acceptance/CheerTalkQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/CheerTalkQueryAcceptanceTest.java
@@ -45,7 +45,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                                     5L,
                                     "응원톡5",
                                     1L,
-                                    LocalDateTime.of(2023, 1, 2, 14, 55, 0),
+                                    LocalDateTime.of(2023, 1, 2, 14, 55, 0).plusHours(9),
                                     false
                             )),
                     () -> assertThat(actual)

--- a/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
@@ -42,7 +42,7 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(game.videoId()).isEqualTo("abc123"),
                 () -> assertThat(game.sportName()).isEqualTo("농구"),
                 () -> assertThat(game.startTime()).isEqualTo(
-                        LocalDateTime.of(2023, 11, 12, 10, 0, 0).plusHours(9)
+                        LocalDateTime.of(2023, 11, 12, 10, 0, 0)
                 ),
 
                 () -> assertThat(teams).hasSize(2),
@@ -86,7 +86,7 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                         .filteredOn(game -> game.id().equals(1L))
                         .containsExactly(
                                 new GameResponseDto(
-                                        1L, LocalDateTime.of(2023, 11, 12, 10, 0, 0).plusHours(9),
+                                        1L, LocalDateTime.of(2023, 11, 12, 10, 0, 0),
                                         "1st Quarter", "농구 대전", 4, "abc123",
                                         List.of(new GameResponseDto.TeamResponse(
                                                         1L, "팀 A", "http://example.com/logo_a.png", 1
@@ -100,7 +100,7 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                         .filteredOn(game -> game.id().equals(2L))
                         .containsExactly(
                                 new GameResponseDto(
-                                        2L, LocalDateTime.of(2023, 11, 12, 10, 10, 0).plusHours(9),
+                                        2L, LocalDateTime.of(2023, 11, 12, 10, 10, 0),
                                         "1st Quarter", "두번째로 빠른 경기", 4, "abc123",
                                         List.of(new GameResponseDto.TeamResponse(
                                                         3L, "팀 B", "http://example.com/logo_b.png", 0),

--- a/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
@@ -1,5 +1,8 @@
 package com.sports.server.query.acceptance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.sports.server.query.dto.response.GameDetailResponse;
 import com.sports.server.query.dto.response.GameResponseDto;
 import com.sports.server.query.dto.response.LineupPlayerResponse;
@@ -7,16 +10,12 @@ import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Sql(scripts = "/game-fixture.sql")
 public class GameQueryAcceptanceTest extends AcceptanceTest {
@@ -43,7 +42,7 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(game.videoId()).isEqualTo("abc123"),
                 () -> assertThat(game.sportName()).isEqualTo("농구"),
                 () -> assertThat(game.startTime()).isEqualTo(
-                        LocalDateTime.of(2023, 11, 12, 10, 0, 0)
+                        LocalDateTime.of(2023, 11, 12, 10, 0, 0).plusHours(9)
                 ),
 
                 () -> assertThat(teams).hasSize(2),
@@ -87,8 +86,8 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                         .filteredOn(game -> game.id().equals(1L))
                         .containsExactly(
                                 new GameResponseDto(
-                                        1L, LocalDateTime.of(2023, 11, 12, 10, 0, 0),
-                                        "1st Quarter", "농구 대전", 4,
+                                        1L, LocalDateTime.of(2023, 11, 12, 10, 0, 0).plusHours(9),
+                                        "1st Quarter", "농구 대전", 4, "abc123",
                                         List.of(new GameResponseDto.TeamResponse(
                                                         1L, "팀 A", "http://example.com/logo_a.png", 1
                                                 ),
@@ -101,8 +100,8 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                         .filteredOn(game -> game.id().equals(2L))
                         .containsExactly(
                                 new GameResponseDto(
-                                        2L, LocalDateTime.of(2023, 11, 12, 10, 10, 0),
-                                        "1st Quarter", "두번째로 빠른 경기", 4,
+                                        2L, LocalDateTime.of(2023, 11, 12, 10, 10, 0).plusHours(9),
+                                        "1st Quarter", "두번째로 빠른 경기", 4, "abc123",
                                         List.of(new GameResponseDto.TeamResponse(
                                                         3L, "팀 B", "http://example.com/logo_b.png", 0),
                                                 new GameResponseDto.TeamResponse(

--- a/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
@@ -108,8 +108,8 @@ class GameQueryControllerTest extends DocumentationTest {
                 new GameResponseDto.TeamResponse(4L, "D팀", "logo.com", 2)
         );
         List<GameResponseDto> responses = List.of(
-                new GameResponseDto(1L, startTime, "전반전", "4강", 4, gameTeams1, "축구"),
-                new GameResponseDto(2L, startTime, "1쿼터", "결승전", 2, gameTeams2, "농구")
+                new GameResponseDto(1L, startTime, "전반전", "4강", 4, "abc123", gameTeams1, "축구"),
+                new GameResponseDto(2L, startTime, "1쿼터", "결승전", 2, "abc123", gameTeams2, "농구")
         );
 
         given(gameQueryService.getAllGames(any(), any()))
@@ -145,7 +145,8 @@ class GameQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].startTime").type(JsonFieldType.STRING).description("게임 시작 시간"),
                                 fieldWithPath("[].gameQuarter").type(JsonFieldType.STRING).description("게임 쿼터"),
                                 fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("게임 이름"),
-                                fieldWithPath("[].round").type(JsonFieldType.NUMBER).description("게임 라운"),
+                                fieldWithPath("[].round").type(JsonFieldType.NUMBER).description("게임 라운드"),
+                                fieldWithPath("[].videoId").type(JsonFieldType.STRING).description("경기 영상 ID"),
                                 fieldWithPath("[].sportsName").type(JsonFieldType.STRING).description("종목"),
                                 fieldWithPath("[].gameTeams[].gameTeamId").type(JsonFieldType.NUMBER)
                                         .description("게임팀의 ID"),


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #131 

## 📝 구현 내용
- 게임 전체 조회 시 video id 도 함께 반환하도록 수정

## 논의 사항
- 저번 이슈 관련 pr 머지한 뒤로 #125 계속 테스트 통과를 못하고 오류가 나는데 (현재 main 에도 빌드 실패로 떠 있네요) 로컬에서는 문제가 없어서요.. 배포 환경에서 문제가 있는 것 같은데 해결 방법을 모르겠네요 ㅠ 또 시간 관련 문제인 것 같아요