### PR TITLE
[FEAT] 리그 단건 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -64,6 +64,9 @@ operation::league-query-controller-test/리그의_해당하는_스포츠_전체�
 
 operation::league-query-controller-test/리그의_모든_리그팀을_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
 
+=== 리그 상세 조회
+operation::league-query-controller-test/리그를_하나_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
+
 == 타임라인 API
 
 === 게임의 타임라인 조회

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -1,5 +1,7 @@
 package com.sports.server.query.application;
 
+import com.sports.server.common.exception.NotFoundException;
+import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
@@ -39,5 +41,11 @@ public class LeagueQueryService {
                 .stream()
                 .map(LeagueTeamResponse::new)
                 .toList();
+    }
+
+    public LeagueDetailResponse findLeagueDetail(Long leagueId) {
+        return leagueQueryRepository.findById(leagueId)
+                .map(LeagueDetailResponse::new)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 리그입니다"));
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueDetailResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueDetailResponse.java
@@ -1,0 +1,28 @@
+package com.sports.server.query.dto.response;
+
+import com.sports.server.command.league.domain.League;
+import com.sports.server.query.application.InProgressLeagueChecker;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record LeagueDetailResponse(
+        String name,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        Integer maxRound,
+        Integer inProgressRound,
+        Boolean isInProgress
+) {
+
+    public LeagueDetailResponse(League league) {
+        this(
+                league.getName(),
+                league.getStartAt(),
+                league.getEndAt(),
+                league.getMaxRound(),
+                league.getInProgressRound(),
+                InProgressLeagueChecker.check(LocalDate.now(), league)
+        );
+    }
+}

--- a/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
@@ -1,6 +1,7 @@
 package com.sports.server.query.presentation;
 
 import com.sports.server.query.application.LeagueQueryService;
+import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
@@ -30,5 +31,10 @@ public class LeagueQueryController {
     @GetMapping("/{leagueId}/teams")
     public ResponseEntity<List<LeagueTeamResponse>> findLeagueTeamsByLeague(@PathVariable Long leagueId) {
         return ResponseEntity.ok(leagueQueryService.findTeamsByLeague(leagueId));
+    }
+
+    @GetMapping("/{leagueId}")
+    public ResponseEntity<LeagueDetailResponse> findLeagueDetail(@PathVariable Long leagueId) {
+        return ResponseEntity.ok(leagueQueryService.findLeagueDetail(leagueId));
     }
 }

--- a/src/main/java/com/sports/server/query/repository/LeagueQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueQueryRepository.java
@@ -3,5 +3,9 @@ package com.sports.server.query.repository;
 import com.sports.server.command.league.domain.League;
 import org.springframework.data.repository.Repository;
 
+import java.util.Optional;
+
 public interface LeagueQueryRepository extends Repository<League, Long>, LeagueQueryDynamicRepository {
+
+    Optional<League> findById(Long id);
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -477,6 +477,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_리그_전체_조회">리그 전체 조회</a></li>
 <li><a href="#_리그에_해당하는_스포츠_전체_조회">리그에 해당하는 스포츠 전체 조회</a></li>
 <li><a href="#_리그에_해당하는_리그팀_전체_조회">리그에 해당하는 리그팀 전체 조회</a></li>
+<li><a href="#_리그_상세_조회">리그 상세 조회</a></li>
 </ul>
 </li>
 <li><a href="#_타임라인_api">타임라인 API</a>
@@ -1738,6 +1739,112 @@ Content-Length: 124
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_리그_상세_조회"><a class="link" href="#_리그_상세_조회">리그 상세 조회</a></h3>
+<div class="sect3">
+<h4 id="_리그_상세_조회_http_request"><a class="link" href="#_리그_상세_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /leagues/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Host: www.api.hufstreaming.site</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리그_상세_조회_path_parameters"><a class="link" href="#_리그_상세_조회_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /leagues/{leagueId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>leagueId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리그의 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리그_상세_조회_http_response"><a class="link" href="#_리그_상세_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 173
+
+{
+  "name" : "삼건물대회",
+  "startAt" : "2024-03-25T00:00:00",
+  "endAt" : "2024-03-26T00:00:00",
+  "maxRound" : 16,
+  "inProgressRound" : 4,
+  "isInProgress" : true
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리그_상세_조회_response_fields"><a class="link" href="#_리그_상세_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리그 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리그 시작 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리그 종료 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>inProgressRound</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리그의 현재 라운드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>maxRound</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리그 총 라운드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isInProgress</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대회가 현재 진행 중인지 여햐</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1972,7 +2079,7 @@ Content-Length: 1344
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-02-27 23:30:31 +0900
+Last updated 2024-03-25 13:51:39 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.sports.server.query.acceptance;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
@@ -10,6 +11,8 @@ import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -119,6 +122,31 @@ public class LeagueQueryAcceptanceTest extends AcceptanceTest {
                         .map(LeagueTeamResponse::leagueTeamId)
                         .containsExactly(1L, 2L, 3L)
 
+        );
+    }
+
+    @Test
+    void 리그를_하나_조회한다() {
+        // given
+        Long threeBuildingCup = 1L;
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/leagues/{leagueId}", threeBuildingCup)
+                .then().log().all()
+                .extract();
+
+        // then
+        LeagueDetailResponse actual = toResponse(response, LeagueDetailResponse.class);
+        assertAll(
+                () -> assertThat(actual.name()).isEqualTo("삼건물 대회"),
+                () -> assertThat(actual.startAt()).isEqualTo(LocalDateTime.of(2023, 11, 9, 0, 0, 0)),
+                () -> assertThat(actual.endAt()).isEqualTo(LocalDateTime.of(2023, 11, 20, 0, 0, 0)),
+                () -> assertThat(actual.inProgressRound()).isEqualTo(8),
+                () -> assertThat(actual.maxRound()).isEqualTo(16),
+                () -> assertThat(actual.isInProgress()).isEqualTo(false)
         );
     }
 }

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -9,10 +9,13 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
 import com.sports.server.support.DocumentationTest;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -121,4 +124,39 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                 ));
     }
 
+    @Test
+    void 리그를_하나_조회한다() throws Exception {
+        // given
+        Long leagueId = 1L;
+        given(leagueQueryService.findLeagueDetail(leagueId))
+                .willReturn(new LeagueDetailResponse(
+                        "삼건물대회",
+                        LocalDateTime.of(2024, 3, 25, 0, 0, 0),
+                        LocalDateTime.of(2024, 3, 26, 0, 0, 0),
+                        16,
+                        4,
+                        true
+                ));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/leagues/{leagueId}", leagueId)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("leagueId").description("리그의 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("리그 이름"),
+                                fieldWithPath("startAt").type(JsonFieldType.STRING).description("리그 시작 시간"),
+                                fieldWithPath("endAt").type(JsonFieldType.STRING).description("리그 종료 시간"),
+                                fieldWithPath("inProgressRound").type(JsonFieldType.NUMBER).description("리그의 현재 라운드"),
+                                fieldWithPath("maxRound").type(JsonFieldType.NUMBER).description("리그 총 라운드"),
+                                fieldWithPath("isInProgress").type(JsonFieldType.BOOLEAN).description("대회가 현재 진행 중인지 여햐")
+                        )
+                ));
+    }
 }


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #137 

## 📝 구현 내용
- 리그 단건 조회 기능 구현

## 🍀 확인해야 할 부분
- 프론트에서 리그의 라운드를 조회하는 기능이 필요하다 하여 추가
- 라운드만 가져올 바에 차라리 단건 조회 만들기로 결정

 **빠른 기능 반영을 위해 코드 리뷰 없이 머지하겠습니다!**