### PR TITLE
[FIX] ScoreRecord 조회 시 recorded_at이 아닌 id로 정렬하도록 수정 #139

### DIFF
--- a/src/main/java/com/sports/server/query/repository/ScoreRecordQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/ScoreRecordQueryRepository.java
@@ -16,6 +16,6 @@ public interface ScoreRecordQueryRepository extends Repository<ScoreRecord, Long
             "join fetch r.recordedQuarter rq " +
             "join fetch sr.lineupPlayer srp " +
             "where r.game.id = :gameId " +
-            "order by r.recordedAt asc")
+            "order by r.id asc")
     List<ScoreRecord> findByGameId(@Param("gameId") Long gameId);
 }

--- a/src/test/java/com/sports/server/query/acceptance/TimelineQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/TimelineQueryAcceptanceTest.java
@@ -83,7 +83,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                 QUARTER1, List.of(
                                 new RecordResponse(
                                         null, 2L, REPLACEMENT_TYPE,
-                                        4,
+                                        24,
                                         "선수6",
                                         2L,
                                         TEAM_B,
@@ -93,7 +93,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                 ),
                                 new RecordResponse(
                                         null, 1L, SCORE_TYPE,
-                                        2,
+                                        22,
                                         "선수2",
                                         1L,
                                         TEAM_A,

--- a/src/test/resources/record-fixture.sql
+++ b/src/test/resources/record-fixture.sql
@@ -45,12 +45,12 @@ VALUES (6, 2, '선수6', '센터', true, 6, 1),
 
 -- 1쿼터 경기 기록 추가
 INSERT INTO records (id, game_id, game_team_id, recorded_quarter_id, recorded_at, record_type)
-VALUES (1, 1, 1, 1, 2, 'SCORE');
+VALUES (1, 1, 1, 1, 22, 'SCORE');
 INSERT INTO score_records (record_id, lineup_player_id, score)
 VALUES (1, 2, 2); -- A팀 선수 2의 2득점
 
 INSERT INTO records (id, game_id, game_team_id, recorded_quarter_id, recorded_at, record_type)
-VALUES (2, 1, 2, 1, 4, 'REPLACEMENT');
+VALUES (2, 1, 2, 1, 24, 'REPLACEMENT');
 INSERT INTO replacement_records(record_id, origin_lineup_player_id, replaced_lineup_player_id)
 VALUES (2, 6, 7);
 -- B팀 6선수 OUT 7선수 IN


### PR DESCRIPTION
## 🌍 이슈 번호
- #139 

## 📝 구현 내용
아래 보면 점수 스냅샷이 이상합니다. 원인을 뜯어보니 점수 기록 계산 시 `score_record`를 `recorded_at`으로 정렬해서 계산했습니다. 이렇게 되면 아래처럼 후반전 6분이 전반전 15분보다 먼저 계산되어 점수 기록이 꼬이게 됩니다.

<img width="345" alt="image" src="https://github.com/hufscheer/spectator-server/assets/78652144/164a9ecc-538a-4b5f-b808-b7a044d16190">

`score_record` 조회 시 `record_id`로 정렬하도록 수정하고 테스트도 이를 고려하도록 수정했습니다!

``` java
    @Query("select sr from ScoreRecord sr " +
            "join fetch sr.record r " +
            "join fetch r.gameTeam gt " +
            "join fetch gt.leagueTeam lt " +
            "join fetch r.recordedQuarter rq " +
            "join fetch sr.lineupPlayer srp " +
            "where r.game.id = :gameId " +
            "order by r.id asc")
    List<ScoreRecord> findByGameId(@Param("gameId") Long gameId);
```

## 🍀 확인해야 할 부분
