### PR TITLE
[FIX] 한 번에 보낼 수 있는 응원 횟수 제한 로직 구현

### DIFF
--- a/src/main/java/com/sports/server/command/game/application/GameTeamService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameTeamService.java
@@ -24,6 +24,7 @@ public class GameTeamService {
     public void updateCheerCount(final Long gameId, final CheerCountUpdateRequest cheerCountUpdateRequest) {
         Game game = entityUtils.getEntity(gameId, Game.class);
         GameTeam gameTeam = entityUtils.getEntity(cheerCountUpdateRequest.gameTeamId(), GameTeam.class);
+        gameTeam.validateCheerCountOfGameTeam(cheerCountUpdateRequest.cheerCount());
         validateGameTeam(gameTeam, game);
         gameTeamRepository.updateCheerCount(cheerCountUpdateRequest.gameTeamId(), cheerCountUpdateRequest.cheerCount());
     }

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -20,7 +20,7 @@ import org.springframework.http.HttpStatus;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GameTeam extends BaseEntity<GameTeam> {
 
-    private static final int MAXIMUM_OF_CHEER_COUNT = 100_000_000;
+    private static final int MAXIMUM_OF_TOTAL_CHEER_COUNT = 100_000_000;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id")
@@ -37,8 +37,8 @@ public class GameTeam extends BaseEntity<GameTeam> {
     private int score;
 
     public void validateCheerCountOfGameTeam(final int cheerCount) {
-        if (this.cheerCount + cheerCount > MAXIMUM_OF_CHEER_COUNT) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, "응원 횟수가 한계에 도달했습니다.");
+        if (this.cheerCount + cheerCount > MAXIMUM_OF_TOTAL_CHEER_COUNT) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "총 응원 횟수가 한계에 도달했습니다.");
         }
     }
 
@@ -47,3 +47,6 @@ public class GameTeam extends BaseEntity<GameTeam> {
     }
 
 }
+
+
+

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -2,16 +2,25 @@ package com.sports.server.command.game.domain;
 
 import com.sports.server.command.leagueteam.LeagueTeam;
 import com.sports.server.common.domain.BaseEntity;
-import jakarta.persistence.*;
+import com.sports.server.common.exception.CustomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Entity
 @Getter
 @Table(name = "game_teams")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GameTeam extends BaseEntity<GameTeam> {
+
+    private static final int MAXIMUM_OF_CHEER_COUNT = 100_000_000;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id")
@@ -27,7 +36,14 @@ public class GameTeam extends BaseEntity<GameTeam> {
     @Column(name = "score", nullable = false)
     private int score;
 
+    public void validateCheerCountOfGameTeam(final int cheerCount) {
+        if (this.cheerCount + cheerCount > MAXIMUM_OF_CHEER_COUNT) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "응원 횟수가 한계에 도달했습니다.");
+        }
+    }
+
     public boolean matchGame(final Game game) {
         return this.game.equals(game);
     }
+
 }

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -20,6 +20,7 @@ import org.springframework.http.HttpStatus;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GameTeam extends BaseEntity<GameTeam> {
 
+    private static final int MAXIMUM_OF_CHEER_COUNT = 500;
     private static final int MAXIMUM_OF_TOTAL_CHEER_COUNT = 100_000_000;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -37,6 +38,9 @@ public class GameTeam extends BaseEntity<GameTeam> {
     private int score;
 
     public void validateCheerCountOfGameTeam(final int cheerCount) {
+        if (cheerCount >= MAXIMUM_OF_CHEER_COUNT) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "응원 횟수가 한계에 도달했습니다.");
+        }
         if (this.cheerCount + cheerCount > MAXIMUM_OF_TOTAL_CHEER_COUNT) {
             throw new CustomException(HttpStatus.BAD_REQUEST, "총 응원 횟수가 한계에 도달했습니다.");
         }

--- a/src/test/java/com/sports/server/command/game/application/GameLeagueTeamServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/GameLeagueTeamServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.jdbc.Sql;
 class GameLeagueTeamServiceTest extends ServiceTest {
 
     private static final int MAXIMUM_OF_TOTAL_CHEER_COUNT = 100_000_000;
+    private static final int MAXIMUM_OF_CHEER_COUNT = 500;
 
     @Autowired
     private GameTeamService gameTeamService;
@@ -89,5 +90,16 @@ class GameLeagueTeamServiceTest extends ServiceTest {
         assertThrows(CustomException.class, () -> gameTeamService.updateCheerCount(gameId, cheerRequestDto));
     }
 
-}
+    @Test
+    void 응원_횟수가_제한에_도달했을_시_예외를_반환한다() {
 
+        //given
+        Long gameId = 1L;
+        Long gameTeamId = 10000L;
+        CheerCountUpdateRequest cheerRequestDto = new CheerCountUpdateRequest(gameTeamId, MAXIMUM_OF_CHEER_COUNT);
+
+        //when&then
+        assertThrows(CustomException.class, () -> gameTeamService.updateCheerCount(gameId, cheerRequestDto));
+    }
+
+}

--- a/src/test/java/com/sports/server/command/game/application/GameLeagueTeamServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/GameLeagueTeamServiceTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.jdbc.Sql;
 @Sql(scripts = "/game-fixture.sql")
 class GameLeagueTeamServiceTest extends ServiceTest {
 
-    private static final int MAXIMUM_OF_CHEER_COUNT = 100_000_000;
+    private static final int MAXIMUM_OF_TOTAL_CHEER_COUNT = 100_000_000;
 
     @Autowired
     private GameTeamService gameTeamService;
@@ -78,12 +78,12 @@ class GameLeagueTeamServiceTest extends ServiceTest {
     }
 
     @Test
-    void 응원_횟수가_제한에_도달했을_시_예외를_반환한다() {
+    void 총_응원_횟수가_제한에_도달했을_시_예외를_반환한다() {
 
         //given
         Long gameId = 1L;
         Long gameTeamId = 10000L;
-        CheerCountUpdateRequest cheerRequestDto = new CheerCountUpdateRequest(gameTeamId, MAXIMUM_OF_CHEER_COUNT);
+        CheerCountUpdateRequest cheerRequestDto = new CheerCountUpdateRequest(gameTeamId, MAXIMUM_OF_TOTAL_CHEER_COUNT);
 
         //when&then
         assertThrows(CustomException.class, () -> gameTeamService.updateCheerCount(gameId, cheerRequestDto));

--- a/src/test/java/com/sports/server/command/game/application/GameLeagueTeamServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/GameLeagueTeamServiceTest.java
@@ -1,23 +1,24 @@
 package com.sports.server.command.game.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.game.dto.CheerCountUpdateRequest;
 import com.sports.server.common.exception.CustomException;
 import com.sports.server.support.ServiceTest;
 import com.sports.server.support.fixture.GameTeamFixtureRepository;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 @Sql(scripts = "/game-fixture.sql")
 class GameLeagueTeamServiceTest extends ServiceTest {
+
+    private static final int MAXIMUM_OF_CHEER_COUNT = 100_000_000;
 
     @Autowired
     private GameTeamService gameTeamService;
@@ -74,6 +75,18 @@ class GameLeagueTeamServiceTest extends ServiceTest {
                 .map(GameTeam::getCheerCount)
                 .get()
                 .isEqualTo(101);
+    }
+
+    @Test
+    void 응원_횟수가_제한에_도달했을_시_예외를_반환한다() {
+
+        //given
+        Long gameId = 1L;
+        Long gameTeamId = 10000L;
+        CheerCountUpdateRequest cheerRequestDto = new CheerCountUpdateRequest(gameTeamId, MAXIMUM_OF_CHEER_COUNT);
+
+        //when&then
+        assertThrows(CustomException.class, () -> gameTeamService.updateCheerCount(gameId, cheerRequestDto));
     }
 
 }


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #141 

## 📝 구현 내용
- 응원 횟수 제한
- 총 응원 횟수 제한