### PR TITLE
[REFACTOR] 대회팀, 대회팀 선수 가나다 순으로 뜨도록 수정

### DIFF
--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -4,12 +4,17 @@ import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
+import com.sports.server.query.dto.response.LeagueTeamPlayerResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
 import com.sports.server.query.repository.LeagueQueryRepository;
 import com.sports.server.query.repository.LeagueSportQueryRepository;
+import com.sports.server.query.repository.LeagueTeamPlayerQueryRepository;
 import com.sports.server.query.repository.LeagueTeamQueryRepository;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,34 +23,42 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LeagueQueryService {
 
-    private final LeagueQueryRepository leagueQueryRepository;
-    private final LeagueSportQueryRepository leagueSportQueryRepository;
-    private final LeagueTeamQueryRepository leagueTeamQueryRepository;
+	private final LeagueQueryRepository leagueQueryRepository;
+	private final LeagueSportQueryRepository leagueSportQueryRepository;
+	private final LeagueTeamQueryRepository leagueTeamQueryRepository;
+	private final LeagueTeamPlayerQueryRepository leagueTeamPlayerQueryRepository;
 
-    public List<LeagueResponse> findLeagues(Integer year) {
-        return leagueQueryRepository.findByYear(year)
-                .stream()
-                .map(LeagueResponse::new)
-                .toList();
-    }
+	public List<LeagueResponse> findLeagues(Integer year) {
+		return leagueQueryRepository.findByYear(year)
+			.stream()
+			.map(LeagueResponse::new)
+			.toList();
+	}
 
-    public List<LeagueSportResponse> findSportsByLeague(Long leagueId) {
-        return leagueSportQueryRepository.findByLeagueId(leagueId)
-                .stream()
-                .map(LeagueSportResponse::new)
-                .toList();
-    }
+	public List<LeagueSportResponse> findSportsByLeague(Long leagueId) {
+		return leagueSportQueryRepository.findByLeagueId(leagueId)
+			.stream()
+			.map(LeagueSportResponse::new)
+			.toList();
+	}
 
-    public List<LeagueTeamResponse> findTeamsByLeague(Long leagueId) {
-        return leagueTeamQueryRepository.findByLeagueId(leagueId)
-                .stream()
-                .map(LeagueTeamResponse::new)
-                .toList();
-    }
+	public List<LeagueTeamResponse> findTeamsByLeague(Long leagueId) {
+		return leagueTeamQueryRepository.findByLeagueId(leagueId)
+			.stream()
+			.map(LeagueTeamResponse::new)
+			.toList();
+	}
 
-    public LeagueDetailResponse findLeagueDetail(Long leagueId) {
-        return leagueQueryRepository.findById(leagueId)
-                .map(LeagueDetailResponse::new)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 리그입니다"));
-    }
+	public LeagueDetailResponse findLeagueDetail(Long leagueId) {
+		return leagueQueryRepository.findById(leagueId)
+			.map(LeagueDetailResponse::new)
+			.orElseThrow(() -> new NotFoundException("존재하지 않는 리그입니다"));
+	}
+
+	public List<LeagueTeamPlayerResponse> findPlayersByLeagueTeam(Long leagueTeamId) {
+		return leagueTeamPlayerQueryRepository.findByLeagueTeamId(leagueTeamId)
+			.stream()
+			.map(LeagueTeamPlayerResponse::new)
+			.toList();
+	}
 }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueTeamPlayerResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueTeamPlayerResponse.java
@@ -1,0 +1,19 @@
+package com.sports.server.query.dto.response;
+
+import com.sports.server.command.leagueteam.LeagueTeamPlayer;
+
+public record LeagueTeamPlayerResponse(
+	Long id,
+	String name,
+	String description,
+	Integer number
+) {
+	public LeagueTeamPlayerResponse(LeagueTeamPlayer leagueTeamPlayer) {
+		this(
+			leagueTeamPlayer.getId(),
+			leagueTeamPlayer.getName(),
+			leagueTeamPlayer.getDescription(),
+			leagueTeamPlayer.getNumber()
+		);
+	}
+}

--- a/src/main/java/com/sports/server/query/dto/response/LeagueTeamResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueTeamResponse.java
@@ -4,11 +4,12 @@ import com.sports.server.command.leagueteam.LeagueTeam;
 
 public record LeagueTeamResponse(
         Long leagueTeamId,
-        String teamName
+        String teamName,
+        String logoImageUrl
 ) {
     public LeagueTeamResponse(final LeagueTeam leagueTeam) {
         this(
-                leagueTeam.getId(), leagueTeam.getName()
+                leagueTeam.getId(), leagueTeam.getName(), leagueTeam.getLogoImageUrl()
         );
     }
 }

--- a/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
@@ -4,6 +4,7 @@ import com.sports.server.query.application.LeagueQueryService;
 import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
+import com.sports.server.query.dto.response.LeagueTeamPlayerResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,5 +37,10 @@ public class LeagueQueryController {
     @GetMapping("/{leagueId}")
     public ResponseEntity<LeagueDetailResponse> findLeagueDetail(@PathVariable Long leagueId) {
         return ResponseEntity.ok(leagueQueryService.findLeagueDetail(leagueId));
+    }
+
+    @GetMapping("/teams/{leagueTeamId}/players/all")
+    public ResponseEntity<List<LeagueTeamPlayerResponse>> findPlayersByLeagueTeam(@PathVariable Long leagueTeamId) {
+        return ResponseEntity.ok(leagueQueryService.findPlayersByLeagueTeam(leagueTeamId));
     }
 }

--- a/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
@@ -39,7 +39,7 @@ public class LeagueQueryController {
         return ResponseEntity.ok(leagueQueryService.findLeagueDetail(leagueId));
     }
 
-    @GetMapping("/teams/{leagueTeamId}/players/all")
+    @GetMapping("/teams/{leagueTeamId}/players")
     public ResponseEntity<List<LeagueTeamPlayerResponse>> findPlayersByLeagueTeam(@PathVariable Long leagueTeamId) {
         return ResponseEntity.ok(leagueQueryService.findPlayersByLeagueTeam(leagueTeamId));
     }

--- a/src/main/java/com/sports/server/query/repository/LeagueTeamPlayerQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueTeamPlayerQueryRepository.java
@@ -1,0 +1,14 @@
+package com.sports.server.query.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import com.sports.server.command.leagueteam.LeagueTeamPlayer;
+
+public interface LeagueTeamPlayerQueryRepository extends Repository<LeagueTeamPlayer, Long> {
+	@Query("select ltp from LeagueTeamPlayer ltp where ltp.leagueTeam.id = :leagueTeamId order by ltp.name asc")
+	List<LeagueTeamPlayer> findByLeagueTeamId(@Param("leagueTeamId") Long leagueTeamId);
+}

--- a/src/main/java/com/sports/server/query/repository/LeagueTeamQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueTeamQueryRepository.java
@@ -1,9 +1,16 @@
 package com.sports.server.query.repository;
 
-import com.sports.server.command.leagueteam.LeagueTeam;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LeagueTeamQueryRepository extends JpaRepository<LeagueTeam, Long> {
-    List<LeagueTeam> findByLeagueId(Long leagueId);
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import com.sports.server.command.leagueteam.LeagueTeam;
+
+public interface LeagueTeamQueryRepository extends Repository<LeagueTeam, Long> {
+    @Query("select lt from LeagueTeam lt where lt.league.id = :leagueId order by lt.name asc")
+    List<LeagueTeam> findByLeagueId(@Param("leagueId") final Long leagueId);
+
+
 }

--- a/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
@@ -160,7 +160,7 @@ public class LeagueQueryAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
             .when()
             .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .get("/leagues/teams/{leagueTeamId]/players/all", soccerishThought)
+            .get("/leagues/teams/{leagueTeamId}/players/all", soccerishThought)
             .then().log().all()
             .extract();
 

--- a/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
@@ -117,10 +117,10 @@ public class LeagueQueryAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(actual)
                         .map(LeagueTeamResponse::teamName)
-                        .containsExactly("경영 야생마", "서어 뻬데뻬", "미컴 축구생각"),
+                        .containsExactly("경영 야생마", "미컴 축구생각", "서어 뻬데뻬"),
                 () -> assertThat(actual)
                         .map(LeagueTeamResponse::leagueTeamId)
-                        .containsExactly(1L, 2L, 3L)
+                        .containsExactly(1L, 3L, 2L)
 
         );
     }

--- a/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
+import com.sports.server.query.dto.response.LeagueTeamPlayerResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
 import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
@@ -147,6 +148,30 @@ public class LeagueQueryAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(actual.inProgressRound()).isEqualTo(8),
                 () -> assertThat(actual.maxRound()).isEqualTo(16),
                 () -> assertThat(actual.isInProgress()).isEqualTo(false)
+        );
+    }
+
+    @Test
+    void 리그팀의_모든_선수를_조회한다() {
+        // given
+        Long soccerishThought = 3L;
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .when()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .get("/leagues/teams/{leagueTeamId]/players/all", soccerishThought)
+            .then().log().all()
+            .extract();
+
+        // then
+        List<LeagueTeamPlayerResponse> actual = toResponses(response, LeagueTeamPlayerResponse.class);
+        assertAll(
+            () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(actual).map(LeagueTeamPlayerResponse::name)
+                .containsExactly("가을전어이동규", "겨울붕어빵이현제", "봄동나물진승희", "여름수박고병룡"),
+            () -> assertThat(actual).map(LeagueTeamPlayerResponse::id)
+                .containsExactly(2L, 3L, 1L, 4L)
         );
     }
 }

--- a/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
@@ -160,7 +160,7 @@ public class LeagueQueryAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
             .when()
             .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .get("/leagues/teams/{leagueTeamId}/players/all", soccerishThought)
+            .get("/leagues/teams/{leagueTeamId}/players", soccerishThought)
             .then().log().all()
             .extract();
 

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -99,8 +99,8 @@ public class LeagueQueryControllerTest extends DocumentationTest {
         Long leagueId = 1L;
 
         List<LeagueTeamResponse> responses = List.of(
-                new LeagueTeamResponse(1L, "경영 야생마"),
-                new LeagueTeamResponse(2L, "서어 뻬데뻬")
+                new LeagueTeamResponse(1L, "경영 야생마", "s3:logoImageUrl1"),
+                new LeagueTeamResponse(2L, "서어 뻬데뻬", "s3:logoImageUrl2")
         );
 
         given(leagueQueryService.findTeamsByLeague(leagueId))
@@ -119,7 +119,8 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                         ),
                         responseFields(
                                 fieldWithPath("[].leagueTeamId").type(JsonFieldType.NUMBER).description("리그의 팀 ID"),
-                                fieldWithPath("[].teamName").type(JsonFieldType.STRING).description("리그에 참여하는 팀의 이름")
+                                fieldWithPath("[].teamName").type(JsonFieldType.STRING).description("리그에 참여하는 팀의 이름"),
+                                fieldWithPath("[].logoImageUrl").type(JsonFieldType.STRING).description("리그의 팀 로고 이미지 URL®")
                         )
                 ));
     }

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -9,14 +9,17 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.cfg.JsonNodeFeature;
 import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
+import com.sports.server.query.dto.response.LeagueTeamPlayerResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
 import com.sports.server.support.DocumentationTest;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -24,140 +27,172 @@ import org.springframework.test.web.servlet.ResultActions;
 
 public class LeagueQueryControllerTest extends DocumentationTest {
 
-    @Test
-    void 리그_전체를_조회한다() throws Exception {
+	@Test
+	void 리그_전체를_조회한다() throws Exception {
 
-        // given
-        List<LeagueResponse> responses = List.of(
-                new LeagueResponse(1L, "리그 첫번쨰", 16, 4, false),
-                new LeagueResponse(2L, "리그 두번째", 32, 32, true)
-        );
+		// given
+		List<LeagueResponse> responses = List.of(
+			new LeagueResponse(1L, "리그 첫번쨰", 16, 4, false),
+			new LeagueResponse(2L, "리그 두번째", 32, 32, true)
+		);
 
-        int year = 2024;
-        given(leagueQueryService.findLeagues(year))
-                .willReturn(responses);
+		int year = 2024;
+		given(leagueQueryService.findLeagues(year))
+			.willReturn(responses);
 
-        // when
-        ResultActions result = mockMvc.perform(get("/leagues")
-                .queryParam("year", String.valueOf(year))
-                .contentType(MediaType.APPLICATION_JSON)
-        );
+		// when
+		ResultActions result = mockMvc.perform(get("/leagues")
+			.queryParam("year", String.valueOf(year))
+			.contentType(MediaType.APPLICATION_JSON)
+		);
 
-        // then
-        result.andExpect((status().isOk()))
-                .andDo(restDocsHandler.document(
-                        queryParameters(
-                                parameterWithName("year").description("리그의 연도")
-                        ),
-                        responseFields(
-                                fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("리그의 ID"),
-                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("리그의 이름"),
-                                fieldWithPath("[].maxRound").type(JsonFieldType.NUMBER).description("리그의 최대 라운드"),
-                                fieldWithPath("[].inProgressRound").type(JsonFieldType.NUMBER)
-                                        .description("현재 진행 중인 라운드"),
-                                fieldWithPath("[].isInProgress").type(JsonFieldType.BOOLEAN).description("현재 진행 중인지 여부")
-                        )
-                ));
-    }
+		// then
+		result.andExpect((status().isOk()))
+			.andDo(restDocsHandler.document(
+				queryParameters(
+					parameterWithName("year").description("리그의 연도")
+				),
+				responseFields(
+					fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("리그의 ID"),
+					fieldWithPath("[].name").type(JsonFieldType.STRING).description("리그의 이름"),
+					fieldWithPath("[].maxRound").type(JsonFieldType.NUMBER).description("리그의 최대 라운드"),
+					fieldWithPath("[].inProgressRound").type(JsonFieldType.NUMBER)
+						.description("현재 진행 중인 라운드"),
+					fieldWithPath("[].isInProgress").type(JsonFieldType.BOOLEAN).description("현재 진행 중인지 여부")
+				)
+			));
+	}
 
-    @Test
-    void 리그의_해당하는_스포츠_전체를_조회한다() throws Exception {
+	@Test
+	void 리그의_해당하는_스포츠_전체를_조회한다() throws Exception {
 
-        // given
-        Long leagueId = 1L;
+		// given
+		Long leagueId = 1L;
 
-        List<LeagueSportResponse> responses = List.of(
-                new LeagueSportResponse(1L, "축구"),
-                new LeagueSportResponse(2L, "농구")
-        );
+		List<LeagueSportResponse> responses = List.of(
+			new LeagueSportResponse(1L, "축구"),
+			new LeagueSportResponse(2L, "농구")
+		);
 
-        given(leagueQueryService.findSportsByLeague(leagueId))
-                .willReturn(responses);
+		given(leagueQueryService.findSportsByLeague(leagueId))
+			.willReturn(responses);
 
-        // when
-        ResultActions result = mockMvc.perform(get("/leagues/{leagueId}/sports", leagueId)
-                .contentType(MediaType.APPLICATION_JSON)
-        );
+		// when
+		ResultActions result = mockMvc.perform(get("/leagues/{leagueId}/sports", leagueId)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
 
-        // then
-        result.andExpect((status().isOk()))
-                .andDo(restDocsHandler.document(
-                        pathParameters(
-                                parameterWithName("leagueId").description("리그의 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("[].sportId").type(JsonFieldType.NUMBER).description("스포츠의 ID"),
-                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("스포츠의 이름")
-                        )
-                ));
-    }
+		// then
+		result.andExpect((status().isOk()))
+			.andDo(restDocsHandler.document(
+				pathParameters(
+					parameterWithName("leagueId").description("리그의 ID")
+				),
+				responseFields(
+					fieldWithPath("[].sportId").type(JsonFieldType.NUMBER).description("스포츠의 ID"),
+					fieldWithPath("[].name").type(JsonFieldType.STRING).description("스포츠의 이름")
+				)
+			));
+	}
 
-    @Test
-    void 리그의_모든_리그팀을_조회한다() throws Exception {
+	@Test
+	void 리그의_모든_리그팀을_조회한다() throws Exception {
 
-        // given
-        Long leagueId = 1L;
+		// given
+		Long leagueId = 1L;
 
-        List<LeagueTeamResponse> responses = List.of(
-                new LeagueTeamResponse(1L, "경영 야생마", "s3:logoImageUrl1"),
-                new LeagueTeamResponse(2L, "서어 뻬데뻬", "s3:logoImageUrl2")
-        );
+		List<LeagueTeamResponse> responses = List.of(
+			new LeagueTeamResponse(1L, "경영 야생마", "s3:logoImageUrl1"),
+			new LeagueTeamResponse(2L, "서어 뻬데뻬", "s3:logoImageUrl2")
+		);
 
-        given(leagueQueryService.findTeamsByLeague(leagueId))
-                .willReturn(responses);
+		given(leagueQueryService.findTeamsByLeague(leagueId))
+			.willReturn(responses);
 
-        // when
-        ResultActions result = mockMvc.perform(get("/leagues/{leagueId}/teams", leagueId)
-                .contentType(MediaType.APPLICATION_JSON)
-        );
+		// when
+		ResultActions result = mockMvc.perform(get("/leagues/{leagueId}/teams", leagueId)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
 
-        // then
-        result.andExpect((status().isOk()))
-                .andDo(restDocsHandler.document(
-                        pathParameters(
-                                parameterWithName("leagueId").description("리그의 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("[].leagueTeamId").type(JsonFieldType.NUMBER).description("리그의 팀 ID"),
-                                fieldWithPath("[].teamName").type(JsonFieldType.STRING).description("리그에 참여하는 팀의 이름"),
-                                fieldWithPath("[].logoImageUrl").type(JsonFieldType.STRING).description("리그의 팀 로고 이미지 URL®")
-                        )
-                ));
-    }
+		// then
+		result.andExpect((status().isOk()))
+			.andDo(restDocsHandler.document(
+				pathParameters(
+					parameterWithName("leagueId").description("리그의 ID")
+				),
+				responseFields(
+					fieldWithPath("[].leagueTeamId").type(JsonFieldType.NUMBER).description("리그의 팀 ID"),
+					fieldWithPath("[].teamName").type(JsonFieldType.STRING).description("리그에 참여하는 팀의 이름"),
+					fieldWithPath("[].logoImageUrl").type(JsonFieldType.STRING).description("리그의 팀 로고 이미지 URL®")
+				)
+			));
+	}
 
-    @Test
-    void 리그를_하나_조회한다() throws Exception {
-        // given
-        Long leagueId = 1L;
-        given(leagueQueryService.findLeagueDetail(leagueId))
-                .willReturn(new LeagueDetailResponse(
-                        "삼건물대회",
-                        LocalDateTime.of(2024, 3, 25, 0, 0, 0),
-                        LocalDateTime.of(2024, 3, 26, 0, 0, 0),
-                        16,
-                        4,
-                        true
-                ));
+	@Test
+	void 리그를_하나_조회한다() throws Exception {
+		// given
+		Long leagueId = 1L;
+		given(leagueQueryService.findLeagueDetail(leagueId))
+			.willReturn(new LeagueDetailResponse(
+				"삼건물대회",
+				LocalDateTime.of(2024, 3, 25, 0, 0, 0),
+				LocalDateTime.of(2024, 3, 26, 0, 0, 0),
+				16,
+				4,
+				true
+			));
 
-        // when
-        ResultActions result = mockMvc.perform(get("/leagues/{leagueId}", leagueId)
-                .contentType(MediaType.APPLICATION_JSON)
-        );
+		// when
+		ResultActions result = mockMvc.perform(get("/leagues/{leagueId}", leagueId)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
 
-        // then
-        result.andExpect((status().isOk()))
-                .andDo(restDocsHandler.document(
-                        pathParameters(
-                                parameterWithName("leagueId").description("리그의 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("name").type(JsonFieldType.STRING).description("리그 이름"),
-                                fieldWithPath("startAt").type(JsonFieldType.STRING).description("리그 시작 시간"),
-                                fieldWithPath("endAt").type(JsonFieldType.STRING).description("리그 종료 시간"),
-                                fieldWithPath("inProgressRound").type(JsonFieldType.NUMBER).description("리그의 현재 라운드"),
-                                fieldWithPath("maxRound").type(JsonFieldType.NUMBER).description("리그 총 라운드"),
-                                fieldWithPath("isInProgress").type(JsonFieldType.BOOLEAN).description("대회가 현재 진행 중인지 여햐")
-                        )
-                ));
-    }
+		// then
+		result.andExpect((status().isOk()))
+			.andDo(restDocsHandler.document(
+				pathParameters(
+					parameterWithName("leagueId").description("리그의 ID")
+				),
+				responseFields(
+					fieldWithPath("name").type(JsonFieldType.STRING).description("리그 이름"),
+					fieldWithPath("startAt").type(JsonFieldType.STRING).description("리그 시작 시간"),
+					fieldWithPath("endAt").type(JsonFieldType.STRING).description("리그 종료 시간"),
+					fieldWithPath("inProgressRound").type(JsonFieldType.NUMBER).description("리그의 현재 라운드"),
+					fieldWithPath("maxRound").type(JsonFieldType.NUMBER).description("리그 총 라운드"),
+					fieldWithPath("isInProgress").type(JsonFieldType.BOOLEAN).description("대회가 현재 진행 중인지 여햐")
+				)
+			));
+	}
+
+	@Test
+	void 리그팀의_모든_선수를_조회한다() throws Exception {
+		// given
+		Long leagueTeamId = 1L;
+
+		List<LeagueTeamPlayerResponse> responses = List.of(
+			new LeagueTeamPlayerResponse(1L, "봄동나물진승희", "설명설명설명", 0),
+			new LeagueTeamPlayerResponse(2L, "가을전어이동규", "설명설명설명", 2)
+		);
+
+		given(leagueQueryService.findPlayersByLeagueTeam(leagueTeamId))
+			.willReturn(responses);
+
+		// when
+		ResultActions result = mockMvc.perform(get("/leagues/teams/{leagueTeamId}/players/all", leagueTeamId)
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		result.andExpect((status().isOk()))
+			.andDo(restDocsHandler.document(
+				pathParameters(
+					parameterWithName("leagueTeamId").description("리그 팀의 ID")
+				),
+				responseFields(
+					fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("대회 팀 선수 ID"),
+					fieldWithPath("[].name").type(JsonFieldType.STRING).description("대회 팀 선수 이름"),
+					fieldWithPath("[].description").type(JsonFieldType.STRING).description("대회 팀 선수 설명"),
+					fieldWithPath("[].number").type(JsonFieldType.NUMBER).description("대회 팀 선수 점수")
+				)
+			));
+	}
 }

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -178,7 +178,7 @@ public class LeagueQueryControllerTest extends DocumentationTest {
 			.willReturn(responses);
 
 		// when
-		ResultActions result = mockMvc.perform(get("/leagues/teams/{leagueTeamId}/players/all", leagueTeamId)
+		ResultActions result = mockMvc.perform(get("/leagues/teams/{leagueTeamId}/players", leagueTeamId)
 			.contentType(MediaType.APPLICATION_JSON));
 
 		// then

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -53,4 +53,11 @@ VALUES (2, '서어 뻬데뻬', '이미지이미지', 1, 1, 1);
 INSERT INTO league_teams (id, name, logo_image_url, manager_id, organization_id, league_id)
 VALUES (3, '미컴 축구생각', '이미지이미지', 1, 1, 1);
 
+-- 리그팀의 선수
+INSERT INTO league_team_players (id, name, description, number, league_team_id)
+    VALUES (1, '봄동나물진승희', '설명설명설명', 0, 3),
+           (2, '가을전어이동규', '설명설명설명', 2, 3),
+           (3, '겨울붕어빵이현제', '설명설명설명', 3, 3),
+           (4, '여름수박고병룡', '설명설명설명', 3, 3);
+
 SET foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
* closed #147

## 📝 구현 내용
* 대회팀과 대회 팀 선수가 가나다 순으로 조회되도록 변경
* 해당 인수 및 문서화 테스트 작성

## 🍀 확인해야 할 부분
