### PR TITLE
[REFACTOR] 타임라인 조회 api Timeline 엔티티 사용하도록 변경

### DIFF
--- a/src/main/java/com/sports/server/command/timeline/domain/GameProgressTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/GameProgressTimeline.java
@@ -11,4 +11,9 @@ public class GameProgressTimeline extends Timeline  {
     @Enumerated(EnumType.STRING)
     @Column(name = "game_progress_type")
     private GameProgressType gameProgressType;
+
+    @Override
+    public String getType() {
+        return "GAME_PROGRESS";
+    }
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/PKTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/PKTimeline.java
@@ -15,4 +15,9 @@ public class PKTimeline extends Timeline {
 
     @Column(name = "is_success")
     private Boolean isSuccess;
+
+    @Override
+    public String getType() {
+        return "PK";
+    }
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
@@ -16,4 +16,9 @@ public class ReplacementTimeline extends Timeline {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "replaced_lineup_player_id")
     private LineupPlayer replacedLineupPlayer;
+
+    @Override
+    public String getType() {
+        return "REPLACEMENT";
+    }
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/ScoreTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ScoreTimeline.java
@@ -15,4 +15,9 @@ public class ScoreTimeline extends Timeline {
 
     @Column(name = "score")
     private Integer score;
+
+    @Override
+    public String getType() {
+        return "SCORE";
+    }
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/ScoreTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ScoreTimeline.java
@@ -1,5 +1,6 @@
 package com.sports.server.command.timeline.domain;
 
+import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.game.domain.LineupPlayer;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -15,6 +16,20 @@ public class ScoreTimeline extends Timeline {
 
     @Column(name = "score")
     private Integer score;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_team1_id")
+    private GameTeam gameTeam1;
+
+    @Column(name = "snapshot_score1")
+    private Integer snapshotScore1;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_team2_id")
+    private GameTeam gameTeam2;
+
+    @Column(name = "snapshot_score2")
+    private Integer snapshotScore2;
 
     @Override
     public String getType() {

--- a/src/main/java/com/sports/server/command/timeline/domain/Timeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/Timeline.java
@@ -26,4 +26,6 @@ public abstract class Timeline extends BaseEntity<Timeline> {
 
     @Column(name = "recorded_at", nullable = false)
     private Integer recordedAt;
+
+    abstract public String getType();
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/Timeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/Timeline.java
@@ -18,14 +18,14 @@ public abstract class Timeline extends BaseEntity<Timeline> {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id", nullable = false)
-    private Game game;
+    protected Game game;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recorded_quarter_id", nullable = false)
-    private Quarter recordedQuarter;
+    protected Quarter recordedQuarter;
 
     @Column(name = "recorded_at", nullable = false)
-    private Integer recordedAt;
+    protected Integer recordedAt;
 
     abstract public String getType();
 }

--- a/src/main/java/com/sports/server/query/application/timeline/TimelineQueryService.java
+++ b/src/main/java/com/sports/server/query/application/timeline/TimelineQueryService.java
@@ -1,8 +1,10 @@
 package com.sports.server.query.application.timeline;
 
 import com.sports.server.command.sport.domain.Quarter;
+import com.sports.server.command.timeline.domain.Timeline;
 import com.sports.server.query.dto.response.RecordResponse;
 import com.sports.server.query.dto.response.TimelineResponse;
+import com.sports.server.query.repository.TimelineQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ import static java.util.stream.Collectors.groupingBy;
 public class TimelineQueryService {
 
     private final List<RecordQueryService> recordQueryServices;
+    private final TimelineQueryRepository timelineQueryRepository;
 
     public List<TimelineResponse> getTimeline(final Long gameId) {
         Map<Quarter, List<RecordResponse>> records = getRecordsGroupByQuarter(gameId);
@@ -38,5 +41,19 @@ public class TimelineQueryService {
                 .flatMap(recordQueryService -> recordQueryService.findByGameId(gameId).stream())
                 .sorted(comparingInt(RecordResponse::recordedAt).reversed())
                 .collect(groupingBy(RecordResponse::quarter));
+    }
+
+    public List<TimelineResponse> getTimelines(final Long gameId) {
+        Map<Quarter, List<Timeline>> timelines = timelineQueryRepository.findByGameId(gameId)
+                .stream()
+                .collect(groupingBy(Timeline::getRecordedQuarter));
+
+        return timelines.keySet()
+                .stream()
+                .sorted(comparingLong(Quarter::getId).reversed())
+                .map(quarter -> TimelineResponse.of(
+                        quarter.getName(),
+                        timelines.get(quarter)
+                )).toList();
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -2,6 +2,7 @@ package com.sports.server.query.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sports.server.command.sport.domain.Quarter;
+import com.sports.server.command.timeline.domain.Timeline;
 
 public record RecordResponse(
         @JsonIgnore
@@ -16,4 +17,11 @@ public record RecordResponse(
         ScoreRecordResponse scoreRecord,
         ReplacementRecordResponse replacementRecord
 ) {
+    public static RecordResponse from(Timeline timeline) {
+        return new RecordResponse(
+                timeline.getRecordedQuarter(),
+                timeline.getId(),
+                timeline.getType(),
+        );
+    }
 }

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -23,7 +23,7 @@ public record RecordResponse(
         ReplacementRecordResponse replacementRecord
 ) {
     public static RecordResponse from(Timeline timeline) {
-        LineupPlayer lineupPlayer = getPlayerName(timeline);
+        LineupPlayer lineupPlayer = getPlayer(timeline);
         GameTeam gameTeam = lineupPlayer.getGameTeam();
         LeagueTeam leagueTeam = gameTeam.getLeagueTeam();
 
@@ -43,7 +43,7 @@ public record RecordResponse(
         );
     }
 
-    private static LineupPlayer getPlayerName(Timeline timeline) {
+    private static LineupPlayer getPlayer(Timeline timeline) {
         if (timeline instanceof ScoreTimeline scoreTimeline) {
             return scoreTimeline.getScorer();
         } else if (timeline instanceof ReplacementTimeline replacementTimeline) {

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -1,7 +1,12 @@
 package com.sports.server.query.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sports.server.command.game.domain.GameTeam;
+import com.sports.server.command.game.domain.LineupPlayer;
+import com.sports.server.command.leagueteam.LeagueTeam;
 import com.sports.server.command.sport.domain.Quarter;
+import com.sports.server.command.timeline.domain.ReplacementTimeline;
+import com.sports.server.command.timeline.domain.ScoreTimeline;
 import com.sports.server.command.timeline.domain.Timeline;
 
 public record RecordResponse(
@@ -18,10 +23,32 @@ public record RecordResponse(
         ReplacementRecordResponse replacementRecord
 ) {
     public static RecordResponse from(Timeline timeline) {
+        LineupPlayer lineupPlayer = getPlayerName(timeline);
+        GameTeam gameTeam = lineupPlayer.getGameTeam();
+        LeagueTeam leagueTeam = gameTeam.getLeagueTeam();
+
         return new RecordResponse(
                 timeline.getRecordedQuarter(),
                 timeline.getId(),
                 timeline.getType(),
+                timeline.getRecordedAt(),
+                lineupPlayer.getName(),
+                gameTeam.getId(),
+                leagueTeam.getName(),
+                leagueTeam.getLogoImageUrl(),
+                timeline instanceof ScoreTimeline scoreTimeline
+                        ? ScoreRecordResponse.from(scoreTimeline) : null,
+                timeline instanceof ReplacementTimeline replacementTimeline
+                        ? ReplacementRecordResponse.from(replacementTimeline) : null
         );
+    }
+
+    private static LineupPlayer getPlayerName(Timeline timeline) {
+        if (timeline instanceof ScoreTimeline scoreTimeline) {
+            return scoreTimeline.getScorer();
+        } else if (timeline instanceof ReplacementTimeline replacementTimeline) {
+            return replacementTimeline.getOriginLineupPlayer();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/ReplacementRecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/ReplacementRecordResponse.java
@@ -1,7 +1,15 @@
 package com.sports.server.query.dto.response;
 
+import com.sports.server.command.timeline.domain.ReplacementTimeline;
+
 public record ReplacementRecordResponse(
         Long replacementRecordId,
         String replacedPlayerName
 ) {
+    public static ReplacementRecordResponse from(ReplacementTimeline timeline) {
+        return new ReplacementRecordResponse(
+                timeline.getId(),
+                timeline.getReplacedLineupPlayer().getName()
+        );
+    }
 }

--- a/src/main/java/com/sports/server/query/dto/response/ScoreRecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/ScoreRecordResponse.java
@@ -1,5 +1,7 @@
 package com.sports.server.query.dto.response;
 
+import com.sports.server.command.timeline.domain.ScoreTimeline;
+
 import java.util.List;
 
 public record ScoreRecordResponse(
@@ -7,6 +9,14 @@ public record ScoreRecordResponse(
         Integer score,
         List<Snapshot> snapshot
 ) {
+
+    public static ScoreRecordResponse from(ScoreTimeline scoreTimeline) {
+        return new ScoreRecordResponse(
+                scoreTimeline.getId(),
+                scoreTimeline.getScore(),
+                List.of()
+        );
+    }
 
     public record Snapshot(
             String teamName,

--- a/src/main/java/com/sports/server/query/dto/response/ScoreRecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/ScoreRecordResponse.java
@@ -1,5 +1,6 @@
 package com.sports.server.query.dto.response;
 
+import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.timeline.domain.ScoreTimeline;
 
 import java.util.List;
@@ -14,7 +15,10 @@ public record ScoreRecordResponse(
         return new ScoreRecordResponse(
                 scoreTimeline.getId(),
                 scoreTimeline.getScore(),
-                List.of()
+                List.of(
+                        Snapshot.of(scoreTimeline.getGameTeam1(), scoreTimeline.getSnapshotScore1()),
+                        Snapshot.of(scoreTimeline.getGameTeam2(), scoreTimeline.getSnapshotScore2())
+                )
         );
     }
 
@@ -23,5 +27,12 @@ public record ScoreRecordResponse(
             String teamImageUrl,
             Integer score
     ) {
+        public static Snapshot of(GameTeam gameTeam, Integer score) {
+            return new Snapshot(
+                    gameTeam.getLeagueTeam().getName(),
+                    gameTeam.getLeagueTeam().getLogoImageUrl(),
+                    score
+            );
+        }
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/TimelineResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/TimelineResponse.java
@@ -9,6 +9,11 @@ public record TimelineResponse(
         List<RecordResponse> records
 ) {
     public static TimelineResponse of(String quarter, List<Timeline> timelines) {
-        return null;
+        return new TimelineResponse(
+                quarter,
+                timelines.stream()
+                        .map(RecordResponse::from)
+                        .toList()
+        );
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/TimelineResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/TimelineResponse.java
@@ -1,9 +1,14 @@
 package com.sports.server.query.dto.response;
 
+import com.sports.server.command.timeline.domain.Timeline;
+
 import java.util.List;
 
 public record TimelineResponse(
         String gameQuarter,
         List<RecordResponse> records
 ) {
+    public static TimelineResponse of(String quarter, List<Timeline> timelines) {
+        return null;
+    }
 }

--- a/src/main/java/com/sports/server/query/presentation/TimelineQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/TimelineQueryController.java
@@ -16,8 +16,21 @@ public class TimelineQueryController {
 
     private final TimelineQueryService timelineQueryService;
 
+    /**
+     * TODO 마이그레이션이 완료되면 삭제될 API
+     */
+    @Deprecated
     @GetMapping("/games/{gameId}/timeline")
     public ResponseEntity<List<TimelineResponse>> getTimeline(@PathVariable final Long gameId) {
         return ResponseEntity.ok(timelineQueryService.getTimeline(gameId));
+    }
+
+    /**
+     * Timeline 엔티티를 사용하는 타임라인 조회 API
+     * TODO 마이그레이션이 완료되면 v2 워딩을 삭제
+     */
+    @GetMapping("/games/{gameId}/timeline/v2")
+    public ResponseEntity<List<TimelineResponse>> getTimelines(@PathVariable final Long gameId) {
+        return ResponseEntity.ok(timelineQueryService.getTimelines(gameId));
     }
 }

--- a/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
@@ -1,0 +1,17 @@
+package com.sports.server.query.repository;
+
+import com.sports.server.command.timeline.domain.Timeline;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface TimelineQueryRepository extends Repository<Timeline, Long> {
+
+    @Query("select t from Timeline t " +
+            "join fetch t.game g " +
+            "join fetch t.recordedQuarter rq " +
+            "where t.game.id = :gameId " +
+            "order by t.id asc")
+    List<Timeline> findByGameId(Long gameId);
+}

--- a/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
@@ -12,6 +12,6 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             "join fetch t.game g " +
             "join fetch t.recordedQuarter rq " +
             "where t.game.id = :gameId " +
-            "order by t.id asc")
+            "order by t.id desc")
     List<Timeline> findByGameId(Long gameId);
 }

--- a/src/main/resources/db/migration/V11__add_column_snapshot.sql
+++ b/src/main/resources/db/migration/V11__add_column_snapshot.sql
@@ -1,0 +1,17 @@
+ALTER TABLE timelines
+    ADD COLUMN game_team1_id BIGINT NULL;
+
+ALTER TABLE timelines
+    ADD COLUMN game_team2_id BIGINT NULL;
+
+ALTER TABLE timelines
+    ADD COLUMN snapshot_score1 INT NULL;
+
+ALTER TABLE timelines
+    ADD COLUMN snapshot_score2 INT NULL;
+
+ALTER TABLE timelines
+    ADD CONSTRAINT FK_TIMELINES_ON_GAME_TEAM1 FOREIGN KEY (game_team1_id) REFERENCES game_teams (id);
+
+ALTER TABLE timelines
+    ADD CONSTRAINT FK_TIMELINES_ON_GAME_TEAM2 FOREIGN KEY (game_team2_id) REFERENCES game_teams (id);

--- a/src/test/java/com/sports/server/query/acceptance/TimelineQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/TimelineQueryAcceptanceTest.java
@@ -42,7 +42,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .get("/games/{gameId}/timeline", baseballId)
+                .get("/games/{gameId}/timeline/v2", baseballId)
                 .then().log().all()
                 .extract();
 
@@ -60,7 +60,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                         2L,
                                         TEAM_B,
                                         TEAM_B_IMAGE_URL,
-                                        new ScoreRecordResponse(2L, 3, List.of(
+                                        new ScoreRecordResponse(4L, 3, List.of(
                                                 new ScoreRecordResponse.Snapshot(
                                                         TEAM_A, TEAM_A_IMAGE_URL, 2),
                                                 new ScoreRecordResponse.Snapshot(
@@ -76,7 +76,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                         TEAM_A,
                                         TEAM_A_IMAGE_URL,
                                         null,
-                                        new ReplacementRecordResponse(2L,"선수3")
+                                        new ReplacementRecordResponse(3L,"선수3")
                                 )
                         )),
                         new TimelineResponse(
@@ -89,7 +89,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                         TEAM_B,
                                         TEAM_B_IMAGE_URL,
                                         null,
-                                        new ReplacementRecordResponse(1L,"선수7")
+                                        new ReplacementRecordResponse(2L,"선수7")
                                 ),
                                 new RecordResponse(
                                         null, 1L, SCORE_TYPE,

--- a/src/test/resources/record-fixture.sql
+++ b/src/test/resources/record-fixture.sql
@@ -1,4 +1,5 @@
-SET foreign_key_checks = 0;
+SET
+foreign_key_checks = 0;
 
 -- 스포츠
 INSERT INTO sports (id, name)
@@ -44,26 +45,86 @@ VALUES (6, 2, '선수6', '센터', true, 6, 1),
        (10, 2, '선수10', '스몰 포워드', false, 10, 1);
 
 -- 1쿼터 경기 기록 추가
-INSERT INTO records (id, game_id, game_team_id, recorded_quarter_id, recorded_at, record_type)
-VALUES (1, 1, 1, 1, 22, 'SCORE');
-INSERT INTO score_records (record_id, lineup_player_id, score)
-VALUES (1, 2, 2); -- A팀 선수 2의 2득점
 
-INSERT INTO records (id, game_id, game_team_id, recorded_quarter_id, recorded_at, record_type)
-VALUES (2, 1, 2, 1, 24, 'REPLACEMENT');
-INSERT INTO replacement_records(record_id, origin_lineup_player_id, replaced_lineup_player_id)
-VALUES (2, 6, 7);
+-- A팀 선수 2의 2득점
+INSERT INTO timelines (type,
+                       game_id,
+                       recorded_quarter_id,
+                       recorded_at,
+                       scorer_id,
+                       score,
+                       game_team1_id,
+                       snapshot_score1,
+                       game_team2_id,
+                       snapshot_score2)
+VALUES ('SCORE', -- type
+        1, -- game_id
+        1, -- recorded_quarter_id
+        22, -- recorded_at (UNIX timestamp)
+        2, -- scorer_id
+        2, -- score
+        1, -- game_team1_id
+        2, -- snapshot_score1
+        2, -- game_team2_id
+        0 -- snapshot_score2
+       );
+
+
 -- B팀 6선수 OUT 7선수 IN
+INSERT INTO timelines (type,
+                       game_id,
+                       recorded_quarter_id,
+                       recorded_at,
+                       origin_lineup_player_id,
+                       replaced_lineup_player_id)
+VALUES ('REPLACEMENT', -- type
+        1, -- game_id
+        1, -- recorded_quarter_id
+        24, -- recorded_at (UNIX timestamp)
+        6, -- origin_lineup_player_id
+        7 -- replaced_lineup_player_id
+       );
 
 -- 2쿼터 경기 기록 추가
-INSERT INTO records (id, game_id, game_team_id, recorded_quarter_id, recorded_at, record_type)
-VALUES (3, 1, 1, 2, 10, 'REPLACEMENT');
-INSERT INTO replacement_records(record_id, origin_lineup_player_id, replaced_lineup_player_id)
-VALUES (3, 2, 3); -- A팀 2선수 OUT 3선수 IN
 
-INSERT INTO records (id, game_id, game_team_id, recorded_quarter_id, recorded_at, record_type)
-VALUES (4, 1, 2, 2, 13, 'SCORE');
-INSERT INTO score_records (record_id, lineup_player_id, score)
-VALUES (4, 10, 3); -- B팀 선수 10의 3득점
+-- A팀 2선수 OUT 3선수 IN
+INSERT INTO timelines (type,
+                       game_id,
+                       recorded_quarter_id,
+                       recorded_at,
+                       origin_lineup_player_id,
+                       replaced_lineup_player_id)
+VALUES ('REPLACEMENT', -- type
+        1, -- game_id
+        2, -- recorded_quarter_id
+        10, -- recorded_at (UNIX timestamp)
+        2, -- origin_lineup_player_id
+        3 -- replaced_lineup_player_id
+       );
 
-SET foreign_key_checks = 1;
+
+-- B팀 선수 10의 3득점
+INSERT INTO timelines (type,
+                       game_id,
+                       recorded_quarter_id,
+                       recorded_at,
+                       scorer_id,
+                       score,
+                       game_team1_id,
+                       snapshot_score1,
+                       game_team2_id,
+                       snapshot_score2)
+VALUES ('SCORE', -- type
+        1, -- game_id
+        2, -- recorded_quarter_id
+        13, -- recorded_at (UNIX timestamp)
+        10, -- scorer_id
+        3, -- score
+        1, -- game_team1_id
+        2, -- snapshot_score1
+        2, -- game_team2_id
+        3 -- snapshot_score2
+       );
+
+SET
+foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #156

## 📝 구현 내용
- 기존 record 테이블 기반으로 조회하던 api를 timeline 테이블을 사용하도록 변경
- 당장 프론트에서 사용하고 있는 api이기 때문에 마이그레이션 전에는 프론트에서 사용하면 안되기 때문에 아래와 같이 반영

``` java
@RestController
@RequiredArgsConstructor
public class TimelineQueryController {

    private final TimelineQueryService timelineQueryService;

    /**
     * TODO 마이그레이션이 완료되면 삭제될 API
     */
    @Deprecated
    @GetMapping("/games/{gameId}/timeline")
    public ResponseEntity<List<TimelineResponse>> getTimeline(@PathVariable final Long gameId) {
        return ResponseEntity.ok(timelineQueryService.getTimeline(gameId));
    }

    /**
     * Timeline 엔티티를 사용하는 타임라인 조회 API
     * TODO 마이그레이션이 완료되면 v2 워딩을 삭제
     */
    @GetMapping("/games/{gameId}/timeline/v2")
    public ResponseEntity<List<TimelineResponse>> getTimelines(@PathVariable final Long gameId) {
        return ResponseEntity.ok(timelineQueryService.getTimelines(gameId));
    }
}
```

- 마이그레이션이 완료되고 프론트가 새로운 api를 쓰도록 변경하면 기존 api와 record 테이블은 drop할 예정

## 🍀 확인해야 할 부분
