### PR TITLE
[FIX] 만료된 토큰으로 로그인 요청 버그 해결

### DIFF
--- a/src/test/java/com/sports/server/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/sports/server/auth/acceptance/AuthAcceptanceTest.java
@@ -77,7 +77,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
             ExtractableResponse<Response> response = RestAssured.given().log().all()
                     .when()
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .cookie(COOKIE_NAME, "expired-token")
+                    .cookie(COOKIE_NAME, expiredToken)
                     .body(loginRequest)
                     .post("/manager/login")
                     .then().log().all()

--- a/src/test/java/com/sports/server/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/sports/server/auth/acceptance/AuthAcceptanceTest.java
@@ -1,9 +1,12 @@
 package com.sports.server.auth.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doThrow;
 
 import com.sports.server.auth.dto.LoginRequest;
 import com.sports.server.auth.exception.AuthorizationErrorMessages;
+import com.sports.server.common.exception.UnauthorizedException;
 import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -11,6 +14,7 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -61,6 +65,32 @@ public class AuthAcceptanceTest extends AcceptanceTest {
             assertThat(cookieValue).isNotNull();
         }
 
+        @Test
+        void 만료된_토큰이_교체된다() {
+            // given
+            String expiredToken = "expired-token";
+
+            doThrow(new UnauthorizedException("만료된 토큰입니다."))
+                    .when(jwtUtil).validateToken(expiredToken);
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .when()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .cookie(COOKIE_NAME, "expired-token")
+                    .body(loginRequest)
+                    .post("/manager/login")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            String cookieValue = response.cookie(COOKIE_NAME);
+
+            assertDoesNotThrow(() -> {
+                jwtUtil.validateToken(cookieValue);
+            });
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #171 

## 📝 구현 내용

`jwtFilter`에서 쿠키의 토큰이 만료된 경우 예외를 터뜨리지 않도록 변경했습니다. 예외를 터뜨리지 않아도 `Authentication`을 `SecurityContextHolder`에 세팅하지 않기 때문에 토큰이 필요한 요청에선 시큐리티가 예외를 터뜨립니다.

대신 예외를 터뜨리지 않음으로써 로그인이 필요 없는 요청에 토큰이 이상하다고 401을 던지지 않게 됩니다.

``` java
    private void authenticate(Cookie cookie) {
        String accessToken = cookie.getValue();

        try {
            jwtUtil.validateToken(accessToken);
        } catch (UnauthorizedException e) {
            return;
        }

        Authentication authentication = new UsernamePasswordAuthenticationToken(
                jwtUtil.getEmail(accessToken),
                null,
                null
        );

        SecurityContextHolder.getContext().setAuthentication(authentication);
    }
```


## 🍀 확인해야 할 부분
