### PR TITLE
[FEAT] 리그팀 상세 조회

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -94,12 +94,18 @@ operation::league-team-controller-test/리그팀을_삭제한다[snippets='http-
 
 operation::league-query-controller-test/리그를_하나_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
 
+=== 리그팀 상세 조회
+
+operation::league-query-controller-test/리그팀을_상세_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
+
 == 타임라인 API
 
 === 득점 타임라인 생성
+
 operation::timeline-controller-test/득점_타임라인을_생성한다[snippets='http-request,path-parameters,http-response']
 
 === 교체 타임라인 생성
+
 operation::timeline-controller-test/교체_타임라인을_생성한다[snippets='http-request,path-parameters,http-response']
 
 === 게임의 타임라인 조회
@@ -107,6 +113,7 @@ operation::timeline-controller-test/교체_타임라인을_생성한다[snippets
 operation::timeline-query-controller-test/타임라인을_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
 
 === 타임라인 삭제
+
 operation::timeline-controller-test/타임라인을_삭제한다[snippets='http-request,request-cookies,path-parameters,http-response']
 
 == 스포츠 API

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -1,11 +1,14 @@
 package com.sports.server.query.application;
 
 import com.sports.server.command.league.domain.League;
+import com.sports.server.command.leagueteam.domain.LeagueTeam;
+import com.sports.server.command.leagueteam.domain.LeagueTeamPlayer;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
+import com.sports.server.query.dto.response.LeagueTeamDetailResponse;
 import com.sports.server.query.dto.response.LeagueTeamPlayerResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
 import com.sports.server.query.repository.LeagueQueryRepository;
@@ -65,5 +68,11 @@ public class LeagueQueryService {
                 .stream()
                 .map(LeagueTeamPlayerResponse::new)
                 .toList();
+    }
+
+    public LeagueTeamDetailResponse findLeagueTeam(final Long leagueTeamId) {
+        LeagueTeam leagueTeam = entityUtils.getEntity(leagueTeamId, LeagueTeam.class);
+        List<LeagueTeamPlayer> leagueTeamPlayers = leagueTeamPlayerQueryRepository.findByLeagueTeamId(leagueTeam.getId());
+        return LeagueTeamDetailResponse.of(leagueTeam, leagueTeamPlayers);
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueTeamDetailResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueTeamDetailResponse.java
@@ -1,0 +1,33 @@
+package com.sports.server.query.dto.response;
+
+import com.sports.server.command.leagueteam.domain.LeagueTeam;
+import com.sports.server.command.leagueteam.domain.LeagueTeamPlayer;
+import java.util.List;
+
+public record LeagueTeamDetailResponse(
+        String logoImageUrl,
+        String teamName,
+        List<LeagueTeamPlayerResponse> leagueTeamPlayers
+) {
+    public static LeagueTeamDetailResponse of(final LeagueTeam leagueTeam,
+                                              final List<LeagueTeamPlayer> leagueTeamPlayers) {
+        return new LeagueTeamDetailResponse(
+                leagueTeam.getLogoImageUrl(), leagueTeam.getName(),
+                leagueTeamPlayers.stream()
+                        .map(LeagueTeamPlayerResponse::of)
+                        .toList()
+        );
+    }
+
+    public record LeagueTeamPlayerResponse(
+            Long id,
+            String name,
+            int number
+    ) {
+        public static LeagueTeamPlayerResponse of(final LeagueTeamPlayer leagueTeamPlayer) {
+            return new LeagueTeamPlayerResponse(
+                    leagueTeamPlayer.getId(), leagueTeamPlayer.getName(), leagueTeamPlayer.getNumber()
+            );
+        }
+    }
+}

--- a/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
@@ -4,6 +4,7 @@ import com.sports.server.query.application.LeagueQueryService;
 import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
+import com.sports.server.query.dto.response.LeagueTeamDetailResponse;
 import com.sports.server.query.dto.response.LeagueTeamPlayerResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
 import java.util.List;
@@ -47,5 +48,10 @@ public class LeagueQueryController {
     @GetMapping("/teams/{leagueTeamId}/players")
     public ResponseEntity<List<LeagueTeamPlayerResponse>> findPlayersByLeagueTeam(@PathVariable Long leagueTeamId) {
         return ResponseEntity.ok(leagueQueryService.findPlayersByLeagueTeam(leagueTeamId));
+    }
+
+    @GetMapping("/teams/{leagueTeamId}")
+    public ResponseEntity<LeagueTeamDetailResponse> findLeagueTeam(@PathVariable final Long leagueTeamId) {
+        return ResponseEntity.ok(leagueQueryService.findLeagueTeam(leagueTeamId));
     }
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -488,6 +488,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_리그팀_수정">리그팀 수정</a></li>
 <li><a href="#_리그팀_삭제">리그팀 삭제</a></li>
 <li><a href="#_리그_상세_조회">리그 상세 조회</a></li>
+<li><a href="#_리그팀_상세_조회">리그팀 상세 조회</a></li>
 </ul>
 </li>
 <li><a href="#_타임라인_api">타임라인 API</a>
@@ -1584,7 +1585,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /leagues HTTP/1.1
 Content-Type: application/json
-Content-Length: 179
+Content-Length: 178
 Host: www.api.hufstreaming.site
 Cookie: HCC_SES=temp-cookie
 
@@ -1592,8 +1593,8 @@ Cookie: HCC_SES=temp-cookie
   "organizationId" : 1,
   "name" : "우물정 제기차기 대회",
   "maxRound" : "4강",
-  "startAt" : "2024-08-07T16:06:38.955637",
-  "endAt" : "2024-08-07T16:06:38.955643"
+  "startAt" : "2024-08-08T16:15:24.740259",
+  "endAt" : "2024-08-08T16:15:24.74027"
 }</code></pre>
 </div>
 </div>
@@ -2304,6 +2305,117 @@ Content-Length: 218
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_리그팀_상세_조회"><a class="link" href="#_리그팀_상세_조회">리그팀 상세 조회</a></h3>
+<div class="sect3">
+<h4 id="_리그팀_상세_조회_http_request"><a class="link" href="#_리그팀_상세_조회_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /leagues/teams/3 HTTP/1.1
+Content-Type: application/json
+Host: www.api.hufstreaming.site</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리그팀_상세_조회_path_parameters"><a class="link" href="#_리그팀_상세_조회_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /leagues/teams/{leagueTeamId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>leagueTeamId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리그 팀의 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_리그팀_상세_조회_http_response"><a class="link" href="#_리그팀_상세_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 261
+
+{
+  "logoImageUrl" : "이미지이미지",
+  "teamName" : "미컴 축구생각",
+  "leagueTeamPlayers" : [ {
+    "id" : 1,
+    "name" : "봄동나물진승희",
+    "number" : 0
+  }, {
+    "id" : 2,
+    "name" : "가을전어이동규",
+    "number" : 2
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_리그팀_상세_조회_response_fields"><a class="link" href="#_리그팀_상세_조회_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>teamName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대회 팀의 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>logoImageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">로고 이미지의 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>leagueTeamPlayers</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대회 팀 선수들</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>leagueTeamPlayers[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대회 팀 선수 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>leagueTeamPlayers[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대회 팀 선수 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>leagueTeamPlayers[].number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대회 팀 선수 점수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -2818,7 +2930,7 @@ Host: www.api.hufstreaming.site
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: HCC_SES=testAccessToken; Path=/; Max-Age=604800; Expires=Wed, 14 Aug 2024 07:06:35 GMT; Secure; HttpOnly; SameSite=Strict</code></pre>
+Set-Cookie: HCC_SES=testAccessToken; Path=/; Max-Age=604800; Expires=Thu, 15 Aug 2024 07:15:21 GMT; Secure; HttpOnly; SameSite=Strict</code></pre>
 </div>
 </div>
 </div>
@@ -2892,7 +3004,7 @@ Content-Length: 82
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-08-07 15:50:23 +0900
+Last updated 2024-08-08 16:14:48 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/LeagueQueryAcceptanceTest.java
@@ -1,24 +1,24 @@
 package com.sports.server.query.acceptance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.sports.server.command.league.domain.LeagueProgress;
 import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
+import com.sports.server.query.dto.response.LeagueTeamDetailResponse;
 import com.sports.server.query.dto.response.LeagueTeamPlayerResponse;
 import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Sql(scripts = "/league-fixture.sql")
 public class LeagueQueryAcceptanceTest extends AcceptanceTest {
@@ -131,20 +131,46 @@ public class LeagueQueryAcceptanceTest extends AcceptanceTest {
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-            .when()
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .get("/leagues/teams/{leagueTeamId}/players", soccerishThought)
-            .then().log().all()
-            .extract();
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/leagues/teams/{leagueTeamId}/players", soccerishThought)
+                .then().log().all()
+                .extract();
 
         // then
         List<LeagueTeamPlayerResponse> actual = toResponses(response, LeagueTeamPlayerResponse.class);
         assertAll(
-            () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-            () -> assertThat(actual).map(LeagueTeamPlayerResponse::name)
-                .containsExactly("가을전어이동규", "겨울붕어빵이현제", "봄동나물진승희", "여름수박고병룡"),
-            () -> assertThat(actual).map(LeagueTeamPlayerResponse::id)
-                .containsExactly(2L, 3L, 1L, 4L)
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual).map(LeagueTeamPlayerResponse::name)
+                        .containsExactly("가을전어이동규", "겨울붕어빵이현제", "봄동나물진승희", "여름수박고병룡"),
+                () -> assertThat(actual).map(LeagueTeamPlayerResponse::id)
+                        .containsExactly(2L, 3L, 1L, 4L)
         );
     }
+
+    @Test
+    void 리그팀의_상세정보를_조회한다() {
+        // given
+        Long leagueTeamId = 3L;
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .pathParam("leagueTeamId", leagueTeamId)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/leagues/teams/{leagueTeamId}")
+                .then().log().all()
+                .extract();
+
+        // then
+        LeagueTeamDetailResponse actual = toResponse(response, LeagueTeamDetailResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual.leagueTeamPlayers()).map(
+                                LeagueTeamDetailResponse.LeagueTeamPlayerResponse::name)
+                        .containsExactly("가을전어이동규", "겨울붕어빵이현제", "봄동나물진승희", "여름수박고병룡"),
+                () -> assertThat(actual.teamName()).isEqualTo("미컴 축구생각"),
+                () -> assertThat(actual.logoImageUrl()).isEqualTo("이미지이미지")
+        );
+    }
+
 }

--- a/src/test/java/com/sports/server/query/application/LeagueQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/LeagueQueryServiceTest.java
@@ -1,11 +1,16 @@
 package com.sports.server.query.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.sports.server.query.dto.response.LeagueTeamDetailResponse;
+import com.sports.server.query.dto.response.LeagueTeamDetailResponse.LeagueTeamPlayerResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
 import com.sports.server.support.ServiceTest;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
@@ -33,5 +38,56 @@ public class LeagueQueryServiceTest extends ServiceTest {
         );
 
     }
+
+    @Nested
+    @DisplayName("리그팀의 상세 정보를 조회할 때")
+    class LeagueTeamDetailedQueryTest {
+        @Test
+        void 정상적으로_조회된다() {
+            // given
+            Long leagueTeamId = 3L;
+
+            // when
+            LeagueTeamDetailResponse leagueTeam = leagueQueryService.findLeagueTeam(leagueTeamId);
+
+            // then
+            assertAll(
+                    () -> assertThat(leagueTeam.teamName()).isEqualTo("미컴 축구생각"),
+                    () -> assertThat(leagueTeam.logoImageUrl()).isEqualTo("이미지이미지"),
+                    () -> assertThat(leagueTeam.leagueTeamPlayers()).hasSize(4),
+                    () -> {
+                        assertThat(leagueTeam.leagueTeamPlayers())
+                                .extracting("id", "name", "number")
+                                .containsExactlyInAnyOrder(
+                                        tuple(1L, "봄동나물진승희", 0),
+                                        tuple(2L, "가을전어이동규", 2),
+                                        tuple(3L, "겨울붕어빵이현제", 3),
+                                        tuple(4L, "여름수박고병룡", 3)
+                                );
+                    }
+            );
+        }
+
+        @Test
+        void 리그팀_선수가_ㄱㄴㄷ순으로_반환된다() {
+            // given
+            Long leagueTeamId = 1L;
+
+            // when
+            LeagueTeamDetailResponse leagueTeam = leagueQueryService.findLeagueTeam(leagueTeamId);
+
+            // then
+            assertAll(
+                    () -> {
+                        List<String> playerNames = leagueTeam.leagueTeamPlayers()
+                                .stream()
+                                .map(LeagueTeamPlayerResponse::name)
+                                .toList();
+                        assertThat(playerNames).isSortedAccordingTo(String.CASE_INSENSITIVE_ORDER);
+                    }
+            );
+        }
+    }
+
 
 }

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.sports.server.query.dto.response.LeagueDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponse;
 import com.sports.server.query.dto.response.LeagueSportResponse;
+import com.sports.server.query.dto.response.LeagueTeamDetailResponse;
 import com.sports.server.query.dto.response.LeagueTeamPlayerResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
 import com.sports.server.support.DocumentationTest;
@@ -198,6 +199,46 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].name").type(JsonFieldType.STRING).description("대회 팀 선수 이름"),
                                 fieldWithPath("[].description").type(JsonFieldType.STRING).description("대회 팀 선수 설명"),
                                 fieldWithPath("[].number").type(JsonFieldType.NUMBER).description("대회 팀 선수 점수")
+                        )
+                ));
+    }
+
+    @Test
+    void 리그팀을_상세_조회한다() throws Exception {
+        // given
+        Long leagueTeamId = 3L;
+
+        List<LeagueTeamDetailResponse.LeagueTeamPlayerResponse> leagueTeamPlayerResponses = List.of(
+                new LeagueTeamDetailResponse.LeagueTeamPlayerResponse(1L, "봄동나물진승희", 0),
+                new LeagueTeamDetailResponse.LeagueTeamPlayerResponse(2L, "가을전어이동규", 2)
+        );
+        LeagueTeamDetailResponse leagueTeamDetailResponse = new LeagueTeamDetailResponse(
+                "이미지이미지", "미컴 축구생각", leagueTeamPlayerResponses
+        );
+
+        given(leagueQueryService.findLeagueTeam(leagueTeamId))
+                .willReturn(leagueTeamDetailResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/leagues/teams/{leagueTeamId}", leagueTeamId)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("leagueTeamId").description("리그 팀의 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("teamName").type(JsonFieldType.STRING).description("대회 팀의 이름"),
+                                fieldWithPath("logoImageUrl").type(JsonFieldType.STRING).description("로고 이미지의 URL"),
+                                fieldWithPath("leagueTeamPlayers").type(JsonFieldType.ARRAY).description("대회 팀 선수들"),
+                                fieldWithPath("leagueTeamPlayers[].id").type(JsonFieldType.NUMBER)
+                                        .description("대회 팀 선수 ID"),
+                                fieldWithPath("leagueTeamPlayers[].name").type(JsonFieldType.STRING)
+                                        .description("대회 팀 선수 이름"),
+                                fieldWithPath("leagueTeamPlayers[].number").type(JsonFieldType.NUMBER)
+                                        .description("대회 팀 선수 점수")
                         )
                 ));
     }


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #184 

## 📝 구현 내용
- 리그팀 상세 조회

## 🍀 확인해야 할 부분
<img width="186" alt="스크린샷 2024-08-08 오후 4 17 07" src="https://github.com/user-attachments/assets/090b5be7-b092-4176-b6af-22f5e3a8975d"><br>
- 위와 같이 리그팀 정보를 수정할 때 필요한 상세 정보 조회를 구현했습니다! 화면에 맞게 잘 설계됐는지 확인 부탁드려요 👀

### DTO 관련
- 기존에 있던 com.sports.server.query.dto.response의 LineupPlayerResponse 를 사용할까 하다가 LeagueDetailResponse 내부에 따로 LineupPlayerResponse 를 만들어 사용했습니다. 어떤 방향이 더 나을지 피드백 주세욥!