### PR TITLE
[FEAT] 라인업 주장으로 등록 및 취소

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -48,6 +48,10 @@ operation::game-controller-test/라인업_선수의_상태를_선발로_변경�
 
 operation::game-controller-test/라인업_선수의_상태를_후보로_변경한다[snippets='path-parameters']
 
+=== 라인업 선수 주장으로 등록 및 취소
+
+operation::game-controller-test/라인업_선수를_주장으로_등록_및_취소한다[snippets='path-parameters']
+
 == 응원 횟수 API
 
 === 응원 횟수 업데이트

--- a/src/main/java/com/sports/server/auth/config/SecurityConfig.java
+++ b/src/main/java/com/sports/server/auth/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
                                 mvc.pattern(HttpMethod.PUT, "/leagues/{leagueId}/teams/{teamId}"),
                                 mvc.pattern(HttpMethod.DELETE, "/leagues/{leagueId}/teams/{teamId}"),
                                 mvc.pattern(HttpMethod.POST, "/leagues/{leagueId}/teams/{teamId}/delete-logo"),
-                                mvc.pattern(HttpMethod.POST, "/games/*/timelines/**")
+                                mvc.pattern(HttpMethod.POST, "/games/*/timelines/**"),
+                                mvc.pattern(HttpMethod.PATCH, "/games/{gameId}/lineup-players/**")
                         )
                         .authenticated()
                         .anyRequest().permitAll()

--- a/src/main/java/com/sports/server/auth/config/SecurityConfig.java
+++ b/src/main/java/com/sports/server/auth/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
                                 mvc.pattern(HttpMethod.DELETE, "/leagues/{leagueId}/teams/{teamId}"),
                                 mvc.pattern(HttpMethod.POST, "/leagues/{leagueId}/teams/{teamId}/delete-logo"),
                                 mvc.pattern(HttpMethod.POST, "/games/*/timelines/**"),
-                                mvc.pattern(HttpMethod.PATCH, "/games/{gameId}/lineup-players/**")
+                                mvc.pattern(HttpMethod.PATCH, "/games/{gameId}/lineup-players/**"),
+                                mvc.pattern(HttpMethod.PATCH, "/games/{gameId}/{gameTeamId}/lineup-players/**")
                         )
                         .authenticated()
                         .anyRequest().permitAll()

--- a/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
+++ b/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
@@ -1,8 +1,11 @@
 package com.sports.server.command.game.application;
 
 import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.GameTeam;
+import com.sports.server.command.game.domain.GameTeamRepository;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.common.application.EntityUtils;
+import com.sports.server.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LineupPlayerService {
     private final EntityUtils entityUtils;
+    private final GameTeamRepository gameTeamRepository;
 
     public void changePlayerStateToStarter(final Long gameId, final Long lineupPlayerId) {
         Game game = entityUtils.getEntity(gameId, Game.class);
@@ -25,9 +29,27 @@ public class LineupPlayerService {
         game.rollbackToCandidate(lineupPlayer);
     }
 
-    public void appointCaptain(Long gameId, Long lineupPlayerId) {
+    public void appointCaptain(final Long gameId, final Long gameTeamId, final Long lineupPlayerId) {
         Game game = entityUtils.getEntity(gameId, Game.class);
-        LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
-        game.appointCaptain(lineupPlayer);
+
+        GameTeam gameTeam = gameTeamRepository.findGameTeamByIdWithLineupPlayers(gameTeamId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 팀입니다."));
+        validateGameTeam(game, gameTeam);
+
+        LineupPlayer lineupPlayer = findLineupPlayer(gameTeam, lineupPlayerId);
+
+        game.appointCaptain(gameTeam, lineupPlayer);
+    }
+
+    private LineupPlayer findLineupPlayer(final GameTeam gameTeam, final Long lineupPlayerId) {
+        return gameTeam.getLineupPlayers().stream()
+                .filter(lup -> lup.getId().equals(lineupPlayerId)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당 선수는 해당 팀에 속하지 않습니다."));
+    }
+
+    private void validateGameTeam(final Game game, final GameTeam gameTeam) {
+        game.getTeams().stream()
+                .filter(gt -> gt.equals(gameTeam)).findAny()
+                .orElseThrow(() -> new IllegalArgumentException("해당 팀은 해당 경기에 속하지 않습니다."));
     }
 }

--- a/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
+++ b/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
@@ -25,9 +25,9 @@ public class LineupPlayerService {
         game.rollbackToCandidate(lineupPlayer);
     }
 
-    public void changePlayerCaptainStatus(Long gameId, Long lineupPlayerId) {
+    public void appointCaptain(Long gameId, Long lineupPlayerId) {
         Game game = entityUtils.getEntity(gameId, Game.class);
         LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
-        game.changeCaptainStatus(lineupPlayer);
+        game.appointCaptain(lineupPlayer);
     }
 }

--- a/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
+++ b/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
@@ -1,29 +1,33 @@
 package com.sports.server.command.game.application;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.common.application.EntityUtils;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class LineupPlayerService {
-	private final EntityUtils entityUtils;
+    private final EntityUtils entityUtils;
 
-	public void changePlayerStateToStarter(final Long gameId, final Long lineupPlayerId) {
-		Game game = entityUtils.getEntity(gameId, Game.class);
-		LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
-		game.registerStarter(lineupPlayer);
-	}
+    public void changePlayerStateToStarter(final Long gameId, final Long lineupPlayerId) {
+        Game game = entityUtils.getEntity(gameId, Game.class);
+        LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
+        game.registerStarter(lineupPlayer);
+    }
 
-	public void changePlayerStateToCandidate(final Long gameId, final Long lineupPlayerId) {
-		Game game = entityUtils.getEntity(gameId, Game.class);
-		LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
-		game.rollbackToCandidate(lineupPlayer);
-	}
+    public void changePlayerStateToCandidate(final Long gameId, final Long lineupPlayerId) {
+        Game game = entityUtils.getEntity(gameId, Game.class);
+        LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
+        game.rollbackToCandidate(lineupPlayer);
+    }
+
+    public void changePlayerCaptainStatus(Long gameId, Long lineupPlayerId) {
+        Game game = entityUtils.getEntity(gameId, Game.class);
+        LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
+        game.changeCaptainStatus(lineupPlayer);
+    }
 }

--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -73,8 +73,8 @@ public class Game extends BaseEntity<Game> {
         this.teams.forEach(gameTeam -> gameTeam.rollbackToCandidate(lineupPlayer));
     }
 
-    public void appointCaptain(final LineupPlayer lineupPlayer) {
-        this.teams.forEach(gameTeam -> gameTeam.changeCaptainStatus(lineupPlayer));
+    public void appointCaptain(final GameTeam gameTeam, final LineupPlayer lineupPlayer) {
+        gameTeam.appointCaptain(lineupPlayer);
     }
 
     public GameTeam getTeam1() {

--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -73,6 +73,10 @@ public class Game extends BaseEntity<Game> {
         this.teams.forEach(gameTeam -> gameTeam.rollbackToCandidate(lineupPlayer));
     }
 
+    public void changeCaptainStatus(final LineupPlayer lineupPlayer) {
+        this.teams.forEach(gameTeam -> gameTeam.changeCaptainStatus(lineupPlayer));
+    }
+
     public GameTeam getTeam1() {
         return teams.stream()
                 .min(Comparator.comparing(GameTeam::getId))

--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -73,7 +73,7 @@ public class Game extends BaseEntity<Game> {
         this.teams.forEach(gameTeam -> gameTeam.rollbackToCandidate(lineupPlayer));
     }
 
-    public void changeCaptainStatus(final LineupPlayer lineupPlayer) {
+    public void appointCaptain(final LineupPlayer lineupPlayer) {
         this.teams.forEach(gameTeam -> gameTeam.changeCaptainStatus(lineupPlayer));
     }
 

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -83,21 +83,16 @@ public class GameTeam extends BaseEntity<GameTeam> {
         }
     }
 
-    public void changeCaptainStatus(LineupPlayer lineupPlayer) {
+    public void appointCaptain(LineupPlayer lineupPlayer) {
         Optional<LineupPlayer> captain = this.lineupPlayers.stream()
                 .filter(LineupPlayer::isCaptain)
                 .findAny();
 
-        boolean playerExistsInTeam = this.lineupPlayers.stream()
-                .anyMatch(lp -> lp.equals(lineupPlayer));
-
-        if (captain.isPresent() && !captain.get().equals(lineupPlayer) && playerExistsInTeam) {
+        if (captain.isPresent() && !captain.get().equals(lineupPlayer)) {
             throw new IllegalStateException("주장은 두 명 이상 등록할 수 없습니다.");
         }
 
-        if (playerExistsInTeam) {
-            lineupPlayer.changeCaptainStatus();
-        }
+        lineupPlayer.appointCaptain();
     }
 
 }

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -1,12 +1,8 @@
 package com.sports.server.command.game.domain;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.sports.server.command.leagueteam.domain.LeagueTeam;
 import com.sports.server.common.domain.BaseEntity;
 import com.sports.server.common.exception.CustomException;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,10 +10,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import org.springframework.http.HttpStatus;
 
 @Entity
@@ -83,6 +80,13 @@ public class GameTeam extends BaseEntity<GameTeam> {
         if (this.score > 0) {
             this.score -= SCORE_VALUE;
         }
+    }
+
+    public void changeCaptainStatus(LineupPlayer lineupPlayer) {
+        this.lineupPlayers.stream()
+                .filter(lp -> lp.equals(lineupPlayer))
+                .findAny()
+                .ifPresent(LineupPlayer::changeCaptainStatus);
     }
 }
 

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -83,11 +83,21 @@ public class GameTeam extends BaseEntity<GameTeam> {
     }
 
     public void changeCaptainStatus(LineupPlayer lineupPlayer) {
-        this.lineupPlayers.stream()
-                .filter(lp -> lp.equals(lineupPlayer))
-                .findAny()
-                .ifPresent(LineupPlayer::changeCaptainStatus);
+        boolean captainExists = this.lineupPlayers.stream()
+                .anyMatch(LineupPlayer::isCaptain);
+
+        boolean playerExistsInTeam = this.lineupPlayers.stream()
+                .anyMatch(lp -> lp.equals(lineupPlayer));
+
+        if (captainExists && playerExistsInTeam) {
+            throw new IllegalStateException("주장은 두 명 이상 등록할 수 없습니다.");
+        }
+
+        if (playerExistsInTeam) {
+            lineupPlayer.changeCaptainStatus();
+        }
     }
+
 }
 
 

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -12,6 +12,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -83,13 +84,14 @@ public class GameTeam extends BaseEntity<GameTeam> {
     }
 
     public void changeCaptainStatus(LineupPlayer lineupPlayer) {
-        boolean captainExists = this.lineupPlayers.stream()
-                .anyMatch(LineupPlayer::isCaptain);
+        Optional<LineupPlayer> captain = this.lineupPlayers.stream()
+                .filter(LineupPlayer::isCaptain)
+                .findAny();
 
         boolean playerExistsInTeam = this.lineupPlayers.stream()
                 .anyMatch(lp -> lp.equals(lineupPlayer));
 
-        if (captainExists && playerExistsInTeam) {
+        if (captain.isPresent() && !captain.get().equals(lineupPlayer) && playerExistsInTeam) {
             throw new IllegalStateException("주장은 두 명 이상 등록할 수 없습니다.");
         }
 

--- a/src/main/java/com/sports/server/command/game/domain/GameTeamRepository.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeamRepository.java
@@ -1,5 +1,6 @@
 package com.sports.server.command.game.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -10,4 +11,11 @@ public interface GameTeamRepository extends Repository<GameTeam, Long> {
     @Modifying
     @Query("UPDATE GameTeam t SET t.cheerCount = t.cheerCount + :cheerCount WHERE t.id = :gameTeamId")
     void updateCheerCount(@Param("gameTeamId") Long gameTeamId, @Param("cheerCount") int cheerCount);
+
+    @Query(
+            "SELECT gt FROM GameTeam gt "
+                    + "JOIN FETCH gt.lineupPlayers "
+                    + "WHERE gt.id=:id "
+    )
+    Optional<GameTeam> findGameTeamByIdWithLineupPlayers(Long id);
 }

--- a/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
+++ b/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
@@ -1,12 +1,10 @@
 package com.sports.server.command.game.domain;
 
-import static com.sports.server.command.game.domain.LineupPlayerState.*;
-
-import org.springframework.http.HttpStatus;
+import static com.sports.server.command.game.domain.LineupPlayerState.CANDIDATE;
+import static com.sports.server.command.game.domain.LineupPlayerState.STARTER;
 
 import com.sports.server.common.domain.BaseEntity;
 import com.sports.server.common.exception.CustomException;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,11 +13,11 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.Objects;
+import org.springframework.http.HttpStatus;
 
 @Entity
 @Getter
@@ -70,5 +68,9 @@ public class LineupPlayer extends BaseEntity<LineupPlayer> {
 
     public boolean isInTeam(GameTeam team) {
         return Objects.equals(this.gameTeam, team);
+    }
+
+    public void changeCaptainStatus() {
+        this.isCaptain = !this.isCaptain;
     }
 }

--- a/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
+++ b/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
@@ -70,7 +70,7 @@ public class LineupPlayer extends BaseEntity<LineupPlayer> {
         return Objects.equals(this.gameTeam, team);
     }
 
-    public void changeCaptainStatus() {
+    public void appointCaptain() {
         this.isCaptain = !this.isCaptain;
     }
 }

--- a/src/main/java/com/sports/server/command/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/command/game/presentation/GameController.java
@@ -42,10 +42,11 @@ public class GameController {
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping("/{gameId}/lineup-players/{lineupPlayerId}/captain")
+    @PatchMapping("/{gameId}/{gameTeamId}/lineup-players/{lineupPlayerId}/captain")
     public ResponseEntity<Void> changePlayerCaptainStatus(@PathVariable final Long gameId,
+                                                          @PathVariable final Long gameTeamId,
                                                           @PathVariable final Long lineupPlayerId) {
-        lineupPlayerService.appointCaptain(gameId, lineupPlayerId);
+        lineupPlayerService.appointCaptain(gameId, gameTeamId, lineupPlayerId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/sports/server/command/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/command/game/presentation/GameController.java
@@ -45,7 +45,7 @@ public class GameController {
     @PatchMapping("/{gameId}/lineup-players/{lineupPlayerId}/captain")
     public ResponseEntity<Void> changePlayerCaptainStatus(@PathVariable final Long gameId,
                                                           @PathVariable final Long lineupPlayerId) {
-        lineupPlayerService.changePlayerCaptainStatus(gameId, lineupPlayerId);
+        lineupPlayerService.appointCaptain(gameId, lineupPlayerId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/sports/server/command/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/command/game/presentation/GameController.java
@@ -18,27 +18,35 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/games")
 public class GameController {
 
-	private final GameTeamService gameTeamService;
-	private final LineupPlayerService lineupPlayerService;
+    private final GameTeamService gameTeamService;
+    private final LineupPlayerService lineupPlayerService;
 
-	@PostMapping("/{gameId}/cheer")
-	public ResponseEntity<Void> updateCheerCount(@PathVariable final Long gameId,
-		@RequestBody @Valid CheerCountUpdateRequest cheerRequestDto) {
-		gameTeamService.updateCheerCount(gameId, cheerRequestDto);
-		return ResponseEntity.ok().build();
-	}
+    @PostMapping("/{gameId}/cheer")
+    public ResponseEntity<Void> updateCheerCount(@PathVariable final Long gameId,
+                                                 @RequestBody @Valid CheerCountUpdateRequest cheerRequestDto) {
+        gameTeamService.updateCheerCount(gameId, cheerRequestDto);
+        return ResponseEntity.ok().build();
+    }
 
-	@PatchMapping("/{gameId}/lineup-players/{lineupPlayerId}/starter")
-	public ResponseEntity<Void> changePlayerStateToStarter(@PathVariable final Long gameId,
-		@PathVariable final Long lineupPlayerId) {
-		lineupPlayerService.changePlayerStateToStarter(gameId, lineupPlayerId);
-		return ResponseEntity.ok().build();
-	}
+    @PatchMapping("/{gameId}/lineup-players/{lineupPlayerId}/starter")
+    public ResponseEntity<Void> changePlayerStateToStarter(@PathVariable final Long gameId,
+                                                           @PathVariable final Long lineupPlayerId) {
+        lineupPlayerService.changePlayerStateToStarter(gameId, lineupPlayerId);
+        return ResponseEntity.ok().build();
+    }
 
-	@PatchMapping("/{gameId}/lineup-players/{lineupPlayerId}/candidate")
-	public ResponseEntity<Void> changePlayerStateToCandidate(@PathVariable final Long gameId,
-		@PathVariable final Long lineupPlayerId) {
-		lineupPlayerService.changePlayerStateToCandidate(gameId, lineupPlayerId);
-		return ResponseEntity.ok().build();
-	}
+    @PatchMapping("/{gameId}/lineup-players/{lineupPlayerId}/candidate")
+    public ResponseEntity<Void> changePlayerStateToCandidate(@PathVariable final Long gameId,
+                                                             @PathVariable final Long lineupPlayerId) {
+        lineupPlayerService.changePlayerStateToCandidate(gameId, lineupPlayerId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{gameId}/lineup-players/{lineupPlayerId}/captain")
+    public ResponseEntity<Void> changePlayerCaptainStatus(@PathVariable final Long gameId,
+                                                          @PathVariable final Long lineupPlayerId) {
+        lineupPlayerService.changePlayerCaptainStatus(gameId, lineupPlayerId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -466,6 +466,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_라인업_선수_선발로_변경">라인업 선수 선발로 변경</a></li>
 <li><a href="#_라인업_선수_후보로_변경">라인업 선수 후보로 변경</a></li>
+<li><a href="#_라인업_선수_주장으로_등록_및_취소">라인업 선수 주장으로 등록 및 취소</a></li>
 </ul>
 </li>
 <li><a href="#_응원_횟수_api">응원 횟수 API</a>
@@ -1450,6 +1451,39 @@ Content-Length: 1620
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_라인업_선수_주장으로_등록_및_취소"><a class="link" href="#_라인업_선수_주장으로_등록_및_취소">라인업 선수 주장으로 등록 및 취소</a></h3>
+<div class="sect3">
+<h4 id="_라인업_선수_주장으로_등록_및_취소_path_parameters"><a class="link" href="#_라인업_선수_주장으로_등록_및_취소_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. /games/{gameId}/{gameTeamId}/lineup-players/{lineupPlayerId}/captain</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>gameId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게임의 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>gameTeamId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게임팀의 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lineupPlayerId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">라인업 선수의 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1585,7 +1619,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /leagues HTTP/1.1
 Content-Type: application/json
-Content-Length: 178
+Content-Length: 179
 Host: www.api.hufstreaming.site
 Cookie: HCC_SES=temp-cookie
 
@@ -1593,8 +1627,8 @@ Cookie: HCC_SES=temp-cookie
   "organizationId" : 1,
   "name" : "우물정 제기차기 대회",
   "maxRound" : "4강",
-  "startAt" : "2024-08-08T16:15:24.740259",
-  "endAt" : "2024-08-08T16:15:24.74027"
+  "startAt" : "2024-08-17T16:38:35.725862",
+  "endAt" : "2024-08-17T16:38:35.725866"
 }</code></pre>
 </div>
 </div>
@@ -2930,7 +2964,7 @@ Host: www.api.hufstreaming.site
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: HCC_SES=testAccessToken; Path=/; Max-Age=604800; Expires=Thu, 15 Aug 2024 07:15:21 GMT; Secure; HttpOnly; SameSite=Strict</code></pre>
+Set-Cookie: HCC_SES=testAccessToken; Path=/; Max-Age=604800; Expires=Sat, 24 Aug 2024 07:38:31 GMT; Secure; HttpOnly; SameSite=Strict</code></pre>
 </div>
 </div>
 </div>
@@ -3004,7 +3038,7 @@ Content-Length: 82
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-08-08 16:14:48 +0900
+Last updated 2024-08-17 16:37:45 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
@@ -143,7 +143,8 @@ public class GameAcceptanceTest extends AcceptanceTest {
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(COOKIE_NAME, mockToken)
-                .patch("/games/{gameId}/lineup-players/{lineupPlayerId}/captain", gameId, lineupPlayerId)
+                .patch("/games/{gameId}/{gameTeamId}/lineup-players/{lineupPlayerId}/captain",
+                        gameId, gameTeamId, lineupPlayerId)
                 .then().log().all()
                 .extract();
 

--- a/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
@@ -1,7 +1,7 @@
 package com.sports.server.command.game.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.sports.server.command.game.domain.LineupPlayerState;
 import com.sports.server.command.game.dto.CheerCountUpdateRequest;
@@ -12,8 +12,6 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.List;
-import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
@@ -64,32 +62,32 @@ public class GameAcceptanceTest extends AcceptanceTest {
 
         // when
         RestAssured.given().log().all()
-            .when()
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .patch("/games/{gameId}/lineup-players/{lineupPlayerId}/starter", gameId, lineupPlayerId)
-            .then().log().all()
-            .extract();
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .patch("/games/{gameId}/lineup-players/{lineupPlayerId}/starter", gameId, lineupPlayerId)
+                .then().log().all()
+                .extract();
 
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-            .when()
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .get("/games/{gameId}/lineup", gameId)
-            .then().log().all()
-            .extract();
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/games/{gameId}/lineup", gameId)
+                .then().log().all()
+                .extract();
 
         // then
         List<LineupPlayerResponse> lineupPlayerResponses = toResponses(response, LineupPlayerResponse.class).stream()
-            .filter(lineupPlayerResponse -> lineupPlayerResponse.gameTeamId().equals(gameTeamId))
-            .toList();
+                .filter(lineupPlayerResponse -> lineupPlayerResponse.gameTeamId().equals(gameTeamId))
+                .toList();
 
         List<LineupPlayerResponse.PlayerResponse> actual = lineupPlayerResponses.get(0).gameTeamPlayers().stream()
-            .filter(playerResponse -> playerResponse.id().equals(lineupPlayerId))
-            .toList();
+                .filter(playerResponse -> playerResponse.id().equals(lineupPlayerId))
+                .toList();
 
         assertAll(
-            () -> assertThat(lineupPlayerResponses.get(0).gameTeamId().equals(gameTeamId)),
-            () -> assertThat(actual.get(0).id().equals(lineupPlayerId)),
-            () -> assertThat(actual.get(0).state().equals(LineupPlayerState.STARTER))
+                () -> assertThat(lineupPlayerResponses.get(0).gameTeamId().equals(gameTeamId)),
+                () -> assertThat(actual.get(0).id().equals(lineupPlayerId)),
+                () -> assertThat(actual.get(0).state().equals(LineupPlayerState.STARTER))
         );
     }
 
@@ -103,32 +101,72 @@ public class GameAcceptanceTest extends AcceptanceTest {
 
         // when
         RestAssured.given().log().all()
-            .when()
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .patch("/games/{gameId}/lineup-players/{lineupPlayerId}/starter", gameId, lineupPlayerId)
-            .then().log().all()
-            .extract();
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .patch("/games/{gameId}/lineup-players/{lineupPlayerId}/starter", gameId, lineupPlayerId)
+                .then().log().all()
+                .extract();
 
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-            .when()
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .get("/games/{gameId}/lineup", gameId)
-            .then().log().all()
-            .extract();
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/games/{gameId}/lineup", gameId)
+                .then().log().all()
+                .extract();
 
         // then
         List<LineupPlayerResponse> lineupPlayerResponses = toResponses(response, LineupPlayerResponse.class).stream()
-            .filter(lineupPlayerResponse -> lineupPlayerResponse.gameTeamId().equals(gameTeamId))
-            .toList();
+                .filter(lineupPlayerResponse -> lineupPlayerResponse.gameTeamId().equals(gameTeamId))
+                .toList();
 
         List<LineupPlayerResponse.PlayerResponse> actual = lineupPlayerResponses.get(0).gameTeamPlayers().stream()
-            .filter(playerResponse -> playerResponse.id().equals(lineupPlayerId))
-            .toList();
+                .filter(playerResponse -> playerResponse.id().equals(lineupPlayerId))
+                .toList();
 
         assertAll(
-            () -> assertThat(lineupPlayerResponses.get(0).gameTeamId().equals(gameTeamId)),
-            () -> assertThat(actual.get(0).id().equals(lineupPlayerId)),
-            () -> assertThat(actual.get(0).state().equals(LineupPlayerState.CANDIDATE))
+                () -> assertThat(lineupPlayerResponses.get(0).gameTeamId().equals(gameTeamId)),
+                () -> assertThat(actual.get(0).id().equals(lineupPlayerId)),
+                () -> assertThat(actual.get(0).state().equals(LineupPlayerState.CANDIDATE))
+        );
+    }
+
+    @Test
+    void 라인업_선수를_주장으로_등록_및_취소한다() throws Exception {
+
+        //given
+        Long gameId = 1L;
+        Long gameTeamId = 1L;
+        Long lineupPlayerId = 2L;
+
+        // when
+        RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(COOKIE_NAME, mockToken)
+                .patch("/games/{gameId}/lineup-players/{lineupPlayerId}/captain", gameId, lineupPlayerId)
+                .then().log().all()
+                .extract();
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/games/{gameId}/lineup", gameId)
+                .then().log().all()
+                .extract();
+
+        // then
+        List<LineupPlayerResponse> lineupPlayerResponses = toResponses(response, LineupPlayerResponse.class).stream()
+                .filter(lineupPlayerResponse -> lineupPlayerResponse.gameTeamId().equals(gameTeamId))
+                .toList();
+
+        List<LineupPlayerResponse.PlayerResponse> actual = lineupPlayerResponses.get(0).gameTeamPlayers().stream()
+                .filter(playerResponse -> playerResponse.id().equals(lineupPlayerId))
+                .toList();
+
+        assertAll(
+                () -> assertThat(lineupPlayerResponses.get(0).gameTeamId().equals(gameTeamId)),
+                () -> assertThat(actual.get(0).id().equals(lineupPlayerId)),
+                () -> assertThat(actual.get(0).isCaptain()).isEqualTo(true)
         );
     }
 }

--- a/src/test/java/com/sports/server/command/game/application/LineupPlayerServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/LineupPlayerServiceTest.java
@@ -1,0 +1,102 @@
+package com.sports.server.command.game.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.sports.server.command.game.domain.LineupPlayer;
+import com.sports.server.common.exception.NotFoundException;
+import com.sports.server.support.ServiceTest;
+import com.sports.server.support.fixture.LineupPlayerFixtureRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql("/game-fixture.sql")
+public class LineupPlayerServiceTest extends ServiceTest {
+
+    @Autowired
+    private LineupPlayerService lineupPlayerService;
+
+    @Autowired
+    private LineupPlayerFixtureRepository lineupPlayerFixtureRepository;
+
+    @Nested
+    @DisplayName("주장과 관련한 상태를 변경할 때")
+    class appointCaptainTest {
+
+        @Test
+        void 게임에_속하지_않는_게임팀에_대해_요청할_경우_예외를_던진다() {
+            // given
+            Long gameId = 1L;
+            Long invalidGameTeamId = 3L;
+            Long lineupPlayerId = 1L;
+
+            // when & then
+            assertThatThrownBy(() -> lineupPlayerService.appointCaptain(gameId, invalidGameTeamId, lineupPlayerId))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("해당 팀은 해당 경기에 속하지 않습니다.");
+        }
+
+        @Test
+        void 게임팀에_속하지_않는_라인업_선수에_대해_요청할_경우_예외를_던진다() {
+            // given
+            Long gameId = 1L;
+            Long gameTeamId = 1L;
+            Long invalidLineupPlayerId = 6L;
+
+            // when & then
+            assertThatThrownBy(() -> lineupPlayerService.appointCaptain(gameId, gameTeamId, invalidLineupPlayerId))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("해당 선수는 해당 팀에 속하지 않습니다.");
+        }
+
+        @Test
+        void 정상적으로_변경된다() {
+            // given
+            Long gameId = 1L;
+            Long gameTeamId = 1L;
+            Long lineupPlayerId = 1L;
+
+            // when
+            lineupPlayerService.appointCaptain(gameId, gameTeamId, lineupPlayerId);
+
+            // then
+            LineupPlayer lineupPlayer = lineupPlayerFixtureRepository.findById(lineupPlayerId)
+                    .orElseThrow(() -> new NotFoundException("존재하지 않는 라인업 선수입니다."));
+            assertThat(lineupPlayer.isCaptain()).isEqualTo(true);
+        }
+
+        @Test
+        void 두명_이상을_등록하지_못한다() {
+            // given
+            Long gameId = 2L;
+            Long gameTeamId = 3L;
+            Long lineupPlayerId = 12L;
+
+            // when & then
+            assertThatThrownBy(() -> lineupPlayerService.appointCaptain(gameId, gameTeamId, lineupPlayerId))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("주장은 두 명 이상 등록할 수 없습니다.");
+        }
+
+        @Test
+        void 이미_주장인_경우에는_주장을_해제한다() {
+            // given
+            Long gameId = 2L;
+            Long gameTeamId = 3L;
+            Long lineupPlayerId = 11L;
+
+            // when
+            lineupPlayerService.appointCaptain(gameId, gameTeamId, lineupPlayerId);
+
+            // then
+            LineupPlayer lineupPlayer = lineupPlayerFixtureRepository.findById(lineupPlayerId)
+                    .orElseThrow(() -> new NotFoundException("존재하지 않는 라인업 선수입니다."));
+            assertThat(lineupPlayer.isCaptain()).isEqualTo(false);
+
+        }
+
+    }
+}

--- a/src/test/java/com/sports/server/command/game/domain/GameTest.java
+++ b/src/test/java/com/sports/server/command/game/domain/GameTest.java
@@ -158,6 +158,8 @@ class GameTest {
         private LineupPlayer team1SecondPlayer;
         private LineupPlayer team2FirstPlayer;
         private LineupPlayer team2SecondPlayer;
+        private GameTeam teamWithoutCaptain;
+        private GameTeam teamWithCaptain;
 
         @BeforeEach
         void setUp() {
@@ -181,13 +183,13 @@ class GameTest {
                     .set("isCaptain", false)
                     .sample();
 
-            GameTeam teamWithCaptain = entityBuilder(GameTeam.class)
+            teamWithCaptain = entityBuilder(GameTeam.class)
                     .set("game", game)
                     .set("score", 0)
                     .set("lineupPlayers", List.of(team1FirstPlayer, team1SecondPlayer))
                     .sample();
 
-            GameTeam teamWithoutCaptain = entityBuilder(GameTeam.class)
+            teamWithoutCaptain = entityBuilder(GameTeam.class)
                     .set("game", game)
                     .set("score", 0)
                     .set("lineupPlayers", List.of(team2FirstPlayer, team2SecondPlayer))
@@ -200,7 +202,7 @@ class GameTest {
         @Test
         void 주장이_없는_팀은_주장_등록을_할_수_있다() {
             // when
-            game.appointCaptain(team2FirstPlayer);
+            game.appointCaptain(teamWithoutCaptain, team2FirstPlayer);
 
             // then
             assertThat(team2FirstPlayer.isCaptain()).isEqualTo(true);
@@ -210,7 +212,7 @@ class GameTest {
         void 주장이_있는_팀은_주장_등록을_할_수_없다() {
             // when & then
             assertThatThrownBy(
-                    () -> game.appointCaptain(team1SecondPlayer))
+                    () -> game.appointCaptain(teamWithCaptain, team1SecondPlayer))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("주장은 두 명 이상 등록할 수 없습니다.");
         }
@@ -218,7 +220,7 @@ class GameTest {
         @Test
         void 주장인_선수는_주장이_아니도록_변경한다() {
             // when
-            game.appointCaptain(team1FirstPlayer);
+            game.appointCaptain(teamWithCaptain, team1FirstPlayer);
 
             // then
             assertThat(team1FirstPlayer.isCaptain()).isEqualTo(false);

--- a/src/test/java/com/sports/server/command/game/domain/GameTest.java
+++ b/src/test/java/com/sports/server/command/game/domain/GameTest.java
@@ -200,7 +200,7 @@ class GameTest {
         @Test
         void 주장이_없는_팀은_주장_등록을_할_수_있다() {
             // when
-            game.changeCaptainStatus(team2FirstPlayer);
+            game.appointCaptain(team2FirstPlayer);
 
             // then
             assertThat(team2FirstPlayer.isCaptain()).isEqualTo(true);
@@ -210,7 +210,7 @@ class GameTest {
         void 주장이_있는_팀은_주장_등록을_할_수_없다() {
             // when & then
             assertThatThrownBy(
-                    () -> game.changeCaptainStatus(team1SecondPlayer))
+                    () -> game.appointCaptain(team1SecondPlayer))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("주장은 두 명 이상 등록할 수 없습니다.");
         }
@@ -218,7 +218,7 @@ class GameTest {
         @Test
         void 주장인_선수는_주장이_아니도록_변경한다() {
             // when
-            game.changeCaptainStatus(team1FirstPlayer);
+            game.appointCaptain(team1FirstPlayer);
 
             // then
             assertThat(team1FirstPlayer.isCaptain()).isEqualTo(false);

--- a/src/test/java/com/sports/server/command/game/domain/GameTest.java
+++ b/src/test/java/com/sports/server/command/game/domain/GameTest.java
@@ -215,6 +215,15 @@ class GameTest {
                     .hasMessage("주장은 두 명 이상 등록할 수 없습니다.");
         }
 
+        @Test
+        void 주장인_선수는_주장이_아니도록_변경한다() {
+            // when
+            game.changeCaptainStatus(team1FirstPlayer);
+
+            // then
+            assertThat(team1FirstPlayer.isCaptain()).isEqualTo(false);
+        }
+
 
     }
 }

--- a/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
+++ b/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
@@ -1,7 +1,8 @@
 package com.sports.server.command.game.presentation;
 
 
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -53,18 +54,18 @@ public class GameControllerTest extends DocumentationTest {
 
         //when
         ResultActions result = mockMvc.perform(
-            patch("/games/{gameId}/lineup-players/{lineupPlayerId}/starter", gameId, lineupPlayerId)
-                .contentType(MediaType.APPLICATION_JSON)
+                patch("/games/{gameId}/lineup-players/{lineupPlayerId}/starter", gameId, lineupPlayerId)
+                        .contentType(MediaType.APPLICATION_JSON)
         );
 
         //then
         result.andExpect((status().isOk()))
-            .andDo(restDocsHandler.document(
-                pathParameters(
-                    parameterWithName("gameId").description("게임의 ID"),
-                    parameterWithName("lineupPlayerId").description("라인업 선수의 ID")
-                )
-            ));
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("gameId").description("게임의 ID"),
+                                parameterWithName("lineupPlayerId").description("라인업 선수의 ID")
+                        )
+                ));
     }
 
     @Test
@@ -76,17 +77,43 @@ public class GameControllerTest extends DocumentationTest {
 
         //when
         ResultActions result = mockMvc.perform(
-            patch("/games/{gameId}/lineup-players/{lineupPlayerId}/candidate", gameId, lineupPlayerId)
-                .contentType(MediaType.APPLICATION_JSON)
+                patch("/games/{gameId}/lineup-players/{lineupPlayerId}/candidate", gameId, lineupPlayerId)
+                        .contentType(MediaType.APPLICATION_JSON)
         );
 
         //then
         result.andExpect((status().isOk()))
-            .andDo(restDocsHandler.document(
-                pathParameters(
-                    parameterWithName("gameId").description("게임의 ID"),
-                    parameterWithName("lineupPlayerId").description("라인업 선수의 ID")
-                )
-            ));
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("gameId").description("게임의 ID"),
+                                parameterWithName("lineupPlayerId").description("라인업 선수의 ID")
+                        )
+                ));
+    }
+
+    @Test
+    void 라인업_선수를_주장으로_등록_및_취소한다() throws Exception {
+
+        //given
+        Long gameId = 1L;
+        Long lineupPlayerId = 1L;
+        Long gameTeamId = 1L;
+
+        //when
+        ResultActions result = mockMvc.perform(
+                patch("/games/{gameId}/{gameTeamId}/lineup-players/{lineupPlayerId}/captain", gameId, gameTeamId,
+                        lineupPlayerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        result.andExpect((status().isOk()))
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("gameId").description("게임의 ID"),
+                                parameterWithName("gameTeamId").description("게임팀의 ID"),
+                                parameterWithName("lineupPlayerId").description("라인업 선수의 ID")
+                        )
+                ));
     }
 }

--- a/src/test/java/com/sports/server/support/fixture/LineupPlayerFixtureRepository.java
+++ b/src/test/java/com/sports/server/support/fixture/LineupPlayerFixtureRepository.java
@@ -1,0 +1,9 @@
+package com.sports.server.support.fixture;
+
+import com.sports.server.command.game.domain.LineupPlayer;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
+
+public interface LineupPlayerFixtureRepository extends Repository<LineupPlayer, Long> {
+    Optional<LineupPlayer> findById(Long id);
+}

--- a/src/test/resources/game-fixture.sql
+++ b/src/test/resources/game-fixture.sql
@@ -90,6 +90,11 @@ VALUES (6, 2, '선수6', '센터', 1, false, 1, 'CANDIDATE'),
        (9, 2, '선수9', '포인트 가드', 4, false, 1, 'STARTER'),
        (10, 2, '선수10', '스몰 포워드', 5, false, 1, 'STARTER');
 
+-- game_id = 2 B팀 선수
+INSERT INTO lineup_players (id, game_team_id, name, description, number, is_captain, league_team_player_id, state)
+VALUES (11, 3, '선수1', '센터', 1, true, 1, 'CANDIDATE'),
+       (12, 3, '선수2', '파워 포워드', 2, false, 2, 'STARTER');
+
 -- 농구 대전 (game_id = 1) A팀 vs B팀
 -- User
 INSERT INTO game_teams (game_id, league_team_id, cheer_count, score)


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #203 

## 📝 구현 내용
- 라인업 주장으로 등록


## 🍀 확인해야 할 부분
### 도메인 테스트
도메인 테스트를 어디서 해야 할지 모르겠어서 진입점인 GameTest 에 추가했는데 적절하다고 생각되는지 궁금합니다!

### 주장 등록 및 취소 한번에
```java
public void changeCaptainStatus(LineupPlayer lineupPlayer) {
        Optional<LineupPlayer> captain = this.lineupPlayers.stream()
                .filter(LineupPlayer::isCaptain)
                .findAny();

        boolean playerExistsInTeam = this.lineupPlayers.stream()
                .anyMatch(lp -> lp.equals(lineupPlayer));

        if (captain.isPresent() && !captain.get().equals(lineupPlayer) && playerExistsInTeam) {
            throw new IllegalStateException("주장은 두 명 이상 등록할 수 없습니다.");
        }

        if (playerExistsInTeam) {
            lineupPlayer.changeCaptainStatus();
        }
    }
```

게임팀에 위와 같이 주장이 존재하고, 요청을 보낸 라인업 선수와는 일치하지 않고 (일치하는 경우에는 주장을 취소하는 요청일 것이기 때문에), 라인업 선수가 해당 팀이라면 예외를 던지도록 했습니다.
이 코드의 가독성을 조금 더 향상할 수 있는 방법이 없을까요?