### PR TITLE
[FEAT] 출전 선수 정보 변경

### DIFF
--- a/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
+++ b/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
@@ -1,29 +1,27 @@
 package com.sports.server.command.game.application;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.common.application.EntityUtils;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class LineupPlayerService {
-	private final EntityUtils entityUtils;
+    private final EntityUtils entityUtils;
 
-	public void changePlayerStateToStarter(final Long gameId, final Long lineupPlayerId) {
-		Game game = entityUtils.getEntity(gameId, Game.class);
-		LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
-		game.registerStarter(lineupPlayer);
-	}
+    public void changePlayerStateToStarter(final Long gameId, final Long lineupPlayerId) {
+        Game game = entityUtils.getEntity(gameId, Game.class);
+        LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
+        game.registerStarter(lineupPlayer);
+    }
 
-	public void changePlayerStateToCandidate(final Long gameId, final Long lineupPlayerId) {
-		Game game = entityUtils.getEntity(gameId, Game.class);
-		LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
-		game.rollbackToCandidate(lineupPlayer);
-	}
+    public void changePlayerStateToCandidate(final Long gameId, final Long lineupPlayerId) {
+        Game game = entityUtils.getEntity(gameId, Game.class);
+        LineupPlayer lineupPlayer = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
+        game.rollbackToCandidate(lineupPlayer);
+    }
 }

--- a/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
+++ b/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
@@ -73,6 +73,14 @@ public class LineupPlayer extends BaseEntity<LineupPlayer> {
         return Objects.equals(this.gameTeam, team);
     }
 
+    public void activatePlayerInGame() {
+        this.isPlaying = true;
+    }
+
+    public void deactivatePlayerInGame() {
+        this.isPlaying = false;
+    }
+
     public LineupPlayer(GameTeam gameTeam, Long leagueTeamPlayerId, String name, int number,
                         boolean isCaptain, LineupPlayerState state) {
         this.gameTeam = gameTeam;

--- a/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
+++ b/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
@@ -48,6 +48,9 @@ public class LineupPlayer extends BaseEntity<LineupPlayer> {
     @Enumerated(EnumType.STRING)
     private LineupPlayerState state;
 
+    @Column(name = "is_playing", nullable = false)
+    private boolean isPlaying;
+
     public void changeStateToStarter() {
         if (this.state == STARTER) {
             throw new CustomException(HttpStatus.BAD_REQUEST, "이미 선발로 등록된 선수입니다.");

--- a/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
+++ b/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
@@ -56,6 +56,7 @@ public class LineupPlayer extends BaseEntity<LineupPlayer> {
             throw new CustomException(HttpStatus.BAD_REQUEST, "이미 선발로 등록된 선수입니다.");
         }
         this.state = STARTER;
+        activatePlayerInGame();
     }
 
     public void changeStateToCandidate() {
@@ -63,6 +64,7 @@ public class LineupPlayer extends BaseEntity<LineupPlayer> {
             throw new CustomException(HttpStatus.BAD_REQUEST, "이미 후보로 등록된 선수입니다.");
         }
         this.state = CANDIDATE;
+        deactivatePlayerInGame();
     }
 
     public boolean isSameTeam(LineupPlayer other) {

--- a/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
@@ -3,7 +3,11 @@ package com.sports.server.command.timeline.domain;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.sport.domain.Quarter;
-import jakarta.persistence.*;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,6 +41,9 @@ public class ReplacementTimeline extends Timeline {
         super(game, recordedQuarter, recordedAt);
 
         validatePlayers(originLineupPlayer, replacedLineupPlayer);
+
+        originLineupPlayer.deactivatePlayerInGame();
+        replacedLineupPlayer.activatePlayerInGame();
 
         this.originLineupPlayer = originLineupPlayer;
         this.replacedLineupPlayer = replacedLineupPlayer;

--- a/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
@@ -57,5 +57,7 @@ public class ReplacementTimeline extends Timeline {
 
     @Override
     public void rollback() {
+        this.originLineupPlayer.activatePlayerInGame();
+        this.replacedLineupPlayer.deactivatePlayerInGame();
     }
 }

--- a/src/main/resources/db/migration/V17__update-lineup-players.sql
+++ b/src/main/resources/db/migration/V17__update-lineup-players.sql
@@ -1,0 +1,11 @@
+-- 1. is_playing 컬럼을 추가하고 기본값을 TRUE 로 설정
+ALTER TABLE lineup_players
+    ADD COLUMN is_playing BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- 2. 기존 레코드의 is_playing 값을 TRUE 로 설정
+UPDATE lineup_players
+SET is_playing = TRUE;
+
+-- 3 기본값을 FALSE 로 변경
+ALTER TABLE lineup_players
+    ALTER COLUMN is_playing SET DEFAULT FALSE;

--- a/src/test/java/com/sports/server/command/timeline/TimelineFixtureRepository.java
+++ b/src/test/java/com/sports/server/command/timeline/TimelineFixtureRepository.java
@@ -1,10 +1,10 @@
 package com.sports.server.command.timeline;
 
+import com.sports.server.command.timeline.domain.ReplacementTimeline;
 import com.sports.server.command.timeline.domain.Timeline;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface TimelineFixtureRepository extends JpaRepository<Timeline, Long> {
     @Query("""
@@ -14,4 +14,14 @@ public interface TimelineFixtureRepository extends JpaRepository<Timeline, Long>
                 ORDER BY t.id DESC
             """)
     List<Timeline> findAllLatest(Long gameId);
+
+    @Query("""
+                SELECT rt 
+                FROM ReplacementTimeline rt
+                LEFT JOIN FETCH rt.originLineupPlayer olp
+                LEFT JOIN FETCH rt.replacedLineupPlayer rlp
+                WHERE rt.game.id = :gameId
+                ORDER BY rt.id DESC
+            """)
+    List<ReplacementTimeline> findReplacementTimelineWithLineupPlayers(Long gameId);
 }

--- a/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
@@ -97,10 +97,10 @@ class TimelineServiceTest extends ServiceTest {
 
             assertAll(
                     () -> assertThat(actual.getScorer().getId()).isEqualTo(team2PlayerId),
-                    () -> assertThat(actual.getSnapshotScore1()).isEqualTo(16),
-                    () -> assertThat(actual.getSnapshotScore2()).isEqualTo(10),
+                    () -> assertThat(actual.getSnapshotScore1()).isEqualTo(15),
+                    () -> assertThat(actual.getSnapshotScore2()).isEqualTo(11),
                     () -> assertThat(actual.getRecordedQuarter().getId()).isEqualTo(quarterId),
-                    () -> assertThat(actual.getRecordedAt()).isEqualTo(3)
+                    () -> assertThat(actual.getRecordedAt()).isEqualTo(5)
             );
         }
     }

--- a/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
@@ -1,11 +1,15 @@
 package com.sports.server.command.timeline.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.member.domain.MemberRepository;
-import com.sports.server.command.timeline.dto.TimelineRequest;
 import com.sports.server.command.timeline.TimelineFixtureRepository;
 import com.sports.server.command.timeline.domain.ReplacementTimeline;
 import com.sports.server.command.timeline.domain.ScoreTimeline;
+import com.sports.server.command.timeline.dto.TimelineRequest;
 import com.sports.server.common.exception.CustomException;
 import com.sports.server.support.ServiceTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,9 +20,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @Sql(scripts = "/timeline-fixture.sql")
 class TimelineServiceTest extends ServiceTest {
@@ -64,13 +65,14 @@ class TimelineServiceTest extends ServiceTest {
             ScoreTimeline actual = (ScoreTimeline) timelineFixtureRepository.findAllLatest(gameId)
                     .get(0);
 
-            assertThat(actual.getScorer().getId()).isEqualTo(team1PlayerId);
+            assertAll(
+                    () -> assertThat(actual.getScorer().getId()).isEqualTo(team1PlayerId),
+                    () -> assertThat(actual.getSnapshotScore1()).isEqualTo(16),
+                    () -> assertThat(actual.getSnapshotScore2()).isEqualTo(10),
+                    () -> assertThat(actual.getRecordedQuarter().getId()).isEqualTo(quarterId),
+                    () -> assertThat(actual.getRecordedAt()).isEqualTo(3)
+            );
 
-            assertThat(actual.getSnapshotScore1()).isEqualTo(16);
-            assertThat(actual.getSnapshotScore2()).isEqualTo(10);
-
-            assertThat(actual.getRecordedQuarter().getId()).isEqualTo(quarterId);
-            assertThat(actual.getRecordedAt()).isEqualTo(3);
         }
 
         @Test
@@ -93,13 +95,13 @@ class TimelineServiceTest extends ServiceTest {
             ScoreTimeline actual = (ScoreTimeline) timelineFixtureRepository.findAllLatest(gameId)
                     .get(0);
 
-            assertThat(actual.getScorer().getId()).isEqualTo(team2PlayerId);
-
-            assertThat(actual.getSnapshotScore1()).isEqualTo(15);
-            assertThat(actual.getSnapshotScore2()).isEqualTo(11);
-
-            assertThat(actual.getRecordedQuarter().getId()).isEqualTo(quarterId);
-            assertThat(actual.getRecordedAt()).isEqualTo(5);
+            assertAll(
+                    () -> assertThat(actual.getScorer().getId()).isEqualTo(team2PlayerId),
+                    () -> assertThat(actual.getSnapshotScore1()).isEqualTo(16),
+                    () -> assertThat(actual.getSnapshotScore2()).isEqualTo(10),
+                    () -> assertThat(actual.getRecordedQuarter().getId()).isEqualTo(quarterId),
+                    () -> assertThat(actual.getRecordedAt()).isEqualTo(3)
+            );
         }
     }
 
@@ -130,15 +132,17 @@ class TimelineServiceTest extends ServiceTest {
             timelineService.register(manager, gameId, request);
 
             // then
-            ReplacementTimeline actual =
-                    (ReplacementTimeline) timelineFixtureRepository.findAllLatest(gameId)
-                            .get(0);
+            ReplacementTimeline actual = timelineFixtureRepository.findReplacementTimelineWithLineupPlayers(gameId)
+                    .get(0);
 
-            assertThat(actual.getOriginLineupPlayer().getId()).isEqualTo(team1OriginPlayerId);
-            assertThat(actual.getReplacedLineupPlayer().getId()).isEqualTo(team1ReplacedPlayerId);
-
-            assertThat(actual.getRecordedQuarter().getId()).isEqualTo(quarterId);
-            assertThat(actual.getRecordedAt()).isEqualTo(3);
+            assertAll(
+                    () -> assertThat(actual.getOriginLineupPlayer().getId()).isEqualTo(team1OriginPlayerId),
+                    () -> assertThat(actual.getReplacedLineupPlayer().getId()).isEqualTo(team1ReplacedPlayerId),
+                    () -> assertThat(actual.getRecordedQuarter().getId()).isEqualTo(quarterId),
+                    () -> assertThat(actual.getRecordedAt()).isEqualTo(3),
+                    () -> assertThat(actual.getOriginLineupPlayer().isPlaying()).isEqualTo(false),
+                    () -> assertThat(actual.getReplacedLineupPlayer().isPlaying()).isEqualTo(true)
+            );
         }
 
         @Test
@@ -156,15 +160,17 @@ class TimelineServiceTest extends ServiceTest {
             timelineService.register(manager, gameId, request);
 
             // then
-            ReplacementTimeline actual =
-                    (ReplacementTimeline) timelineFixtureRepository.findAllLatest(gameId)
-                            .get(0);
+            ReplacementTimeline actual = timelineFixtureRepository.findReplacementTimelineWithLineupPlayers(gameId)
+                    .get(0);
 
-            assertThat(actual.getOriginLineupPlayer().getId()).isEqualTo(team2OriginPlayerId);
-            assertThat(actual.getReplacedLineupPlayer().getId()).isEqualTo(team2ReplacedPlayerId);
-
-            assertThat(actual.getRecordedQuarter().getId()).isEqualTo(quarterId);
-            assertThat(actual.getRecordedAt()).isEqualTo(3);
+            assertAll(
+                    () -> assertThat(actual.getOriginLineupPlayer().getId()).isEqualTo(team2OriginPlayerId),
+                    () -> assertThat(actual.getReplacedLineupPlayer().getId()).isEqualTo(team2ReplacedPlayerId),
+                    () -> assertThat(actual.getRecordedQuarter().getId()).isEqualTo(quarterId),
+                    () -> assertThat(actual.getRecordedAt()).isEqualTo(3),
+                    () -> assertThat(actual.getOriginLineupPlayer().isPlaying()).isEqualTo(false),
+                    () -> assertThat(actual.getReplacedLineupPlayer().isPlaying()).isEqualTo(true)
+            );
         }
 
         @Test

--- a/src/test/resources/game-fixture.sql
+++ b/src/test/resources/game-fixture.sql
@@ -91,21 +91,23 @@ VALUES (1, '농구'),
        (3, '축구');
 
 -- 농구 대전(game_id = 1) A팀 선수
-INSERT INTO lineup_players (id, game_team_id, name, description, number, is_captain, league_team_player_id, state)
-VALUES (1, 1, '선수1', '센터', 1, false, 1, 'CANDIDATE'),
-       (2, 1, '선수2', '파워 포워드', 2, false, 2, 'STARTER'),
-       (3, 1, '선수3', '슈팅 가드', 3, false, 3, 'STARTER'),
-       (4, 1, '선수4', '포인트 가드', 4, false, 4, 'STARTER'),
-       (5, 1, '선수5', '스몰 포워드', 5, false, 5, 'STARTER');
+INSERT INTO lineup_players (id, game_team_id, name, description, number, is_captain, league_team_player_id, state,
+                            is_playing)
+VALUES (1, 1, '선수1', '센터', 1, false, 1, 'CANDIDATE', false),
+       (2, 1, '선수2', '파워 포워드', 2, false, 2, 'STARTER', false),
+       (3, 1, '선수3', '슈팅 가드', 3, false, 3, 'STARTER', false),
+       (4, 1, '선수4', '포인트 가드', 4, false, 4, 'STARTER', false),
+       (5, 1, '선수5', '스몰 포워드', 5, false, 5, 'STARTER', false);
 
 
 -- 농구 대전(game_id = 1) B팀 선수
-INSERT INTO lineup_players (id, game_team_id, name, description, number, is_captain, league_team_player_id, state)
-VALUES (6, 2, '선수6', '센터', 1, false, 1, 'CANDIDATE'),
-       (7, 2, '선수7', '파워 포워드', 2, false, 1, 'STARTER'),
-       (8, 2, '선수8', '슈팅 가드', 3, false, 1, 'STARTER'),
-       (9, 2, '선수9', '포인트 가드', 4, false, 1, 'STARTER'),
-       (10, 2, '선수10', '스몰 포워드', 5, false, 1, 'STARTER');
+INSERT INTO lineup_players (id, game_team_id, name, description, number, is_captain, league_team_player_id, state,
+                            is_playing)
+VALUES (6, 2, '선수6', '센터', 1, false, 1, 'CANDIDATE', false),
+       (7, 2, '선수7', '파워 포워드', 2, false, 1, 'STARTER', false),
+       (8, 2, '선수8', '슈팅 가드', 3, false, 1, 'STARTER', false),
+       (9, 2, '선수9', '포인트 가드', 4, false, 1, 'STARTER', false),
+       (10, 2, '선수10', '스몰 포워드', 5, false, 1, 'STARTER', false);
 
 -- 농구 대전 (game_id = 1) A팀 vs B팀
 -- User

--- a/src/test/resources/timeline-fixture.sql
+++ b/src/test/resources/timeline-fixture.sql
@@ -32,20 +32,20 @@ VALUES (1, 1, 1, 15), -- 팀 A의 정보
 -- 팀 B의 정보
 
 -- 농구 대전(game_id = 1) A팀(game_team_id = 1) 선수
-INSERT INTO lineup_players (id, game_team_id, name, description, is_captain, number, league_team_player_id)
-VALUES (1, 1, '선수1', '센터', true, 1, 1),
-       (2, 1, '선수2', '파워 포워드', false, 2, 1),
-       (3, 1, '선수3', '슈팅 가드', false, 3, 1),
-       (4, 1, '선수4', '포인트 가드', false, 4, 1),
-       (5, 1, '선수5', '스몰 포워드', false, 5, 1);
+INSERT INTO lineup_players (id, game_team_id, name, description, is_captain, number, league_team_player_id, is_playing)
+VALUES (1, 1, '선수1', '센터', true, 1, 1, false),
+       (2, 1, '선수2', '파워 포워드', false, 2, 1, false),
+       (3, 1, '선수3', '슈팅 가드', false, 3, 1, false),
+       (4, 1, '선수4', '포인트 가드', false, 4, 1, false),
+       (5, 1, '선수5', '스몰 포워드', false, 5, 1, false);
 
 -- 농구 대전(game_id = 1) B팀(game_team_id = 2) 선수
-INSERT INTO lineup_players (id, game_team_id, name, description, is_captain, number, league_team_player_id)
-VALUES (6, 2, '선수6', '센터', true, 6, 1),
-       (7, 2, '선수7', '파워 포워드', false, 7, 1),
-       (8, 2, '선수8', '슈팅 가드', false, 8, 1),
-       (9, 2, '선수9', '포인트 가드', false, 9, 1),
-       (10, 2, '선수10', '스몰 포워드', false, 10, 1);
+INSERT INTO lineup_players (id, game_team_id, name, description, is_captain, number, league_team_player_id, is_playing)
+VALUES (6, 2, '선수6', '센터', true, 6, 1, false),
+       (7, 2, '선수7', '파워 포워드', false, 7, 1, false),
+       (8, 2, '선수8', '슈팅 가드', false, 8, 1, false),
+       (9, 2, '선수9', '포인트 가드', false, 9, 1, false),
+       (10, 2, '선수10', '스몰 포워드', false, 10, 1, false);
 
 -- 1쿼터 경기 기록 추가
 


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #212 

## 📝 구현 내용
- 출전 정보를 의미하는 is_playing 필드 추가
   - 기존에 데이터베이스에 있던 값들은 모두 true로
      - 이유 : 기존에는 출전 / 선발 / 후보를 구분하지 않고 뛰고 있는 사람만 라인업에 올렸기 때문에
   - 기본값은 false 로 생성되도록
- 교체 타임라인 등록 시 선수의 출전 정보 변경
- 선발 / 후보 변경 시에 선수의 출전 정보 변경

## 🍀 확인해야 할 부분
### 이전 데이터 관련
기존에는 출전 / 선발 / 후보를 구분하지 않고 뛰고 있는 사람만 라인업에 올렸기 때문에 기존 데이터베이스에 있던 라인업 선수들은 모두 is_playing 을 true 로 갖게 하도록 했는데 어떻게 생각하시는지?
### 선발 / 후보 변경 시에 선수의 출전 정보 변경
슬랙에 코멘트 남긴 것처럼 선수의 출전 정보를 저장하는 시점이 두개가 있다고 생각했어

1-1. 라인업 선수가 선발이 될 때마다 isPlaying 을  true 로 바꾸고 후보가 될 때마다 false 로 바꾼다. 그리고 교체 타임라인에서 선발이었던 선수가 나갈 때마다 false 로 바꾼다.
1-2. 게임이 시작하는 시점에 (게임 시작 상태변경 타임라인이 등록되는 경우) 라인업 선수 중 선발인 선수는 모두 isPlaying 을 true 로 바꾼다. 그리고 교체 타임라인에서 선발이었던 선수가 나갈 때마다 false 로 바꾼다.

이 pr 에서는 1-1 로 구현하기는 했어. 왜냐하면 1-2 의 경우에는 상태변경 타임라인이 등록되고 만약 롤백되는 상황이 일어나게 되면 변경 지점이 너무 많아져서 복잡해지지 않을까? 하는 생각이 들었어.
게임 시작 전까지는 사실상 출전 == 선발이니까 괜찮지 않을까? 하는 생각이었어
이거에 대해 어떻게 생각하는지 궁금해.

### 라인업 선발/후보 변경 시점 관련
슬랙에서 라인업 정보를 변경하는 데에 제한을 둬야 하지 않겠냐고 이야기했던 것도 같은 맥락인데,
경기 시작 이후에 선수의 선발/후보 정보를 변경하게 되면 선발 != 출전이 아니게 되니까 라인업을 더 이상 건드리면 안되지 않을까? 하는 생각이 들었어. 그런데 이렇게 되면 만약 주장이 교체되어 나간다면.. 주장 변경을 못하게 되네

😵‍💫 다른 사람들의 의견이 필요한 것 같아