### PR TITLE
[FEAT] 경기 시작 대신 전반전 시작을 사용하도록 수정

### DIFF
--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
 public class Game extends BaseEntity<Game> implements ManagedEntity {
 
     private static final String NAME_OF_PK_QUARTER = "승부차기";
+    private static final String NAME_OF_FIRST_HALF_QUARTER = "전반전";
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sport_id")
@@ -215,6 +216,10 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
 
     public void updateQuarter(Quarter quarter) {
         this.gameQuarter = quarter.getName();
+
+        if (gameQuarter.equals(NAME_OF_FIRST_HALF_QUARTER)) {
+            this.state = GameState.PLAYING;
+        }
 
         if (gameQuarter.equals(NAME_OF_PK_QUARTER)) {
             startPk();

--- a/src/main/java/com/sports/server/command/timeline/domain/GameProgressTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/GameProgressTimeline.java
@@ -24,6 +24,8 @@ import org.springframework.http.HttpStatus;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GameProgressTimeline extends Timeline {
 
+    private static final String NAME_OF_BEFORE_GAME_QUARTER = "경기전";
+
     @Enumerated(EnumType.STRING)
     @Column(name = "game_progress_type")
     private GameProgressType gameProgressType;
@@ -75,7 +77,8 @@ public class GameProgressTimeline extends Timeline {
     public void rollback() {
         game.updateQuarter(previousQuarter, previousQuarterChangedAt);
 
-        if (gameProgressType == GameProgressTypeGM.GAME_START) {
+        if (gameProgressType == GameProgressType.QUARTER_START && previousQuarter.getName()
+                .equals(NAME_OF_BEFORE_GAME_QUARTER)) {
             game.updateState(GameState.SCHEDULED);
         }
 

--- a/src/main/java/com/sports/server/command/timeline/domain/GameProgressTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/GameProgressTimeline.java
@@ -61,9 +61,6 @@ public class GameProgressTimeline extends Timeline {
 
     @Override
     public void apply() {
-        if (gameProgressType == GameProgressType.GAME_START) {
-            game.play();
-        }
 
         if (gameProgressType == GameProgressType.QUARTER_START) {
             game.updateQuarter(recordedQuarter);
@@ -78,7 +75,7 @@ public class GameProgressTimeline extends Timeline {
     public void rollback() {
         game.updateQuarter(previousQuarter, previousQuarterChangedAt);
 
-        if (gameProgressType == GameProgressType.GAME_START) {
+        if (gameProgressType == GameProgressTypeGM.GAME_START) {
             game.updateState(GameState.SCHEDULED);
         }
 

--- a/src/main/java/com/sports/server/command/timeline/domain/GameProgressType.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/GameProgressType.java
@@ -3,6 +3,5 @@ package com.sports.server.command.timeline.domain;
 public enum GameProgressType {
     QUARTER_START,
     QUARTER_END,
-    GAME_START,
     GAME_END
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/PKTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/PKTimeline.java
@@ -3,6 +3,7 @@ package com.sports.server.command.timeline.domain;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.sport.domain.Quarter;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class PKTimeline extends Timeline {
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "scorer_id")
     private LineupPlayer scorer;
 

--- a/src/main/java/com/sports/server/command/timeline/domain/PKTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/PKTimeline.java
@@ -3,7 +3,6 @@ package com.sports.server.command.timeline.domain;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.sport.domain.Quarter;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
@@ -13,6 +12,8 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,7 +21,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class PKTimeline extends Timeline {
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "scorer_id")
     private LineupPlayer scorer;
 

--- a/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
@@ -3,7 +3,6 @@ package com.sports.server.command.timeline.domain;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.sport.domain.Quarter;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,6 +11,8 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @DiscriminatorValue("REPLACEMENT")
@@ -19,11 +20,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReplacementTimeline extends Timeline {
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "origin_lineup_player_id")
     private LineupPlayer originLineupPlayer;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "replaced_lineup_player_id")
     private LineupPlayer replacedLineupPlayer;
 

--- a/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
@@ -3,6 +3,7 @@ package com.sports.server.command.timeline.domain;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.sport.domain.Quarter;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,11 +19,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReplacementTimeline extends Timeline {
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "origin_lineup_player_id")
     private LineupPlayer originLineupPlayer;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "replaced_lineup_player_id")
     private LineupPlayer replacedLineupPlayer;
 

--- a/src/main/java/com/sports/server/command/timeline/domain/ScoreTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ScoreTimeline.java
@@ -4,7 +4,13 @@ import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.sport.domain.Quarter;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,21 +22,21 @@ public class ScoreTimeline extends Timeline {
 
     private static final int SCORE_VALUE = 1;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "scorer_id")
     private LineupPlayer scorer;
 
     @Column(name = "score")
     private Integer score;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "game_team1_id")
     private GameTeam gameTeam1;
 
     @Column(name = "snapshot_score1")
     private Integer snapshotScore1;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "game_team2_id")
     private GameTeam gameTeam2;
 

--- a/src/main/java/com/sports/server/command/timeline/domain/ScoreTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ScoreTimeline.java
@@ -13,6 +13,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @DiscriminatorValue("SCORE")
@@ -22,14 +24,15 @@ public class ScoreTimeline extends Timeline {
 
     private static final int SCORE_VALUE = 1;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "scorer_id")
     private LineupPlayer scorer;
 
     @Column(name = "score")
     private Integer score;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "game_team1_id")
     private GameTeam gameTeam1;
 

--- a/src/main/java/com/sports/server/command/timeline/domain/ScoreTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ScoreTimeline.java
@@ -4,7 +4,6 @@ import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.sport.domain.Quarter;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
@@ -39,7 +38,8 @@ public class ScoreTimeline extends Timeline {
     @Column(name = "snapshot_score1")
     private Integer snapshotScore1;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "game_team2_id")
     private GameTeam gameTeam2;
 

--- a/src/main/java/com/sports/server/command/timeline/domain/Timeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/Timeline.java
@@ -3,10 +3,21 @@ package com.sports.server.command.timeline.domain;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.sport.domain.Quarter;
 import com.sports.server.common.domain.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -17,6 +28,7 @@ import lombok.NoArgsConstructor;
 public abstract class Timeline extends BaseEntity<Timeline> {
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "game_id", nullable = false)
     protected Game game;
 

--- a/src/test/java/com/sports/server/command/timeline/domain/GameProgressTimelineTest.java
+++ b/src/test/java/com/sports/server/command/timeline/domain/GameProgressTimelineTest.java
@@ -74,25 +74,9 @@ class GameProgressTimelineTest {
 
     @Nested
     class ApplyTest {
-        @Test
-        void 경기_시작_타임라인을_생성한다() {
-            // when
-            GameProgressTimeline timeline = 경기_시작_타임라인_생성(game);
-
-            timeline.apply();
-
-            // then
-            assertAll(
-                    () -> assertThat(game.getGameQuarter()).isEqualTo(전반전.getName()),
-                    () -> assertThat(game.getState()).isEqualTo(GameState.PLAYING)
-            );
-        }
 
         @Test
         void 전반전_시작_타임라인을_생성한다() {
-            // given
-            경기_시작_타임라인_생성(game).apply();
-
             // when
             GameProgressTimeline timeline = 전반전_시작_타임라인_생성(game);
 
@@ -108,7 +92,6 @@ class GameProgressTimelineTest {
         @Test
         void 전반전_종료_타임라인을_생성한다() {
             // given
-            경기_시작_타임라인_생성(game).apply();
             전반전_시작_타임라인_생성(game).apply();
 
             // when
@@ -126,7 +109,6 @@ class GameProgressTimelineTest {
         @Test
         void 후반전_시작_타임라인을_생성한다() {
             // given
-            경기_시작_타임라인_생성(game).apply();
             전반전_시작_타임라인_생성(game).apply();
             전반전_종료_타임라인_생성(game).apply();
 
@@ -145,7 +127,6 @@ class GameProgressTimelineTest {
         @Test
         void 후반전_종료_타임라인을_생성한다() {
             // given
-            경기_시작_타임라인_생성(game).apply();
             전반전_시작_타임라인_생성(game).apply();
             전반전_종료_타임라인_생성(game).apply();
             후반전_시작_타임라인_생성(game).apply();
@@ -165,7 +146,6 @@ class GameProgressTimelineTest {
         @Test
         void 경기_종료_타임라인을_생성한다() {
             // given
-            경기_시작_타임라인_생성(game).apply();
             전반전_시작_타임라인_생성(game).apply();
             전반전_종료_타임라인_생성(game).apply();
             후반전_시작_타임라인_생성(game).apply();
@@ -212,11 +192,11 @@ class GameProgressTimelineTest {
 
     @Nested
     class RollbackTest {
-        @Test
-        void 경기_시작_타임라인을_롤백한다() {
-            // given
-            GameProgressTimeline timeline = 경기_시작_타임라인_생성(GameProgressTimelineTest.this.game);
 
+        @Test
+        void 전반전_시작_타임라인을_롤백한다() {
+            // given
+            GameProgressTimeline timeline = 전반전_시작_타임라인_생성(game);
             timeline.apply();
 
             // when
@@ -230,27 +210,8 @@ class GameProgressTimelineTest {
         }
 
         @Test
-        void 전반전_시작_타임라인을_롤백한다() {
-            // given
-            경기_시작_타임라인_생성(game).apply();
-
-            GameProgressTimeline timeline = 전반전_시작_타임라인_생성(game);
-            timeline.apply();
-
-            // when
-            timeline.rollback();
-
-            // then
-            assertAll(
-                    () -> assertThat(game.getGameQuarter()).isEqualTo(전반전.getName()),
-                    () -> assertThat(game.getState()).isEqualTo(GameState.PLAYING)
-            );
-        }
-
-        @Test
         void 전반전_종료_타임라인을_롤백한다() {
             // given
-            경기_시작_타임라인_생성(game).apply();
             전반전_시작_타임라인_생성(game).apply();
 
             GameProgressTimeline timeline = 전반전_종료_타임라인_생성(game);
@@ -270,7 +231,6 @@ class GameProgressTimelineTest {
         @Test
         void 후반전_시작_타임라인을_롤백한다() {
             // given
-            경기_시작_타임라인_생성(game).apply();
             전반전_시작_타임라인_생성(game).apply();
             전반전_종료_타임라인_생성(game).apply();
 
@@ -303,7 +263,6 @@ class GameProgressTimelineTest {
         @Test
         void 경기_종료_타임라인을_롤백한다() {
             // given
-            경기_시작_타임라인_생성(game).apply();
             전반전_시작_타임라인_생성(game).apply();
             전반전_종료_타임라인_생성(game).apply();
             후반전_시작_타임라인_생성(game).apply();
@@ -330,15 +289,6 @@ class GameProgressTimelineTest {
                 전반전,
                 0,
                 GameProgressType.QUARTER_START
-        );
-    }
-
-    private GameProgressTimeline 경기_시작_타임라인_생성(Game game) {
-        return new GameProgressTimeline(
-                game,
-                경기전,
-                0,
-                GameProgressType.GAME_START
         );
     }
 

--- a/src/test/java/com/sports/server/query/acceptance/TimelineQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/TimelineQueryAcceptanceTest.java
@@ -148,7 +148,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                         null,
                                         null,
                                         null,
-                                        new ProgressRecordResponse(GameProgressType.GAME_START), null
+                                        new ProgressRecordResponse(GameProgressType.QUARTER_START), null
                                 )
                         ))
                 ))

--- a/src/test/resources/timeline-fixture.sql
+++ b/src/test/resources/timeline-fixture.sql
@@ -56,7 +56,7 @@ INSERT INTO timelines(type,
                       previous_quarter_id,
                       recorded_at,
                       game_progress_type)
-VALUES ('GAME_PROGRESS', 1, 1, 1, 0, 'GAME_START');
+VALUES ('GAME_PROGRESS', 1, 1, 1, 0, 'QUARTER_START');
 
 -- A팀 선수 2의 2득점
 INSERT INTO timelines (type,


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #269 

## 📝 구현 내용
- progressType 에서 GAME_START 삭제
- 전반전 시작이 같은 기능을 하도록 수정

## 🍀 확인해야 할 부분
1. 전반전 시작 등록 시
- 경기 시작을 등록한 것과 같이 state 가 PLAYING 으로 업데이트

2. 전반전 시작 삭제 시
- 삭제하고자 하는 타임라인의 progressType 이 QUARTER_START 고 previous quarter 가 '시작전' 인 경우 state 를 SCHEDULED 로 업데이트

위 로직 맞는지 크로스 체크 부탁드려요!