### PR TITLE
[FEAT] 경기 종료 이후 새로운 타임라인 등록 막기

### DIFF
--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -250,7 +250,7 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
                 .orElseThrow(() -> new IllegalArgumentException("해당 쿼터가 존재하지 않습니다."));
     }
 
-    public void checkFinished() {
+    public void checkStateForTimeline() {
         if (this.getState().equals(GameState.FINISHED)) {
             throw new CustomException(HttpStatus.BAD_REQUEST, GAME_ALREADY_FINISHED);
         }

--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -28,6 +28,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 
+import static com.sports.server.command.timeline.exception.TimelineErrorMessage.GAME_ALREADY_FINISHED;
+
 @Entity
 @Getter
 @Table(name = "games")
@@ -246,6 +248,12 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
                 .filter(quarter -> quarter.getName().equals(gameQuarter))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("해당 쿼터가 존재하지 않습니다."));
+    }
+
+    public void checkFinished() {
+        if (this.getState().equals(GameState.FINISHED)) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, GAME_ALREADY_FINISHED);
+        }
     }
 
     @Override

--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -28,7 +28,7 @@ public class TimelineService {
 
     public void register(Member manager, Long gameId, TimelineRequest request) {
         Game game = entityUtils.getEntity(gameId, Game.class);
-        game.checkFinished();
+        game.checkStateForTimeline();
         PermissionValidator.checkPermission(game, manager);
 
         Timeline timeline = timelineMapper.toEntity(game, request);

--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -28,9 +28,7 @@ public class TimelineService {
 
     public void register(Member manager, Long gameId, TimelineRequest request) {
         Game game = entityUtils.getEntity(gameId, Game.class);
-        if (game.getState().equals(GameState.FINISHED)) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, GAME_ALREADY_FINISHED);
-        }
+        game.checkFinished();
         PermissionValidator.checkPermission(game, manager);
 
         Timeline timeline = timelineMapper.toEntity(game, request);

--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -1,10 +1,12 @@
 package com.sports.server.command.timeline.application;
 
 import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.GameState;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.timeline.domain.Timeline;
 import com.sports.server.command.timeline.domain.TimelineRepository;
 import com.sports.server.command.timeline.dto.TimelineRequest;
+import com.sports.server.command.timeline.exception.TimelineErrorMessage;
 import com.sports.server.command.timeline.mapper.TimelineMapper;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.application.PermissionValidator;
@@ -13,6 +15,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+
+import static com.sports.server.command.timeline.exception.TimelineErrorMessage.GAME_ALREADY_FINISHED;
 
 @Service
 @Transactional
@@ -24,11 +28,13 @@ public class TimelineService {
 
     public void register(Member manager, Long gameId, TimelineRequest request) {
         Game game = entityUtils.getEntity(gameId, Game.class);
+        if (game.getState().equals(GameState.FINISHED)) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, GAME_ALREADY_FINISHED);
+        }
         PermissionValidator.checkPermission(game, manager);
 
         Timeline timeline = timelineMapper.toEntity(game, request);
         timeline.apply();
-
         timelineRepository.save(timeline);
     }
 

--- a/src/main/java/com/sports/server/command/timeline/exception/TimelineErrorMessage.java
+++ b/src/main/java/com/sports/server/command/timeline/exception/TimelineErrorMessage.java
@@ -1,0 +1,11 @@
+package com.sports.server.command.timeline.exception;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TimelineErrorMessage {
+
+    public static final String GAME_ALREADY_FINISHED = "종료된 게임에 새로운 타임라인을 등록할 수 없습니다.";
+
+}

--- a/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
@@ -294,4 +294,23 @@ class TimelineServiceTest extends ServiceTest {
                     .isInstanceOf(CustomException.class);
         }
     }
+
+    @Test
+    void 경기_종료_후_타임라인을_등록하려고_하면_에러가_발생한다() {
+        // given
+        Long team1Id = 1L;
+        Long team1PlayerId = 1L;
+        Long finishedGameId = 2L;
+
+        TimelineRequest.RegisterScore request = new TimelineRequest.RegisterScore(
+                team1Id,
+                quarterId,
+                team1PlayerId,
+                3
+        );
+
+        // when & then
+        assertThatThrownBy(() -> timelineService.register(manager, finishedGameId, request))
+                .isInstanceOf(CustomException.class);
+    }
 }

--- a/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
@@ -14,6 +14,7 @@ import com.sports.server.command.timeline.domain.ReplacementTimeline;
 import com.sports.server.command.timeline.domain.ScoreTimeline;
 import com.sports.server.command.timeline.domain.Timeline;
 import com.sports.server.command.timeline.dto.TimelineRequest;
+import com.sports.server.command.timeline.exception.TimelineErrorMessage;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.exception.CustomException;
 import com.sports.server.common.exception.UnauthorizedException;
@@ -312,6 +313,6 @@ class TimelineServiceTest extends ServiceTest {
         // when & then
         assertThatThrownBy(() -> timelineService.register(manager, finishedGameId, request))
                 .isInstanceOf(CustomException.class)
-                .hasMessage("종료된 게임에 새로운 타임라인을 등록할 수 없습니다.");
+                .hasMessage(TimelineErrorMessage.GAME_ALREADY_FINISHED);
     }
 }

--- a/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
@@ -311,6 +311,7 @@ class TimelineServiceTest extends ServiceTest {
 
         // when & then
         assertThatThrownBy(() -> timelineService.register(manager, finishedGameId, request))
-                .isInstanceOf(CustomException.class);
+                .isInstanceOf(CustomException.class)
+                .hasMessage("종료된 게임에 새로운 타임라인을 등록할 수 없습니다.");
     }
 }

--- a/src/test/resources/timeline-fixture.sql
+++ b/src/test/resources/timeline-fixture.sql
@@ -18,7 +18,8 @@ VALUES (1, '1쿼터', 1),
 -- 경기
 INSERT INTO games (id, sport_id, manager_id, league_id, name, start_time, video_id, quarter_changed_at,
                    game_quarter, state, round)
-VALUES (1, 1, 1, 1, '농구 대전', '2023-11-12T10:00:00', 'abc123', '2023-11-12T10:15:00', '3쿼터', 'PLAYING', '4강');
+VALUES (1, 1, 1, 1, '농구 대전', '2023-11-12T10:00:00', 'abc123', '2023-11-12T10:15:00', '3쿼터', 'PLAYING', '4강'),
+       (2, 1, 1, 1, '농구 대전', '2023-11-12T10:00:00', 'abc123', '2023-11-12T10:15:00', '3쿼터', 'FINISHED', '4강');
 
 -- 팀
 INSERT INTO league_teams (name, logo_image_url, manager_id, organization_id, league_id)


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #271 

## 📝 구현 내용
- Game의 state가 FINISHED일 때 새로운 타임라인 등록 시도 시 에러 발생

## 🍀 확인해야 할 부분
