### PR TITLE
[FEAT 리그의 maxRound 보다 등록하고자 하는 경기의 round 가 더 크면 등록하지 못하도록 막는다

### DIFF
--- a/src/main/java/com/sports/server/command/game/application/GameService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameService.java
@@ -1,6 +1,5 @@
 package com.sports.server.command.game.application;
 
-import com.sports.server.auth.exception.AuthorizationErrorMessages;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.GameRepository;
 import com.sports.server.command.game.domain.GameState;
@@ -15,7 +14,6 @@ import com.sports.server.command.sport.domain.SportRepository;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.application.PermissionValidator;
 import com.sports.server.common.exception.NotFoundException;
-import com.sports.server.common.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +33,7 @@ public class GameService {
                          final Member manager) {
         League league = entityUtils.getEntity(leagueId, League.class);
         PermissionValidator.checkPermission(league, manager);
+        league.validateRoundWithinLimit(requestDto.round());
 
         Game game = saveGame(leagueId, manager, requestDto);
         saveGameTeams(game, requestDto);
@@ -73,6 +72,7 @@ public class GameService {
     public void updateGame(Long leagueId, Long gameId, GameRequestDto.Update request, Member manager) {
         League league = entityUtils.getEntity(leagueId, League.class);
         PermissionValidator.checkPermission(league, manager);
+        league.validateRoundWithinLimit(request.round());
 
         Game game = entityUtils.getEntity(gameId, Game.class);
         game.updateName(request.name());

--- a/src/main/java/com/sports/server/command/league/domain/League.java
+++ b/src/main/java/com/sports/server/command/league/domain/League.java
@@ -5,6 +5,7 @@ import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.organization.domain.Organization;
 import com.sports.server.common.domain.BaseEntity;
 import com.sports.server.common.domain.ManagedEntity;
+import com.sports.server.common.exception.CustomException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,6 +23,7 @@ import lombok.NoArgsConstructor;
 import org.flywaydb.core.internal.util.StringUtils;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+import org.springframework.http.HttpStatus;
 
 @Entity
 @Table(name = "leagues")
@@ -98,5 +100,11 @@ public class League extends BaseEntity<League> implements ManagedEntity {
 
     public String manager() {
         return manager.getEmail();
+    }
+
+    public void validateRoundWithinLimit(Integer round) {
+        if (maxRound.numberIsLessThan(round)) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "최대 라운드보다 더 큰 라운드의 경기를 등록할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/sports/server/command/league/domain/Round.java
+++ b/src/main/java/com/sports/server/command/league/domain/Round.java
@@ -32,7 +32,8 @@ public enum Round {
         return Stream.of(Round.values())
                 .filter(round -> round.number == number)
                 .findAny()
-                .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, LeagueErrorMessages.ROUND_NOT_FOUND_EXCEPTION));
+                .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST,
+                        LeagueErrorMessages.ROUND_NOT_FOUND_EXCEPTION));
     }
 
 
@@ -42,8 +43,14 @@ public enum Round {
     }
 
     public static boolean isValidNumber(final Integer value) {
-        if (value == null) {return false;}
+        if (value == null) {
+            return false;
+        }
         return Stream.of(Round.values())
                 .anyMatch(round -> round.getNumber() == value);
+    }
+
+    public boolean numberIsLessThan(Integer otherNumber) {
+        return this.number < otherNumber;
     }
 }

--- a/src/main/java/com/sports/server/query/application/TimelineQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TimelineQueryService.java
@@ -27,7 +27,7 @@ public class TimelineQueryService {
 
         return timelines.keySet()
                 .stream()
-                .sorted(comparingLong(Quarter::getOrder).reversed().thenComparing(Quarter::getId).reversed())
+                .sorted(comparingLong(Quarter::getOrder).thenComparing(Quarter::getId).reversed())
                 .map(quarter -> TimelineResponse.of(
                         quarter.getName(),
                         timelines.get(quarter)

--- a/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
@@ -1,6 +1,7 @@
 package com.sports.server.command.game.application;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.sports.server.command.game.domain.Game;
@@ -8,12 +9,12 @@ import com.sports.server.command.game.domain.GameState;
 import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.game.dto.GameRequestDto;
-import com.sports.server.command.league.domain.League;
 import com.sports.server.command.league.domain.Round;
 import com.sports.server.command.leagueteam.domain.LeagueTeam;
 import com.sports.server.command.leagueteam.domain.LeagueTeamPlayer;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.common.application.EntityUtils;
+import com.sports.server.common.exception.CustomException;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.common.exception.UnauthorizedException;
 import com.sports.server.support.ServiceTest;
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
-import org.testcontainers.shaded.org.checkerframework.checker.units.qual.K;
 
 @Sql("/game-fixture.sql")
 public class GameServiceTest extends ServiceTest {
@@ -136,6 +136,20 @@ public class GameServiceTest extends ServiceTest {
             // when & then
             assertThatThrownBy(() -> gameService.register(leagueId, requestDto, nonManager))
                     .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        void maxRound보다_큰_round의_경기를_등록할_수_없다() {
+            // given
+            Long leagueId = 1L;
+            Member manager = entityUtils.getEntity(1L, Member.class);
+            GameRequestDto.Register requestDto = new GameRequestDto.Register(nameOfGame, 32, "전반전", "SCHEDULED",
+                    LocalDateTime.now(), idOfTeam1, idOfTeam2, null);
+
+            // when & then
+            assertThatThrownBy(() -> gameService.register(leagueId, requestDto, manager))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("최대 라운드보다 더 큰 라운드의 경기를 등록할 수 없습니다.");
         }
     }
 

--- a/src/test/resources/timeline-fixture.sql
+++ b/src/test/resources/timeline-fixture.sql
@@ -9,11 +9,11 @@ VALUES (1, 1, 'john.doe@example.com', 'password123', TRUE, '2024-07-01 10:00:00'
 INSERT INTO sports (id, name)
 VALUES (1, '농구');
 -- 농구 쿼터
-INSERT INTO quarters (id, name, sports_id)
-VALUES (1, '1쿼터', 1),
-       (2, '2쿼터', 1),
-       (3, '3쿼터', 1),
-       (4, '4쿼터', 1);
+INSERT INTO quarters (id, name, sports_id, _order)
+VALUES (1, '1쿼터', 1, 1),
+       (2, '2쿼터', 1, 2),
+       (3, '3쿼터', 1, 3),
+       (4, '4쿼터', 1, 4);
 
 -- 경기
 INSERT INTO games (id, sport_id, manager_id, league_id, name, start_time, video_id, quarter_changed_at,


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #285 

## 📝 구현 내용
- 게임 저장 / 수정 로직 일부 수정
- 테스트 추가