### PR TITLE
[CHORE] db 구조 변경을 위한 스키마 및 flyway 설정

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/renewal_test
+    username: root
+    password: password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    schemas: T_renewal_test
+    baseline-on-migrate: true
+    version: 1
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
       ddl-auto: none
   flyway:
     enabled: true
-    baseline-on-migrate: true
+    baseline-on-migrate: false
     version: 1
 server:
   port: 8080
@@ -39,3 +39,11 @@ spring:
       on-profile: prod
     import:
       - classpath:be-config/application-prod.yml
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+    import:
+      - application-test.yml


### PR DESCRIPTION
## 🌍 이슈 번호
#299 

## 📝 구현 내용
- renewal_test의 `baseline-on-migrate: true`로 하여 이 DB의 상태를 기준으로 하도록 설정
- `schemas: T_renewal_test` 와 같이 스키마 이름 앞에 T(Test)를 붙여 테이블 이름이 `T_table`과 같이 생성되도록 설정

## 🍀 확인해야 할 부분
- @Zena0128 @Jin409 
- 설정 잘 되었는지, 따로 설정할 부분 있는지 확인 부탁드립니다.