### PR TITLE
[FIX] 게임 삭제 시 연관 타임라인 삭제

### DIFF
--- a/src/main/java/com/sports/server/ServerApplication.java
+++ b/src/main/java/com/sports/server/ServerApplication.java
@@ -14,9 +14,4 @@ public class ServerApplication {
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
         SpringApplication.run(ServerApplication.class, args);
     }
-
-//    @PostConstruct
-//    void started() {
-//        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-//    }
 }

--- a/src/main/java/com/sports/server/command/game/application/GameService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameService.java
@@ -11,6 +11,7 @@ import com.sports.server.command.leagueteam.domain.LeagueTeam;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.sport.domain.Sport;
 import com.sports.server.command.sport.domain.SportRepository;
+import com.sports.server.command.timeline.domain.TimelineRepository;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.application.PermissionValidator;
 import com.sports.server.common.exception.NotFoundException;
@@ -27,6 +28,7 @@ public class GameService {
     private final EntityUtils entityUtils;
     private final GameRepository gameRepository;
     private final SportRepository sportRepository;
+    private final TimelineRepository timelineRepository;
     private static final String NAME_OF_SPORT = "축구";
 
     @Transactional
@@ -94,6 +96,7 @@ public class GameService {
         PermissionValidator.checkPermission(league, manager);
 
         Game game = entityUtils.getEntity(gameId, Game.class);
+        timelineRepository.deleteByGame(game);
         gameRepository.delete(game);
     }
 }

--- a/src/main/java/com/sports/server/command/league/dto/LeagueRequestDto.java
+++ b/src/main/java/com/sports/server/command/league/dto/LeagueRequestDto.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 
 import com.sports.server.command.league.domain.League;
 import com.sports.server.command.member.domain.Member;
-import com.sports.server.command.organization.domain.Organization;
 
 public class LeagueRequestDto {
 	public record Register(

--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -1,12 +1,10 @@
 package com.sports.server.command.timeline.application;
 
 import com.sports.server.command.game.domain.Game;
-import com.sports.server.command.game.domain.GameState;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.timeline.domain.Timeline;
 import com.sports.server.command.timeline.domain.TimelineRepository;
 import com.sports.server.command.timeline.dto.TimelineRequest;
-import com.sports.server.command.timeline.exception.TimelineErrorMessage;
 import com.sports.server.command.timeline.mapper.TimelineMapper;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.application.PermissionValidator;
@@ -16,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import static com.sports.server.command.timeline.exception.TimelineErrorMessage.GAME_ALREADY_FINISHED;
 
 @Service
 @Transactional

--- a/src/main/java/com/sports/server/command/timeline/domain/TimelineRepository.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/TimelineRepository.java
@@ -1,7 +1,11 @@
 package com.sports.server.command.timeline.domain;
 
 import com.sports.server.command.game.domain.Game;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -11,4 +15,9 @@ public interface TimelineRepository extends Repository<Timeline, Long> {
     Optional<Timeline> findFirstByGameOrderByIdDesc(Game game);
 
     void delete(Timeline timeline);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Timeline t WHERE t.game = :game")
+    void deleteByGame(@Param("game") Game game);
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/TimelineRepository.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/TimelineRepository.java
@@ -1,7 +1,6 @@
 package com.sports.server.command.timeline.domain;
 
 import com.sports.server.command.game.domain.Game;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -17,7 +16,6 @@ public interface TimelineRepository extends Repository<Timeline, Long> {
     void delete(Timeline timeline);
 
     @Modifying
-    @Transactional
     @Query("DELETE FROM Timeline t WHERE t.game = :game")
     void deleteByGame(@Param("game") Game game);
 }


### PR DESCRIPTION
## 🌍 이슈 번호
#312 

## 📝 구현 내용

- ScoreTimeline에 cascade 삭제 설정했음에도 리그, 게임 삭제 시 득점 타임라인이 두 개 이상 존재하면 삭제 실패
- LineupPlayer를 삭제할 때 scorer_id 참조가 존재하므로 제약위반이 발생하는 것이 아닌가 하는 추측
- 그래서 아예 게임 삭제할 때 해당 게임이랑 연관되어있는 타임라인을 삭제하는 로직을 추가(리그 삭제 로직에 추가하지 않은 이유는 리그가 논리 삭제이므로)


## 🍀 확인해야 할 부분


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 게임 삭제 시 관련 타임라인 데이터가 함께 제거되어 데이터 정리가 강화되었습니다.
  - 게임 관련 타임라인 항목을 일괄 삭제하는 기능이 추가되었습니다.

- **Chores**
  - 사용하지 않는 주석 처리된 코드와 불필요한 import 구문을 제거하여 코드 정리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->