### PR TITLE
[FEAT] 경고카드 타임라인 구현 및 테스트코드 작성

### DIFF
--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -2,6 +2,7 @@ package com.sports.server.command.game.domain;
 
 import static com.sports.server.command.timeline.exception.TimelineErrorMessage.GAME_ALREADY_FINISHED;
 
+import com.sports.server.command.game.exception.GameErrorMessages;
 import com.sports.server.command.league.domain.League;
 import com.sports.server.command.league.domain.Round;
 import com.sports.server.command.member.domain.Member;
@@ -108,39 +109,34 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
     }
 
     public void score(LineupPlayer scorer) {
-        GameTeam scoredTeam = teams.stream()
-                .filter(scorer::isInTeam)
-                .findAny()
-                .orElseThrow(() -> new IllegalArgumentException("참여하지 않는 선수는 득점할 수 없습니다."));
-
-        scoredTeam.score();
+        findTeamOf(scorer, GameErrorMessages.NOT_PARTICIPATING_PLAYER_SCORE).score();
     }
 
     public void scoreInPk(LineupPlayer scorer) {
-        GameTeam scoredTeam = teams.stream()
-                .filter(scorer::isInTeam)
-                .findAny()
-                .orElseThrow(() -> new IllegalArgumentException("참여하지 않는 선수는 승부차기에서 득점할 수 없습니다."));
-
-        scoredTeam.scoreInPk();
+        findTeamOf(scorer, GameErrorMessages.NOT_PARTICIPATING_PLAYER_PK_SCORE).scoreInPk();
     }
 
     public void cancelScore(LineupPlayer scorer) {
-        GameTeam scoredTeam = teams.stream()
-                .filter(scorer::isInTeam)
-                .findAny()
-                .orElseThrow(() -> new IllegalArgumentException("참여하지 않는 선수는 득점을 취소할 수 없습니다."));
-
-        scoredTeam.cancelScore();
+        findTeamOf(scorer, GameErrorMessages.NOT_PARTICIPATING_PLAYER_CANCEL_SCORE).cancelScore();
     }
 
     public void cancelPkScore(LineupPlayer scorer) {
-        GameTeam scoredTeam = teams.stream()
+        findTeamOf(scorer, GameErrorMessages.NOT_PARTICIPATING_PLAYER_CANCEL_SCORE).cancelPkScore();
+    }
+
+    public void issueWarningCard(LineupPlayer scorer){
+        findTeamOf(scorer, GameErrorMessages.NOT_PARTICIPATING_PLAYER_ISSUE_WARNING_CARD);
+    }
+
+    public void cancelWarningCard(LineupPlayer scorer){
+        findTeamOf(scorer, GameErrorMessages.NOT_PARTICIPATING_PLAYER_CANCEL_WARNING_CARD);
+    }
+
+    private GameTeam findTeamOf(LineupPlayer scorer, String errorMessage) {
+        return teams.stream()
                 .filter(scorer::isInTeam)
                 .findAny()
-                .orElseThrow(() -> new IllegalArgumentException("참여하지 않는 선수는 득점을 취소할 수 없습니다."));
-
-        scoredTeam.cancelPkScore();
+                .orElseThrow(() -> new IllegalArgumentException(errorMessage));
     }
 
     public void updateName(String name) {
@@ -198,7 +194,7 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
 
     private void validateGameTeam(final GameTeam gameTeam) {
         if (this.teams.stream().noneMatch(team -> team.getId().equals(gameTeam.getId()))) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, "해당 게임팀은 이 게임에 포함되지 않습니다.");
+            throw new CustomException(HttpStatus.BAD_REQUEST, GameErrorMessages.GAME_TEAM_NOT_PARTICIPANT_EXCEPTION);
         }
     }
 

--- a/src/main/java/com/sports/server/command/game/exception/GameErrorMessages.java
+++ b/src/main/java/com/sports/server/command/game/exception/GameErrorMessages.java
@@ -3,4 +3,9 @@ package com.sports.server.command.game.exception;
 public class GameErrorMessages {
     public static final String STATE_NOT_FOUND_EXCEPTION = "해당 경기의 상태는 존재하지 않습니다.";
     public static final String GAME_TEAM_NOT_PARTICIPANT_EXCEPTION = "해당 팀은 해당 게임에 속하지 않습니다.";
+    public static final String NOT_PARTICIPATING_PLAYER_SCORE = "참여하지 않는 선수는 득점할 수 없습니다.";
+    public static final String NOT_PARTICIPATING_PLAYER_PK_SCORE = "참여하지 않는 선수는 승부차기에서 득점할 수 없습니다.";
+    public static final String NOT_PARTICIPATING_PLAYER_CANCEL_SCORE = "참여하지 않는 선수는 득점을 취소할 수 없습니다.";
+    public static final String NOT_PARTICIPATING_PLAYER_ISSUE_WARNING_CARD = "참여하지 않는 선수는 경고카드를 받을 수 없습니다.";
+    public static final String NOT_PARTICIPATING_PLAYER_CANCEL_WARNING_CARD = "참여하지 않는 선수는 경고카드를 취소할 수 없습니다.";
 }

--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -39,7 +39,6 @@ public class TimelineService {
 
         Timeline timeline = getLastTimeline(timelineId, game);
         timeline.rollback();
-
         timelineRepository.delete(timeline);
     }
 

--- a/src/main/java/com/sports/server/command/timeline/domain/TimelineType.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/TimelineType.java
@@ -5,4 +5,5 @@ public enum TimelineType {
     REPLACEMENT,
     GAME_PROGRESS,
     PK,
+    WARNING_CARD
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/WarningCardTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/WarningCardTimeline.java
@@ -1,0 +1,53 @@
+package com.sports.server.command.timeline.domain;
+
+import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.LineupPlayer;
+import com.sports.server.command.sport.domain.Quarter;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@DiscriminatorValue("WARNING_CARD")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WarningCardTimeline extends Timeline{
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "scorer_id")
+    private LineupPlayer scorer;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "warning_card_type")
+    private WarningCardType warningCardType;
+
+    public WarningCardTimeline(Game game,
+                               Quarter recoredQuarter,
+                               Integer recordedAt,
+                               LineupPlayer scorer,
+                               WarningCardType warningCardType
+    ) {
+        super(game, recoredQuarter, recordedAt);
+        this.scorer = scorer;
+        this.warningCardType = warningCardType;
+    }
+
+    @Override
+    public TimelineType getType() {
+        return TimelineType.WARNING_CARD;
+    }
+
+    @Override
+    public void apply() {
+        game.issueWarningCard(scorer);
+    }
+
+    @Override
+    public void rollback() {
+        game.cancelWarningCard(scorer);
+    }
+}

--- a/src/main/java/com/sports/server/command/timeline/domain/WarningCardType.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/WarningCardType.java
@@ -1,0 +1,6 @@
+package com.sports.server.command.timeline.domain;
+
+public enum WarningCardType {
+    YELLOW,
+    RED
+}

--- a/src/main/java/com/sports/server/command/timeline/dto/TimelineRequest.java
+++ b/src/main/java/com/sports/server/command/timeline/dto/TimelineRequest.java
@@ -3,6 +3,7 @@ package com.sports.server.command.timeline.dto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sports.server.command.timeline.domain.GameProgressType;
 import com.sports.server.command.timeline.domain.TimelineType;
+import com.sports.server.command.timeline.domain.WarningCardType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -106,5 +107,29 @@ public abstract class TimelineRequest {
         }
     }
 
+    @Getter
+    public static class RegisterWarningCard extends TimelineRequest {
+        private final Long gameTeamId;
+        private final Long warnedLineupPlayerId;
+        private final WarningCardType cardType;
+
+        public RegisterWarningCard(
+                Integer recordedAt,
+                Long recordedQuarterId,
+                Long gameTeamId,
+                Long warnedPlayerId,
+                WarningCardType cardType
+        ){
+            super(recordedQuarterId, recordedAt);
+            this.gameTeamId = gameTeamId;
+            this.warnedLineupPlayerId = warnedPlayerId;
+            this.cardType = cardType;
+        }
+
+        @Override
+        public TimelineType getType() {
+            return TimelineType.WARNING_CARD;
+        }
+    }
 
 }

--- a/src/main/java/com/sports/server/command/timeline/mapper/TimelineMapper.java
+++ b/src/main/java/com/sports/server/command/timeline/mapper/TimelineMapper.java
@@ -3,12 +3,7 @@ package com.sports.server.command.timeline.mapper;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.sport.domain.Quarter;
-import com.sports.server.command.timeline.domain.GameProgressTimeline;
-import com.sports.server.command.timeline.domain.PKTimeline;
-import com.sports.server.command.timeline.domain.ReplacementTimeline;
-import com.sports.server.command.timeline.domain.ScoreTimeline;
-import com.sports.server.command.timeline.domain.Timeline;
-import com.sports.server.command.timeline.domain.TimelineType;
+import com.sports.server.command.timeline.domain.*;
 import com.sports.server.command.timeline.dto.TimelineRequest;
 import com.sports.server.common.application.EntityUtils;
 import java.util.Map;
@@ -25,7 +20,8 @@ public class TimelineMapper {
             TimelineType.SCORE, (g, r) -> toScoreTimeline(g, (TimelineRequest.RegisterScore) r),
             TimelineType.REPLACEMENT, (g, r) -> toReplacementTimeline(g, (TimelineRequest.RegisterReplacement) r),
             TimelineType.GAME_PROGRESS, (g, r) -> toProgressTimeline(g, (TimelineRequest.RegisterProgress) r),
-            TimelineType.PK, (g, r) -> toPkTimeline(g, (TimelineRequest.RegisterPk) r)
+            TimelineType.PK, (g, r) -> toPkTimeline(g, (TimelineRequest.RegisterPk) r),
+            TimelineType.WARNING_CARD, (g, r) -> toWarningCardTimeline(g, (TimelineRequest.RegisterWarningCard) r)
     );
 
     public Timeline toEntity(Game game, TimelineRequest request) {
@@ -73,6 +69,17 @@ public class TimelineMapper {
                 pkRequest.getRecordedAt(),
                 getPlayer(pkRequest.getScorerId()),
                 pkRequest.getIsSuccess()
+        );
+    }
+
+    private WarningCardTimeline toWarningCardTimeline(Game game,
+                                                      TimelineRequest.RegisterWarningCard warningCardRequest) {
+        return new WarningCardTimeline(
+                game,
+                getQuarter(warningCardRequest.getRecordedQuarterId()),
+                warningCardRequest.getRecordedAt(),
+                getPlayer(warningCardRequest.getWarnedLineupPlayerId()),
+                warningCardRequest.getCardType()
         );
     }
 

--- a/src/main/java/com/sports/server/command/timeline/presentation/TimelineController.java
+++ b/src/main/java/com/sports/server/command/timeline/presentation/TimelineController.java
@@ -52,6 +52,14 @@ public class TimelineController {
         return ResponseEntity.created(URI.create("")).build();
     }
 
+    @PostMapping("/warning")
+    public ResponseEntity<Void> createWarningTimeline(@PathVariable Long gameId,
+                                                      @RequestBody TimelineRequest.RegisterWarningCard request,
+                                                      Member member) {
+        timelineService.register(member, gameId, request);
+        return ResponseEntity.created(URI.create("")).build();
+    }
+
     @DeleteMapping("/{timelineId}")
     public ResponseEntity<Void> deleteTimeline(@PathVariable Long gameId,
                                                @PathVariable Long timelineId,

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -5,11 +5,8 @@ import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.leagueteam.domain.LeagueTeam;
 import com.sports.server.command.sport.domain.Quarter;
-import com.sports.server.command.timeline.domain.GameProgressTimeline;
-import com.sports.server.command.timeline.domain.PKTimeline;
-import com.sports.server.command.timeline.domain.ReplacementTimeline;
-import com.sports.server.command.timeline.domain.ScoreTimeline;
-import com.sports.server.command.timeline.domain.Timeline;
+import com.sports.server.command.timeline.domain.*;
+
 import java.util.Optional;
 
 public record RecordResponse(
@@ -25,7 +22,8 @@ public record RecordResponse(
         ScoreRecordResponse scoreRecord,
         ReplacementRecordResponse replacementRecord,
         ProgressRecordResponse progressRecord,
-        PkRecordResponse pkRecord
+        PkRecordResponse pkRecord,
+        WarningCardRecordResponse warningCardRecord
 ) {
     public static RecordResponse from(Timeline timeline) {
         Optional<LineupPlayer> lineupPlayer = getPlayer(timeline);
@@ -48,7 +46,9 @@ public record RecordResponse(
                 timeline instanceof GameProgressTimeline progressTimeline
                         ? ProgressRecordResponse.from(progressTimeline) : null,
                 timeline instanceof PKTimeline pkTimeline
-                        ? PkRecordResponse.from(pkTimeline) : null
+                        ? PkRecordResponse.from(pkTimeline) : null,
+                timeline instanceof WarningCardTimeline warningCardTimeline
+                        ? WarningCardRecordResponse.from(warningCardTimeline) : null
         );
     }
 

--- a/src/main/java/com/sports/server/query/dto/response/WarningCardRecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/WarningCardRecordResponse.java
@@ -1,0 +1,14 @@
+package com.sports.server.query.dto.response;
+
+import com.sports.server.command.timeline.domain.WarningCardTimeline;
+import com.sports.server.command.timeline.domain.WarningCardType;
+
+public record WarningCardRecordResponse (
+        WarningCardType warningCardType
+){
+    public static WarningCardRecordResponse from(WarningCardTimeline timeline){
+        return new WarningCardRecordResponse(
+                timeline.getWarningCardType()
+        );
+    }
+}

--- a/src/main/resources/db/migration/prod/V25__update_warning_card_timeline.sql
+++ b/src/main/resources/db/migration/prod/V25__update_warning_card_timeline.sql
@@ -1,0 +1,2 @@
+ALTER TABLE timelines
+    ADD COLUMN warning_card_type VARCHAR(255);

--- a/src/test/java/com/sports/server/command/timeline/acceptance/TimelineAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/acceptance/TimelineAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.sports.server.command.timeline.acceptance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sports.server.command.timeline.domain.GameProgressType;
+import com.sports.server.command.timeline.domain.WarningCardType;
 import com.sports.server.command.timeline.dto.TimelineRequest;
 import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
@@ -120,6 +121,31 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 경고카드_타임라인을_생성한다(){
+        //given
+        TimelineRequest.RegisterWarningCard request = new TimelineRequest.RegisterWarningCard(
+                10,
+                quarterId,
+                team1Id,
+                team1PlayerId,
+                WarningCardType.YELLOW
+        );
+
+        //when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .cookie(COOKIE_NAME, mockToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .post("/games/{gameId}/timelines/warning", gameId)
+                .then().log().all()
+                .extract();
+
+        //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
 }

--- a/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
@@ -7,12 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.member.domain.MemberRepository;
 import com.sports.server.command.timeline.TimelineFixtureRepository;
-import com.sports.server.command.timeline.domain.GameProgressTimeline;
-import com.sports.server.command.timeline.domain.GameProgressType;
-import com.sports.server.command.timeline.domain.PKTimeline;
-import com.sports.server.command.timeline.domain.ReplacementTimeline;
-import com.sports.server.command.timeline.domain.ScoreTimeline;
-import com.sports.server.command.timeline.domain.Timeline;
+import com.sports.server.command.timeline.domain.*;
 import com.sports.server.command.timeline.dto.TimelineRequest;
 import com.sports.server.command.timeline.exception.TimelineErrorMessage;
 import com.sports.server.common.application.EntityUtils;
@@ -270,13 +265,40 @@ class TimelineServiceTest extends ServiceTest {
         }
     }
 
+    @DisplayName("경고 타임라인을")
+    @Nested
+    class WarningCardTest{
+        @Test
+        void 생성한다(){
+            //given
+            Long teamId = 1L;
+            Long playerId = 1L;
+            int recordedAt = 10;
+
+            TimelineRequest.RegisterWarningCard request = new TimelineRequest.RegisterWarningCard(
+                    recordedAt,
+                    quarterId,
+                    teamId,
+                    playerId,
+                    WarningCardType.YELLOW
+            );
+
+            //when
+            timelineService.register(manager, gameId, request);
+
+            //then
+            Timeline actual = timelineFixtureRepository.findAllLatest(gameId).get(0);
+            assertThat(actual).isInstanceOf(WarningCardTimeline.class);
+        }
+    }
+
     @DisplayName("타임라인을 삭제할 때")
     @Nested
     class DeleteTest {
         @Test
         void 마지막_타임라인을_차례로_삭제한다() {
             // given
-            long lastId = 7L;
+            long lastId = 9L;
 
             // when
             for (long i = lastId; i > 0; i--) {

--- a/src/test/java/com/sports/server/command/timeline/domain/WarningCardTimelineTest.java
+++ b/src/test/java/com/sports/server/command/timeline/domain/WarningCardTimelineTest.java
@@ -1,0 +1,63 @@
+package com.sports.server.command.timeline.domain;
+
+import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.GameTeam;
+import com.sports.server.command.game.domain.LineupPlayer;
+import com.sports.server.command.sport.domain.Quarter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.sports.server.support.fixture.FixtureMonkeyUtils.entityBuilder;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class WarningCardTimelineTest {
+
+    private final Game game = entityBuilder(Game.class).sample();
+    private final GameTeam gameTeam = entityBuilder(GameTeam.class).sample();
+    private final Quarter quarter = entityBuilder(Quarter.class).sample();
+
+    @Nested
+    @DisplayName("경고 카드 타임라인을")
+    class CreateTest{
+        @Test
+        void 옐로카드로_생성한다(){
+            //given
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).sample();
+
+            //when
+            WarningCardTimeline timeline = new WarningCardTimeline(
+                    game,
+                    quarter,
+                    10,
+                    scorer,
+                    WarningCardType.YELLOW
+            );
+
+            //then
+            assertThat(timeline.getScorer()).isEqualTo(scorer);
+            assertThat(timeline.getWarningCardType()).isEqualTo(WarningCardType.YELLOW);
+        }
+
+        @Test
+        void 레드카드로_생성한다(){
+            //given
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).sample();
+
+            //when
+            WarningCardTimeline timeline = new WarningCardTimeline(
+                    game,
+                    quarter,
+                    10,
+                    scorer,
+                    WarningCardType.RED
+            );
+
+            //then
+            assertThat(timeline.getScorer()).isEqualTo(scorer);
+            assertThat(timeline.getWarningCardType()).isEqualTo(WarningCardType.RED);
+        }
+    }
+}

--- a/src/test/java/com/sports/server/command/timeline/presentation/TimelineControllerTest.java
+++ b/src/test/java/com/sports/server/command/timeline/presentation/TimelineControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sports.server.command.timeline.domain.GameProgressType;
+import com.sports.server.command.timeline.domain.WarningCardType;
 import com.sports.server.command.timeline.dto.TimelineRequest;
 import com.sports.server.support.DocumentationTest;
 import jakarta.servlet.http.Cookie;
@@ -176,6 +177,43 @@ public class TimelineControllerTest extends DocumentationTest {
                         pathParameters(
                                 parameterWithName("gameId").description("경기의 ID"),
                                 parameterWithName("timelineId").description("타임라인의 ID")
+                        ),
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        )
+                ));
+    }
+
+    @Test
+    void 경고_타임라인을_생성한다() throws Exception {
+        // given
+        TimelineRequest.RegisterWarningCard request = new TimelineRequest.RegisterWarningCard(
+                10,
+                1L,
+                2L,
+                3L,
+                WarningCardType.YELLOW
+        );
+
+        // when
+        ResultActions result = mockMvc.perform(post("/games/{gameId}/timelines/warning", 1)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .cookie(new Cookie(COOKIE_NAME, "temp-cookie"))
+        );
+
+        // then
+        result.andExpect(status().isCreated())
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("gameId").description("경기의 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("gameTeamId").type(JsonFieldType.NUMBER).description("경기 팀의 Id"),
+                                fieldWithPath("recordedQuarterId").type(JsonFieldType.NUMBER).description("쿼터 Id"),
+                                fieldWithPath("warnedLineupPlayerId").type(JsonFieldType.NUMBER).description("경고 선수 Id"),
+                                fieldWithPath("recordedAt").type(JsonFieldType.NUMBER).description("경고 시간"),
+                                fieldWithPath("cardType").type(JsonFieldType.STRING).description("경고 카드 종류")
                         ),
                         requestCookies(
                                 cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")

--- a/src/test/java/com/sports/server/query/acceptance/TimelineQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/TimelineQueryAcceptanceTest.java
@@ -4,12 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.sports.server.command.timeline.domain.GameProgressType;
-import com.sports.server.query.dto.response.PkRecordResponse;
-import com.sports.server.query.dto.response.ProgressRecordResponse;
-import com.sports.server.query.dto.response.RecordResponse;
-import com.sports.server.query.dto.response.ReplacementRecordResponse;
-import com.sports.server.query.dto.response.ScoreRecordResponse;
-import com.sports.server.query.dto.response.TimelineResponse;
+import com.sports.server.command.timeline.domain.WarningCardType;
+import com.sports.server.query.dto.response.*;
 import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -36,17 +32,18 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
     private static final String REPLACEMENT_TYPE = "REPLACEMENT";
     private static final String PROGRESS_TYPE = "GAME_PROGRESS";
     private static final String PK_TYPE = "PK";
+    private static final String WARNING_CARD_TYPE = "WARNING_CARD";
 
     @Test
     void 게임의_타임라인을_조회한다() {
         // given
-        Long baseballId = 1L;
+        Long gameId = 1L;
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .get("/games/{gameId}/timeline", baseballId)
+                .get("/games/{gameId}/timeline", gameId)
                 .then().log().all()
                 .extract();
 
@@ -59,6 +56,16 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                         new TimelineResponse(
                                 "2쿼터", List.of(
                                 new RecordResponse(
+                                        null, 8L, "WARNING_CARD",
+                                        25,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null, null, null, null,
+                                        new WarningCardRecordResponse(WarningCardType.YELLOW)
+                                ),
+                                new RecordResponse(
                                         null, 6L, "GAME_PROGRESS",
                                         20,
                                         null,
@@ -68,7 +75,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                         null,
                                         null,
                                         new ProgressRecordResponse(GameProgressType.GAME_END),
-                                        null
+                                        null, null
                                 ),
                                 new RecordResponse(
                                         null, 5L, "SCORE",
@@ -84,7 +91,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                                         "팀B", "http://example.com/logo_b.png", 3)
                                         )),
                                         null,
-                                        null, null
+                                        null, null, null
                                 ),
                                 new RecordResponse(
                                         null, 7L, "PK",
@@ -96,7 +103,8 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                         null,
                                         null,
                                         null,
-                                        new PkRecordResponse(7L, true)
+                                        new PkRecordResponse(7L, true),
+                                        null
                                 ),
                                 new RecordResponse(
                                         null, 4L, "REPLACEMENT",
@@ -107,11 +115,21 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                         "http://example.com/logo_a.png",
                                         null,
                                         new ReplacementRecordResponse(4L, "선수3"),
-                                        null, null
+                                        null, null, null
                                 )
                         )),
                         new TimelineResponse(
                                 "1쿼터", List.of(
+                                new RecordResponse(
+                                        null, 9L, "WARNING_CARD",
+                                        25,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null, null, null, null,
+                                        new WarningCardRecordResponse(WarningCardType.RED)
+                                ),
                                 new RecordResponse(
                                         null, 3L, "REPLACEMENT",
                                         24,
@@ -121,7 +139,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                         "http://example.com/logo_b.png",
                                         null,
                                         new ReplacementRecordResponse(3L, "선수7"),
-                                        null, null
+                                        null, null, null
                                 ),
                                 new RecordResponse(
                                         null, 2L, "SCORE",
@@ -137,7 +155,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                                         "팀B", "http://example.com/logo_b.png", 0)
                                         )),
                                         null,
-                                        null, null
+                                        null, null, null
                                 ),
                                 new RecordResponse(
                                         null, 1L, "GAME_PROGRESS",
@@ -148,7 +166,7 @@ public class TimelineQueryAcceptanceTest extends AcceptanceTest {
                                         null,
                                         null,
                                         null,
-                                        new ProgressRecordResponse(GameProgressType.QUARTER_START), null
+                                        new ProgressRecordResponse(GameProgressType.QUARTER_START), null, null
                                 )
                         ))
                 ))

--- a/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
@@ -8,12 +8,8 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sports.server.command.timeline.domain.GameProgressType;
-import com.sports.server.query.dto.response.PkRecordResponse;
-import com.sports.server.query.dto.response.ProgressRecordResponse;
-import com.sports.server.query.dto.response.RecordResponse;
-import com.sports.server.query.dto.response.ReplacementRecordResponse;
-import com.sports.server.query.dto.response.ScoreRecordResponse;
-import com.sports.server.query.dto.response.TimelineResponse;
+import com.sports.server.command.timeline.domain.WarningCardType;
+import com.sports.server.query.dto.response.*;
 import com.sports.server.support.DocumentationTest;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -58,7 +54,8 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                         )),
                                         new ReplacementRecordResponse(1L, "선수3"),
                                         new ProgressRecordResponse(GameProgressType.QUARTER_START),
-                                        new PkRecordResponse(1L, true)
+                                        new PkRecordResponse(1L, true),
+                                        new WarningCardRecordResponse(WarningCardType.YELLOW)
                                 ),
                                 new RecordResponse(
                                         null, 1L, REPLACEMENT_TYPE,
@@ -75,7 +72,8 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                         )),
                                         new ReplacementRecordResponse(1L, "선수3"),
                                         new ProgressRecordResponse(GameProgressType.QUARTER_END),
-                                        new PkRecordResponse(4L, false)
+                                        new PkRecordResponse(4L, false),
+                                        new WarningCardRecordResponse(WarningCardType.RED)
                                 )
                         ))
                 ));
@@ -130,10 +128,11 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                         .description("PK 타입 기록의  ID"),
                                 fieldWithPath("[].records[].pkRecord.isSuccess").type(
                                                 JsonFieldType.BOOLEAN)
-                                        .description("승부차기 득점 성공 여부")
+                                        .description("승부차기 득점 성공 여부"),
+                                fieldWithPath("[].records[].warningCardRecord.warningCardType").type(
+                                                JsonFieldType.STRING)
+                                        .description("WARNING_CARD 타입일 때 경고 카드 타입(YELLOW, RED)")
                         )
                 ));
-
-
     }
 }

--- a/src/test/resources/timeline-fixture.sql
+++ b/src/test/resources/timeline-fixture.sql
@@ -156,5 +156,23 @@ INSERT INTO timelines(type,
                       is_success)
 VALUES ('PK', 1, 2, 10, 10, true);
 
+-- 경고카드 타임라인 추가
+INSERT INTO timelines(type,
+                      game_id,
+                      recorded_quarter_id,
+                      recorded_at,
+                      scorer_id,
+                      warning_card_type)
+VALUES ('WARNING_CARD', 1, 2, 25, 10, 'YELLOW');
+
+INSERT INTO timelines(type,
+                      game_id,
+                      recorded_quarter_id,
+                      recorded_at,
+                      scorer_id,
+                      warning_card_type)
+VALUES ('WARNING_CARD', 1, 1, 25, 10, 'RED');
+
+-- 외래키 체크 켜기
 SET
     foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
#314 

## 📝 구현 내용
- `WarningCardTimeline` 도메인 및 연관된 서비스, 컨트롤러 등 구현
- 경고카드는 타임라인 용도로만 구현하였으므로 `WarningCardTimeline`의 `apply`, `rollback`에서는 선수 유효성 검사만 진행
- `Game` 클래스 내에서 중복되는 선수 유효성 검사 로직 리팩토링 및 예외 메시지 상수처리
- 테스트코드 작성
- 타임라인 테이블에 경고카드 타입 추가하는 flyway 스크립트 작성
- `timeline-fixture.sql`에 경고카드 타임라인 추가하는 쿼리문 추가


## 🍀 확인해야 할 부분
