### PR TITLE
[Feature] 리그 통계 api 및 테스트 코드 구현

### DIFF
--- a/src/main/java/com/sports/server/command/game/application/GameService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameService.java
@@ -38,10 +38,11 @@ public class GameService {
     }
 
     @Transactional
-    public void updateGameStatusToFinish(LocalDateTime now) {
+    public List<Game> updateGameStatusToFinish(LocalDateTime now) {
         LocalDateTime cutoffTime = now.minusHours(5);
         List<Game> games = gameRepository.findGamesOlderThanFiveHours(cutoffTime);
         games.forEach(game -> game.updateState(GameState.FINISHED));
+        return games;
     }
 
     private Game saveGame(League league, Member manager, GameRequest.Register request) {

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -1,20 +1,31 @@
 package com.sports.server.command.game.application;
 
 import java.time.LocalDateTime;
+import java.util.List;
+
+import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.league.application.LeagueStatisticsService;
+import com.sports.server.command.league.domain.Round;
+import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class GameStatusScheduler {
 
     private final GameService gameService;
-
-    public GameStatusScheduler(GameService gameService) {
-        this.gameService = gameService;
-    }
+    private final LeagueStatisticsService leagueStatisticsService;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void scheduleUpdateGameStatusToFinish() {
-        gameService.updateGameStatusToFinish(LocalDateTime.now());
+        List<Game> finishedGames = gameService.updateGameStatusToFinish(LocalDateTime.now());
+        updateLeagueStatisticsForFinalGames(finishedGames);
+    }
+
+    private void updateLeagueStatisticsForFinalGames(List<Game> finishedGames) {
+        finishedGames.stream()
+                .filter(game -> Round.FINAL.equals(game.getRound()) && game.getLeague() != null)
+                .forEach(leagueStatisticsService::updateLeagueStatisticFromFinalGame);
     }
 }

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -20,6 +20,7 @@ public class GameStatusScheduler {
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void scheduleUpdateGameStatusToFinish() {
         List<Game> finishedGames = gameService.updateGameStatusToFinish(LocalDateTime.now());
+        finishedGames.forEach(Game::determineResult);
         updateLeagueStatisticsForFinalGames(finishedGames);
     }
 

--- a/src/main/java/com/sports/server/command/game/domain/GameResult.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameResult.java
@@ -1,0 +1,14 @@
+package com.sports.server.command.game.domain;
+
+public enum GameResult {
+    WIN("승리"),
+    LOSE("패배"),
+    DRAW("무승부"),
+    NOT_DETERMINED("미정");
+
+    private final String description;
+
+    GameResult(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/sports/server/command/game/domain/GameResult.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameResult.java
@@ -1,14 +1,8 @@
 package com.sports.server.command.game.domain;
 
 public enum GameResult {
-    WIN("승리"),
-    LOSE("패배"),
-    DRAW("무승부"),
-    NOT_DETERMINED("미정");
-
-    private final String description;
-
-    GameResult(String description) {
-        this.description = description;
-    }
+    WIN,
+    LOSE,
+    DRAW,
+    NOT_DETERMINED
 }

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -3,14 +3,8 @@ package com.sports.server.command.game.domain;
 import com.sports.server.command.team.domain.Team;
 import com.sports.server.common.domain.BaseEntity;
 import com.sports.server.common.exception.CustomException;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -49,6 +43,10 @@ public class GameTeam extends BaseEntity<GameTeam> {
 
     @Column(name = "pk_score", nullable = false)
     private int pkScore;
+
+    @Column(name = "result")
+    @Enumerated(EnumType.STRING)
+    private GameResult result;
 
     public void validateCheerCountOfGameTeam(final int cheerCount) {
         if (cheerCount >= MAXIMUM_OF_CHEER_COUNT || cheerCount <= MINIMUM_OF_CHEER_COUNT) {
@@ -140,4 +138,15 @@ public class GameTeam extends BaseEntity<GameTeam> {
         }
     }
 
+    public void markAsWinner() {
+        this.result = GameResult.WIN;
+    }
+
+    public void markAsLoser() {
+        this.result = GameResult.LOSE;
+    }
+
+    public void markAsDraw() {
+        this.result = GameResult.DRAW;
+    }
 }

--- a/src/main/java/com/sports/server/command/game/exception/GameErrorMessages.java
+++ b/src/main/java/com/sports/server/command/game/exception/GameErrorMessages.java
@@ -3,6 +3,7 @@ package com.sports.server.command.game.exception;
 public class GameErrorMessages {
     public static final String STATE_NOT_FOUND_EXCEPTION = "해당 경기의 상태는 존재하지 않습니다.";
     public static final String GAME_TEAM_NOT_PARTICIPANT_EXCEPTION = "해당 게임팀은 이 게임에 포함되지 않습니다.";
+    public static final String GAME_REQUIRES_TWO_TEAMS = "게임에는 두 팀이 필요합니다.";
     public static final String QUARTER_NOT_EXIST_EXCEPTION = "해당 쿼터가 존재하지 않습니다.";
 
     public static final String PLAYER_NOT_PARTICIPANT_SCORE_EXCEPTION = "참여하지 않는 선수는 득점할 수 없습니다.";
@@ -10,4 +11,5 @@ public class GameErrorMessages {
     public static final String PLAYER_NOT_PARTICIPANT_CANCEL_SCORE_EXCEPTION = "참여하지 않는 선수는 득점을 취소할 수 없습니다.";
     public static final String PLAYER_NOT_PARTICIPANT_ISSUE_WARNING_CARD_EXCEPTION = "참여하지 않는 선수는 경고카드를 받을 수 없습니다.";
     public static final String PLAYER_NOT_PARTICIPANT_CANCEL_WARNING_CARD_EXCEPTION = "참여하지 않는 선수는 경고카드를 취소할 수 없습니다.";
+
 }

--- a/src/main/java/com/sports/server/command/league/application/LeagueStatisticsService.java
+++ b/src/main/java/com/sports/server/command/league/application/LeagueStatisticsService.java
@@ -1,0 +1,105 @@
+package com.sports.server.command.league.application;
+
+import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.GameResult;
+import com.sports.server.command.game.domain.GameTeam;
+import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.LeagueStatistics;
+import com.sports.server.command.league.domain.LeagueStatisticsRepository;
+import com.sports.server.command.league.domain.LeagueTeam;
+import com.sports.server.command.team.domain.Team;
+import com.sports.server.common.application.EntityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LeagueStatisticsService {
+    private final LeagueStatisticsRepository leagueStatisticsRepository;
+    private final EntityUtils entityUtils;
+
+    @Transactional
+    public Long updateLeagueStatisticFromFinalGame(Game finalGame) {
+        if (finalGame == null || finalGame.getLeague() == null) {
+            throw new IllegalArgumentException("유효한 게임 또는 리그 정보가 없습니다.");
+        }
+
+        League league = finalGame.getLeague();
+        LeagueStatistics leagueStatistics = getOrCreateLeagueStatistics(league);
+
+        updateWinnerTeamsFromGame(finalGame, leagueStatistics);
+
+        updateMostCheeredAndTalkedTeams(league, leagueStatistics);
+
+        return leagueStatistics.getId();
+    }
+
+    private LeagueStatistics getOrCreateLeagueStatistics(League league) {
+        LeagueStatistics leagueStatistics = league.getLeagueStatistics();
+        if (leagueStatistics == null) {
+            leagueStatistics = new LeagueStatistics(league);
+            leagueStatisticsRepository.save(leagueStatistics);
+        }
+        return leagueStatistics;
+    }
+
+    private void updateWinnerTeamsFromGame(Game finalGame, LeagueStatistics leagueStatistic) {
+        List<GameTeam> teams = finalGame.getGameTeams();
+        if (teams.size() < 2) {
+            return;
+        }
+
+        League league = leagueStatistic.getLeague();
+
+        // 우승팀 설정
+        teams.stream()
+                .filter(gameTeam -> GameResult.WIN.equals(gameTeam.getResult()))
+                .findFirst()
+                .ifPresent(winner -> {
+                    Team winnerTeam = winner.getTeam();
+                    leagueStatistic.updateFirstWinnerTeam(winnerTeam);
+                    updateLeagueTeamRanking(league, winnerTeam, 1);
+                });
+
+        // 준우승팀 설정
+        teams.stream()
+                .filter(gameTeam -> GameResult.LOSE.equals(gameTeam.getResult()))
+                .findFirst()
+                .ifPresent(loser -> {
+                    Team loserTeam = loser.getTeam();
+                    leagueStatistic.updateSecondWinnerTeam(loserTeam);
+                    updateLeagueTeamRanking(league, loserTeam, 2);
+                });
+    }
+
+    private void updateMostCheeredAndTalkedTeams(League league, LeagueStatistics leagueStatistic) {
+        List<LeagueTeam> leagueTeams = league.getLeagueTeams();
+        if (leagueTeams.isEmpty()) {
+            return;
+        }
+
+        // 최다 응원팀 찾기
+        leagueTeams.stream()
+                .max(Comparator.comparing(LeagueTeam::getTotalCheerCount))
+                .map(LeagueTeam::getTeam)
+                .ifPresent(leagueStatistic::updateMostCheeredTeam);
+
+        // 최다 응원 톡 팀 찾기
+        leagueTeams.stream()
+                .max(Comparator.comparing(LeagueTeam::getTotalTalkCount))
+                .map(LeagueTeam::getTeam)
+                .ifPresent(leagueStatistic::updateMostCheerTalksTeam);
+    }
+
+    private void updateLeagueTeamRanking(League league, Team team, int ranking) {
+        league.getLeagueTeams().stream()
+                .filter(lt -> lt.getTeam().equals(team))
+                .findFirst()
+                .ifPresent(lt -> lt.updateRanking(ranking));
+    }
+}

--- a/src/main/java/com/sports/server/command/league/domain/League.java
+++ b/src/main/java/com/sports/server/command/league/domain/League.java
@@ -58,9 +58,6 @@ public class League extends BaseEntity<League> implements ManagedEntity {
     @OneToMany(mappedBy = "league", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LeagueTopScorer> topScorers = new ArrayList<>();
 
-    @OneToOne(mappedBy = "league", cascade = CascadeType.ALL, orphanRemoval = true)
-    private LeagueStatistics leagueStatistics;
-
     public League(
             final Member administrator,
             final Organization organization,

--- a/src/main/java/com/sports/server/command/league/domain/League.java
+++ b/src/main/java/com/sports/server/command/league/domain/League.java
@@ -58,6 +58,9 @@ public class League extends BaseEntity<League> implements ManagedEntity {
     @OneToMany(mappedBy = "league", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LeagueTopScorer> topScorers = new ArrayList<>();
 
+    @OneToOne(mappedBy = "league", cascade = CascadeType.ALL, orphanRemoval = true)
+    private LeagueStatistics leagueStatistics;
+
     public League(
             final Member administrator,
             final Organization organization,

--- a/src/main/java/com/sports/server/command/league/domain/LeagueStatistics.java
+++ b/src/main/java/com/sports/server/command/league/domain/LeagueStatistics.java
@@ -39,6 +39,10 @@ public class LeagueStatistics extends BaseEntity<LeagueStatistics> {
         this.league = league;
     }
 
+    public static LeagueStatistics of(League league) {
+        return new LeagueStatistics(league);
+    }
+
     public void updateFirstWinnerTeam(Team firstWinnerTeam) {
         this.firstWinnerTeam = firstWinnerTeam;
     }

--- a/src/main/java/com/sports/server/command/league/domain/LeagueStatisticsRepository.java
+++ b/src/main/java/com/sports/server/command/league/domain/LeagueStatisticsRepository.java
@@ -1,0 +1,7 @@
+package com.sports.server.command.league.domain;
+
+import org.springframework.data.repository.Repository;
+
+public interface LeagueStatisticsRepository extends Repository<LeagueStatistics, Long> {
+    LeagueStatistics save(LeagueStatistics leagueStatistic);
+}

--- a/src/main/java/com/sports/server/command/league/domain/LeagueStatisticsRepository.java
+++ b/src/main/java/com/sports/server/command/league/domain/LeagueStatisticsRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.repository.Repository;
 
 public interface LeagueStatisticsRepository extends Repository<LeagueStatistics, Long> {
     LeagueStatistics save(LeagueStatistics leagueStatistic);
+    LeagueStatistics findByLeagueId(Long leagueId);
 }

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -27,7 +27,7 @@ public class LeagueQueryService {
     private final TeamDynamicRepository teamDynamicRepository;
     private final LeagueTeamPlayerQueryRepository leagueTeamPlayerQueryRepository;
     private final GameQueryRepository gameQueryRepository;
-    private final LegueStatisticsQueryRepository leagueStatisticsQueryRepository;
+    private final LeagueStatisticsQueryRepository leagueStatisticsQueryRepository;
     private final EntityUtils entityUtils;
 
     public List<LeagueResponse> findLeagues(Integer year) {

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -3,18 +3,13 @@ package com.sports.server.query.application;
 import static java.util.stream.Collectors.toMap;
 
 import com.sports.server.command.game.domain.Game;
-import com.sports.server.command.league.domain.League;
-import com.sports.server.command.league.domain.LeagueProgress;
-import com.sports.server.command.league.domain.LeagueTeam;
-import com.sports.server.command.league.domain.LeagueTeamPlayer;
+import com.sports.server.command.league.domain.*;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.query.dto.response.*;
-import com.sports.server.query.repository.GameQueryRepository;
-import com.sports.server.query.repository.LeagueQueryRepository;
-import com.sports.server.query.repository.TeamDynamicRepository;
-import com.sports.server.query.repository.LeagueTeamPlayerQueryRepository;
+import com.sports.server.query.repository.*;
+
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -32,6 +27,7 @@ public class LeagueQueryService {
     private final TeamDynamicRepository teamDynamicRepository;
     private final LeagueTeamPlayerQueryRepository leagueTeamPlayerQueryRepository;
     private final GameQueryRepository gameQueryRepository;
+    private final LegueStatisticsQueryRepository leagueStatisticsQueryRepository;
     private final EntityUtils entityUtils;
 
     public List<LeagueResponse> findLeagues(Integer year) {
@@ -108,6 +104,15 @@ public class LeagueQueryService {
                 .sorted(comparator)
                 .map(LeagueResponseToManage::of)
                 .toList();
+    }
+
+    public LeagueStatisticsResponse findLeagueStatistic(Long leagueId) {
+        League league = entityUtils.getEntity(leagueId, League.class);
+        LeagueStatistics leagueStatistics = leagueStatisticsQueryRepository.findByLeagueId(leagueId);
+        if (leagueStatistics == null) {
+            throw new NotFoundException("해당 리그의 통계를 찾을 수 없습니다.");
+        }
+        return new LeagueStatisticsResponse(leagueStatistics);
     }
 
     public static Map<String, Integer> leagueProgressOrderMap = Map.ofEntries(

--- a/src/main/java/com/sports/server/query/dto/response/LeagueStatisticsResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueStatisticsResponse.java
@@ -1,0 +1,21 @@
+package com.sports.server.query.dto.response;
+
+import com.sports.server.command.league.domain.LeagueStatistics;
+
+public record LeagueStatisticsResponse(
+        Long leagueStatisticsId,
+        TeamResponse firstWinnerTeam,
+        TeamResponse secondWinnerTeam,
+        TeamResponse mostCheeredTeam,
+        TeamResponse mostCheerTalksTeam
+) {
+    public LeagueStatisticsResponse(LeagueStatistics leagueStatistics){
+        this(
+                leagueStatistics.getId(),
+                new TeamResponse(leagueStatistics.getFirstWinnerTeam()),
+                new TeamResponse(leagueStatistics.getSecondWinnerTeam()),
+                new TeamResponse(leagueStatistics.getMostCheeredTeam()),
+                new TeamResponse(leagueStatistics.getMostCheerTalksTeam())
+        );
+    }
+}

--- a/src/main/java/com/sports/server/query/dto/response/LeagueStatisticsResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueStatisticsResponse.java
@@ -1,7 +1,8 @@
 package com.sports.server.query.dto.response;
 
-import com.sports.server.command.league.domain.LeagueStatistics;
+import lombok.Builder;
 
+@Builder
 public record LeagueStatisticsResponse(
         Long leagueStatisticsId,
         TeamResponse firstWinnerTeam,
@@ -9,13 +10,4 @@ public record LeagueStatisticsResponse(
         TeamResponse mostCheeredTeam,
         TeamResponse mostCheerTalksTeam
 ) {
-    public LeagueStatisticsResponse(LeagueStatistics leagueStatistics){
-        this(
-                leagueStatistics.getId(),
-                new TeamResponse(leagueStatistics.getFirstWinnerTeam()),
-                new TeamResponse(leagueStatistics.getSecondWinnerTeam()),
-                new TeamResponse(leagueStatistics.getMostCheeredTeam()),
-                new TeamResponse(leagueStatistics.getMostCheerTalksTeam())
-        );
-    }
 }

--- a/src/main/java/com/sports/server/query/dto/response/TeamResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/TeamResponse.java
@@ -1,22 +1,22 @@
-package com.sports.server.query.dto.response;
+    package com.sports.server.query.dto.response;
 
-import com.sports.server.command.team.domain.Team;
-import com.sports.server.command.team.domain.Unit;
+    import com.sports.server.command.team.domain.Team;
+    import com.sports.server.command.team.domain.Unit;
 
-public record TeamResponse(
-        Long id,
-        String name,
-        String logoImageUrl,
-        Unit unit,
-        String teamColor
-) {
-    public TeamResponse(final Team team){
-        this(
-                team.getId(),
-                team.getName(),
-                team.getLogoImageUrl(),
-                team.getUnit(),
-                team.getTeamColor()
-        );
+    public record TeamResponse(
+            Long id,
+            String name,
+            String logoImageUrl,
+            Unit unit,
+            String teamColor
+    ) {
+        public TeamResponse(final Team team){
+            this(
+                    team.getId(),
+                    team.getName(),
+                    team.getLogoImageUrl(),
+                    team.getUnit(),
+                    team.getTeamColor()
+            );
+        }
     }
-}

--- a/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
@@ -37,6 +37,11 @@ public class LeagueQueryController {
         return ResponseEntity.ok(leagueQueryService.findLeagueDetail(leagueId));
     }
 
+    @GetMapping("/{leagueId}/statistics")
+    public ResponseEntity<LeagueStatisticsResponse> findLeagueStatistics(@PathVariable Long leagueId) {
+        return ResponseEntity.ok(leagueQueryService.findLeagueStatistic(leagueId));
+    }
+
     @GetMapping("/teams/{leagueTeamId}/players")
     public ResponseEntity<List<PlayerResponse>> findPlayersByLeagueTeam(@PathVariable Long leagueTeamId) {
         return ResponseEntity.ok(leagueQueryService.findPlayersByLeagueTeam(leagueTeamId));

--- a/src/main/java/com/sports/server/query/repository/LeagueStatisticsQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueStatisticsQueryRepository.java
@@ -3,6 +3,6 @@ package com.sports.server.query.repository;
 import com.sports.server.command.league.domain.LeagueStatistics;
 import org.springframework.data.repository.Repository;
 
-public interface LegueStatisticsQueryRepository extends Repository<LeagueStatistics, Long> {
+public interface LeagueStatisticsQueryRepository extends Repository<LeagueStatistics, Long> {
     LeagueStatistics findByLeagueId(Long leagueId);
 }

--- a/src/main/java/com/sports/server/query/repository/LeagueTeamQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueTeamQueryRepository.java
@@ -1,0 +1,10 @@
+package com.sports.server.query.repository;
+
+import com.sports.server.command.league.domain.LeagueTeam;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface LeagueTeamQueryRepository extends Repository<LeagueTeam, Long> {
+    List<LeagueTeam> findByLeagueId(Long leagueId);
+}

--- a/src/main/java/com/sports/server/query/repository/LegueStatisticsQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LegueStatisticsQueryRepository.java
@@ -1,0 +1,8 @@
+package com.sports.server.query.repository;
+
+import com.sports.server.command.league.domain.LeagueStatistics;
+import org.springframework.data.repository.Repository;
+
+public interface LegueStatisticsQueryRepository extends Repository<LeagueStatistics, Long> {
+    LeagueStatistics findByLeagueId(Long leagueId);
+}

--- a/src/test/java/com/sports/server/command/league/application/LeagueStatisticsServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueStatisticsServiceTest.java
@@ -1,0 +1,138 @@
+package com.sports.server.command.league.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.LeagueStatistics;
+import com.sports.server.command.league.domain.LeagueStatisticsRepository;
+import com.sports.server.command.league.domain.LeagueTeam;
+import com.sports.server.command.league.domain.LeagueTeamRepository;
+import com.sports.server.command.team.domain.Team;
+import com.sports.server.common.application.EntityUtils;
+import com.sports.server.support.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql("/league-fixture.sql")
+public class LeagueStatisticsServiceTest extends ServiceTest {
+
+    @Autowired
+    private LeagueStatisticsService leagueStatisticsService;
+
+    @Autowired
+    private LeagueStatisticsRepository leagueStatisticsRepository;
+
+    @Autowired
+    private LeagueTeamRepository leagueTeamRepository;
+
+    @Autowired
+    private EntityUtils entityUtils;
+
+    @Nested
+    @DisplayName("최종 게임으로부터 리그 통계를 업데이트할 때")
+    class UpdateLeagueStatisticFromFinalGameTest {
+
+        @Test
+        @DisplayName("유효한 게임이 주어지면 리그 통계가 업데이트된다")
+        void 유효한_게임이_주어지면_리그_통계가_업데이트된다() {
+            // given
+            Game finalGame = entityUtils.getEntity(1L, Game.class);
+            League league = finalGame.getLeague();
+
+            // when
+            leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGame);
+
+            // then
+            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
+            assertThat(statistics).isNotNull();
+        }
+
+        @Test
+        @DisplayName("승리팀과 준우승팀이 올바르게 업데이트된다")
+        void 승리팀과_준우승팀이_올바르게_업데이트된다() {
+            // given
+            Game finalGame = entityUtils.getEntity(1L, Game.class);
+            League league = finalGame.getLeague();
+
+            // when
+            leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGame);
+
+            // then
+            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
+            assertThat(statistics.getFirstWinnerTeam()).isNotNull();
+            assertThat(statistics.getSecondWinnerTeam()).isNotNull();
+
+            // 승리팀의 랭킹이 1위로 업데이트되었는지 확인
+            Team winnerTeam = statistics.getFirstWinnerTeam();
+            LeagueTeam winnerLeagueTeam = leagueTeamRepository.findByLeagueAndTeam(league, winnerTeam).orElse(null);
+            assertThat(winnerLeagueTeam).isNotNull();
+            assertThat(winnerLeagueTeam.getRanking()).isEqualTo(1);
+
+            // 준우승팀의 랭킹이 2위로 업데이트되었는지 확인
+            Team secondTeam = statistics.getSecondWinnerTeam();
+            LeagueTeam secondLeagueTeam = leagueTeamRepository.findByLeagueAndTeam(league, secondTeam).orElse(null);
+            assertThat(secondLeagueTeam).isNotNull();
+            assertThat(secondLeagueTeam.getRanking()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("최다 응원팀과 최다 대화팀이 올바르게 업데이트된다")
+        void 최다_응원팀과_최다_대화팀이_올바르게_업데이트된다() {
+            // given
+            Game finalGame = entityUtils.getEntity(1L, Game.class);
+            League league = finalGame.getLeague();
+
+            // when
+            leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGame);
+
+            // then
+            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
+            assertThat(statistics.getMostCheeredTeam()).isNotNull();
+            assertThat(statistics.getMostCheerTalksTeam()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("게임이 null이면 예외가 발생한다")
+        void 게임이_null이면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> leagueStatisticsService.updateLeagueStatisticFromFinalGame(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("유효한 게임 또는 리그 정보가 없습니다.");
+        }
+
+        @Test
+        @DisplayName("게임에 리그 정보가 없으면 예외가 발생한다")
+        void 게임에_리그_정보가_없으면_예외가_발생한다() {
+            // given
+            Game gameWithoutLeague = Game.builder()
+                    .league(null)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> leagueStatisticsService.updateLeagueStatisticFromFinalGame(gameWithoutLeague))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("유효한 게임 또는 리그 정보가 없습니다.");
+        }
+
+        @Test
+        @DisplayName("게임팀이 최소 팀 수보다 적으면 업데이트하지 않는다")
+        void 게임팀이_최소_팀_수보다_적으면_업데이트하지_않는다() {
+            // given
+            Game gameWithInsufficientTeams = entityUtils.getEntity(2L, Game.class); // 팀 수가 부족한 게임
+            League league = gameWithInsufficientTeams.getLeague();
+
+            // when
+            leagueStatisticsService.updateLeagueStatisticFromFinalGame(gameWithInsufficientTeams);
+
+            // then
+            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
+            // 통계는 생성되지만 승리팀 정보는 업데이트되지 않음
+            assertThat(statistics).isNotNull();
+        }
+    }
+}

--- a/src/test/java/com/sports/server/query/application/LeagueQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/LeagueQueryServiceTest.java
@@ -231,6 +231,29 @@ public class LeagueQueryServiceTest extends ServiceTest {
     }
 
     @Nested
+    @DisplayName("리그 통계를 조회할 때")
+    class findLeagueStatisticTest {
+
+        @Test
+        void 리그_통계를_정상적으로_조회한다() {
+            // given
+            Long leagueId = 1L;
+
+            // when
+            LeagueStatisticsResponse response = leagueQueryService.findLeagueStatistic(leagueId);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.leagueStatisticsId()).isNotNull(),
+                    () -> assertThat(response.firstWinnerTeam()).isNotNull(),
+                    () -> assertThat(response.secondWinnerTeam()).isNotNull(),
+                    () -> assertThat(response.mostCheeredTeam()).isNotNull(),
+                    () -> assertThat(response.mostCheerTalksTeam()).isNotNull()
+            );
+        }
+    }
+
+    @Nested
     @DisplayName("리그와 리그의 경기들을 조회할 때")
     class findLeagueAndGamesTest {
 

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -119,10 +119,10 @@ public class LeagueQueryControllerTest extends DocumentationTest {
     void 리그_통계를_조회한다() throws Exception {
         // given
         Long leagueId = 1L;
-        TeamResponse firstWinnerTeam = new TeamResponse(1L, "우승팀", "logo1.png", Unit.BUSINESS, "#FF0000");
-        TeamResponse secondWinnerTeam = new TeamResponse(2L, "준우승팀", "logo2.png", Unit.ENGLISH, "#00FF00");
-        TeamResponse mostCheeredTeam = new TeamResponse(3L, "최다응원팀", "logo3.png", Unit.AI_CONVERGENCE, "#0000FF");
-        TeamResponse mostCheerTalksTeam = new TeamResponse(4L, "최다응원톡팀", "logo4.png", Unit.SOCIAL_SCIENCES, "#FFFF00");
+        TeamResponse firstWinnerTeam = new TeamResponse(1L, "우승팀", "logo1.png", Unit.BUSINESS, "#FF0000", null, null);
+        TeamResponse secondWinnerTeam = new TeamResponse(2L, "준우승팀", "logo2.png", Unit.ENGLISH, "#00FF00", null, null);
+        TeamResponse mostCheeredTeam = new TeamResponse(3L, "최다응원팀", "logo3.png", Unit.AI_CONVERGENCE, "#0000FF", 100, null);
+        TeamResponse mostCheerTalksTeam = new TeamResponse(4L, "최다응원톡팀", "logo4.png", Unit.SOCIAL_SCIENCES, "#FFFF00", null, 50);
         
         LeagueStatisticsResponse response = new LeagueStatisticsResponse(
                 1L,

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -10,8 +10,13 @@ import com.sports.server.query.dto.response.LeagueResponseWithGames.GameDetail.G
 import com.sports.server.query.dto.response.LeagueResponseWithInProgressGames;
 import com.sports.server.query.dto.response.LeagueResponseWithInProgressGames.GameDetailResponse;
 import com.sports.server.query.dto.response.LeagueResponseWithInProgressGames.GameDetailResponse.GameTeamResponse;
+import com.sports.server.query.dto.response.LeagueStatisticsResponse;
+import com.sports.server.query.dto.response.LeagueTeamDetailResponse;
 import com.sports.server.query.dto.response.LeagueTeamPlayerResponse;
 import com.sports.server.query.dto.response.LeagueTeamResponse;
+import com.sports.server.query.dto.response.PlayerResponse;
+import com.sports.server.query.dto.response.TeamResponse;
+import com.sports.server.command.team.domain.Unit;
 import com.sports.server.support.DocumentationTest;
 import jakarta.servlet.http.Cookie;
 import java.time.LocalDateTime;
@@ -106,6 +111,67 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                                         .description("리그의 팀 로고 이미지 URL®"),
                                 fieldWithPath("[].sizeOfLeagueTeamPlayers").type(JsonFieldType.NUMBER)
                                         .description("리그팀 선수의 인원수")
+                        )
+                ));
+    }
+
+    @Test
+    void 리그_통계를_조회한다() throws Exception {
+        // given
+        Long leagueId = 1L;
+        TeamResponse firstWinnerTeam = new TeamResponse(1L, "우승팀", "logo1.png", Unit.BUSINESS, "#FF0000");
+        TeamResponse secondWinnerTeam = new TeamResponse(2L, "준우승팀", "logo2.png", Unit.ENGLISH, "#00FF00");
+        TeamResponse mostCheeredTeam = new TeamResponse(3L, "최다응원팀", "logo3.png", Unit.AI_CONVERGENCE, "#0000FF");
+        TeamResponse mostCheerTalksTeam = new TeamResponse(4L, "최다응원톡팀", "logo4.png", Unit.SOCIAL_SCIENCES, "#FFFF00");
+        
+        LeagueStatisticsResponse response = new LeagueStatisticsResponse(
+                1L,
+                firstWinnerTeam,
+                secondWinnerTeam,
+                mostCheeredTeam,
+                mostCheerTalksTeam
+        );
+
+        given(leagueQueryService.findLeagueStatistic(leagueId))
+                .willReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/leagues/{leagueId}/statistics", leagueId)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect((status().isOk()))
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("leagueId").description("리그의 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("leagueStatisticsId").type(JsonFieldType.NUMBER).description("리그 통계 ID"),
+                                fieldWithPath("firstWinnerTeam").type(JsonFieldType.OBJECT).description("우승팀 정보"),
+                                fieldWithPath("firstWinnerTeam.id").type(JsonFieldType.NUMBER).description("우승팀 ID"),
+                                fieldWithPath("firstWinnerTeam.name").type(JsonFieldType.STRING).description("우승팀 이름"),
+                                fieldWithPath("firstWinnerTeam.logoImageUrl").type(JsonFieldType.STRING).description("우승팀 로고 이미지 URL"),
+                                fieldWithPath("firstWinnerTeam.unit").type(JsonFieldType.STRING).description("우승팀 소속 단과대학"),
+                                fieldWithPath("firstWinnerTeam.teamColor").type(JsonFieldType.STRING).description("우승팀 색상"),
+                                fieldWithPath("secondWinnerTeam").type(JsonFieldType.OBJECT).description("준우승팀 정보"),
+                                fieldWithPath("secondWinnerTeam.id").type(JsonFieldType.NUMBER).description("준우승팀 ID"),
+                                fieldWithPath("secondWinnerTeam.name").type(JsonFieldType.STRING).description("준우승팀 이름"),
+                                fieldWithPath("secondWinnerTeam.logoImageUrl").type(JsonFieldType.STRING).description("준우승팀 로고 이미지 URL"),
+                                fieldWithPath("secondWinnerTeam.unit").type(JsonFieldType.STRING).description("준우승팀 소속 단과대학"),
+                                fieldWithPath("secondWinnerTeam.teamColor").type(JsonFieldType.STRING).description("준우승팀 색상"),
+                                fieldWithPath("mostCheeredTeam").type(JsonFieldType.OBJECT).description("최다 응원받은 팀 정보"),
+                                fieldWithPath("mostCheeredTeam.id").type(JsonFieldType.NUMBER).description("최다 응원받은 팀 ID"),
+                                fieldWithPath("mostCheeredTeam.name").type(JsonFieldType.STRING).description("최다 응원받은 팀 이름"),
+                                fieldWithPath("mostCheeredTeam.logoImageUrl").type(JsonFieldType.STRING).description("최다 응원받은 팀 로고 이미지 URL"),
+                                fieldWithPath("mostCheeredTeam.unit").type(JsonFieldType.STRING).description("최다 응원받은 팀 소속 단과대학"),
+                                fieldWithPath("mostCheeredTeam.teamColor").type(JsonFieldType.STRING).description("최다 응원받은 팀 색상"),
+                                fieldWithPath("mostCheerTalksTeam").type(JsonFieldType.OBJECT).description("최다 응원톡 팀 정보"),
+                                fieldWithPath("mostCheerTalksTeam.id").type(JsonFieldType.NUMBER).description("최다 응원톡 팀 ID"),
+                                fieldWithPath("mostCheerTalksTeam.name").type(JsonFieldType.STRING).description("최다 응원톡 팀 이름"),
+                                fieldWithPath("mostCheerTalksTeam.logoImageUrl").type(JsonFieldType.STRING).description("최다 응원톡 팀 로고 이미지 URL"),
+                                fieldWithPath("mostCheerTalksTeam.unit").type(JsonFieldType.STRING).description("최다 응원톡 팀 소속 단과대학"),
+                                fieldWithPath("mostCheerTalksTeam.teamColor").type(JsonFieldType.STRING).description("최다 응원톡 팀 색상")
                         )
                 ));
     }

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -12,9 +12,8 @@ VALUES (1, 1, 'john.doe@example.com', 'password123', TRUE, '2024-07-01 10:00:00'
        (4, 1, 'bob.brown@example.com', 'password321', FALSE, '2024-07-04 14:20:00'),
        (5, 1, 'carol.white@example.com', 'password654', TRUE, '2024-07-05 16:10:00');
 
-
 -- 리그
-INSERT INTO leagues (id, manager_id, organization_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)
+INSERT INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)
 VALUES (1, 1, 1, '삼건물 대회', '2023-11-09 00:00:00', '2023-11-20 00:00:00', false, '16강', '8강'),
        (2, 1, 1, '농구대잔치', '2023-11-10 00:00:00', '2023-11-15 00:00:00', false, '8강', '결승'),
        (3, 1, 1, '롤 대회', '2023-11-10 00:00:00', '2023-11-20 00:00:00', false, '8강', '8강'),
@@ -28,58 +27,100 @@ VALUES (1, 1, 1, '삼건물 대회', '2023-11-09 00:00:00', '2023-11-20 00:00:00
 
 -- 리그의 스포츠
 INSERT INTO league_sports (id, league_id)
-VALUES (1, 1);
-INSERT INTO league_sports (id, league_id)
-VALUES (2, 2);
-INSERT INTO league_sports (id, league_id)
-VALUES (3, 3);
-INSERT INTO league_sports (id, league_id)
-VALUES (4, 4;
+VALUES (1, 1),
+       (2, 2),
+       (3, 3),
+       (4, 4);
 
--- 리그의 리그팀
-INSERT INTO league_teams (id, name, logo_image_url, manager_id, organization_id, league_id)
-VALUES (1, '경영 야생마', '이미지이미지', 1, 1, 1),
-       (2, '서어 뻬데뻬', '이미지이미지', 1, 1, 1),
-       (3, '미컴 축구생각', '이미지이미지', 1, 1, 1),
-       (4, '새로운 팀', '이미지이미지', 2, 1, 1),
-       (5, '새로운 팀 2', '이미지이미지', 2, 1, 1),
-       (6, '팀3', '이미지', 1, 1, 9),
-       (7, '팀4', '이미지', 1, 1, 9);
+-- TEAMS 테이블 - 실제 팀 데이터
+INSERT INTO teams (id, organization_id, logo_image_url, name, team_color, unit)
+VALUES (1, 1, 'https://example.com/logo1.png', '경영 야생마', '#FF0000', 'ENGLISH'),
+       (2, 1, 'https://example.com/logo2.png', '서어 뻬데뻬', '#00FF00', 'ENGLISH'),
+       (3, 1, 'https://example.com/logo3.png', '미컴 축구생각', '#0000FF', 'ENGLISH'),
+       (4, 1, 'https://example.com/logo4.png', '새로운 팀', '#FFFF00', 'ENGLISH'),
+       (5, 1, 'https://example.com/logo5.png', '새로운 팀 2', '#FF00FF', 'ENGLISH'),
+       (6, 1, 'https://example.com/logo6.png', '팀3', '#00FFFF', 'ENGLISH'),
+       (7, 1, 'https://example.com/logo7.png', '팀4', '#FFA500', 'ENGLISH');
 
--- 리그팀의 선수
-INSERT INTO league_team_players (id, name, description, number, league_team_id)
-VALUES (1, '봄동나물진승희', '설명설명설명', 0, 3),
-       (2, '가을전어이동규', '설명설명설명', 2, 3),
-       (3, '겨울붕어빵이현제', '설명설명설명', 3, 3),
-       (4, '여름수박고병룡', '설명설명설명', 3, 3),
-       (5, '승희', '설명', 10, 1);
+-- LEAGUE_TEAMS 테이블 - 리그와 팀의 매핑
+INSERT INTO league_teams (id, league_id, team_id, ranking, total_cheer_count, total_talk_count)
+VALUES (1, 1, 1, 1, 100, 50),
+       (2, 1, 2, 2, 80, 40),
+       (3, 1, 3, 3, 60, 30),
+       (4, 1, 4, 4, 40, 20),
+       (5, 1, 5, 5, 20, 10),
+       (6, 9, 6, 1, 150, 75),
+       (7, 9, 7, 2, 120, 60);
 
-INSERT INTO games (id,manager_id, league_id, name, start_time, video_id, quarter_changed_at,
-                   game_quarter, state, round)
+-- PLAYERS 테이블 - 선수 데이터
+INSERT INTO players (id, name, student_number)
+VALUES (1, '봄동나물진승희', '20200001'),
+       (2, '가을전어이동규', '20200002'),
+       (3, '겨울붕어빵이현제', '20200003'),
+       (4, '여름수박고병룡', '20200004'),
+       (5, '승희', '20200005'),
+       (6, '김선수', '20200006'),
+       (7, '박선수', '20200007'),
+       (8, '이선수', '20200008'),
+       (9, '최선수', '20200009'),
+       (10, '정선수', '20200010');
+
+-- TEAM_PLAYERS 테이블 - 팀과 선수의 매핑
+INSERT INTO team_players (id, team_id, player_id)
+VALUES (1, 1, 1),
+       (2, 1, 5),
+       (3, 3, 1),
+       (4, 3, 2),
+       (5, 3, 3),
+       (6, 3, 4),
+       (7, 6, 6),
+       (8, 6, 7),
+       (9, 7, 8),
+       (10, 7, 9),
+       (11, 7, 10);
+
+-- LEAGUE_TEAM_PLAYERS 테이블 - 리그팀과 선수의 매핑
+INSERT INTO league_team_players (id, league_team_id, player_id, jersey_number)
+VALUES (1, 3, 1, 0),   -- 미컴 축구생각 - 봄동나물진승희
+       (2, 3, 2, 2),   -- 미컴 축구생각 - 가을전어이동규
+       (3, 3, 3, 3),   -- 미컴 축구생각 - 겨울붕어빵이현제
+       (4, 3, 4, 4),   -- 미컴 축구생각 - 여름수박고병룡
+       (5, 1, 5, 10),  -- 경영 야생마 - 승희
+       (6, 6, 6, 1),   -- 팀3 - 김선수
+       (7, 6, 7, 2),   -- 팀3 - 박선수
+       (8, 7, 8, 3),   -- 팀4 - 이선수
+       (9, 7, 9, 4),   -- 팀4 - 최선수
+       (10, 7, 10, 5); -- 팀4 - 정선수
+
+-- 게임 데이터
+INSERT INTO games (id, manager_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter, state, round)
 VALUES (1, 1, 1, '농구 대전', '2023-11-12T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter', 'PLAYING', '4강'),
-       (2, 1, 1, '두번째로 빠른 경기', '2023-11-12T10:10:00', 'abc123', '2023-11-12T10:10:00', '1st Quarter', 'SCHEDULED',
-        '4강'),
-       (3, 1, 1, '세번째로 빠른 경기', '2023-11-12T11:00:00', 'abc123', '2023-11-12T11:15:00', '1st Quarter', 'PLAYING',
-        '4강'),
-       (4, 1, 2, '네번째로 빠른 경기', '2023-11-12T12:00:00', 'abc123', '2023-11-12T12:15:00', '1st Quarter', 'PLAYING',
-        '4강'),
-       (5, 1, 1, '예시 경기', '2023-11-12T12:00:00', 'abc123', '2023-11-12T12:15:00', '1st Quarter', 'FINISHED',
-        '4강');
+       (2, 1, 1, '두번째로 빠른 경기', '2023-11-12T10:10:00', 'abc123', '2023-11-12T10:10:00', '1st Quarter', 'SCHEDULED', '4강'),
+       (3, 1, 1, '세번째로 빠른 경기', '2023-11-12T11:00:00', 'abc123', '2023-11-12T11:15:00', '1st Quarter', 'PLAYING', '4강'),
+       (4, 1, 2, '네번째로 빠른 경기', '2023-11-12T12:00:00', 'abc123', '2023-11-12T12:15:00', '1st Quarter', 'PLAYING', '4강'),
+       (5, 1, 1, '예시 경기', '2023-11-12T12:00:00', 'abc123', '2023-11-12T12:15:00', '1st Quarter', 'FINISHED', '4강');
 
-INSERT INTO game_teams (game_id, league_team_id, cheer_count, score)
-VALUES (1, 1, 1, 1),
-       (1, 2, 2, 2),
+-- 게임팀 데이터
+INSERT INTO game_teams (game_id, team_id, cheer_count, score, pk_score)
+VALUES (1, 1, 1, 1, 0),  -- 경영 야생마
+       (1, 2, 2, 2, 0),  -- 서어 뻬데뻬
 
-       (2, 2, 1, 0),
-       (2, 3, 1, 0),
+       (2, 2, 1, 0, 0),  -- 서어 뻬데뻬
+       (2, 3, 1, 0, 0),  -- 미컴 축구생각
 
-       (3, 1, 1, 0),
-       (3, 3, 1, 0),
+       (3, 1, 1, 0, 0),  -- 경영 야생마
+       (3, 3, 1, 0, 0),  -- 미컴 축구생각
 
-       (4, 4, 1, 1),
-       (4, 5, 2, 2),
+       (4, 4, 1, 1, 0),  -- 새로운 팀
+       (4, 5, 2, 2, 0),  -- 새로운 팀 2
 
-       (5, 1, 1, 0),
-       (5, 5, 1, 0);
+       (5, 1, 1, 0, 0),  -- 경영 야생마
+       (5, 5, 1, 0, 0);  -- 새로운 팀 2
+
+-- LEAGUE_STATISTICS 테이블
+INSERT INTO league_statistics (id, league_id, first_winner_team_id, second_winner_team_id, most_cheered_team_id, most_cheer_talks_team_id)
+VALUES (1, 1, 1, 2, 2, 3),  -- 삼건물 대회: 1등 경영야생마, 2등 서어뻬데뻬, 최다응원 서어뻬데뻬, 최다응원댓글 미컴축구생각
+       (2, 2, 4, 5, 4, 5),  -- 농구대잔치: 1등 새로운팀, 2등 새로운팀2, 최다응원 새로운팀, 최다응원댓글 새로운팀2
+       (3, 9, 6, 7, 6, 7);  -- 야구 대회: 1등 팀3, 2등 팀4, 최다응원 팀3, 최다응원댓글 팀4
 
 SET foreign_key_checks = 1;

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -93,7 +93,7 @@ VALUES (1, 3, 1, 0),   -- 미컴 축구생각 - 봄동나물진승희
        (10, 7, 10, 5); -- 팀4 - 정선수
 
 -- 게임 데이터
-INSERT INTO games (id, manager_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter, state, round)
+INSERT INTO games (id, administrator_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter, state, round)
 VALUES (1, 1, 1, '농구 대전', '2023-11-12T10:00:00', 'abc123', '2023-11-12T10:15:00', '1st Quarter', 'PLAYING', '4강'),
        (2, 1, 1, '두번째로 빠른 경기', '2023-11-12T10:10:00', 'abc123', '2023-11-12T10:10:00', '1st Quarter', 'SCHEDULED', '4강'),
        (3, 1, 1, '세번째로 빠른 경기', '2023-11-12T11:00:00', 'abc123', '2023-11-12T11:15:00', '1st Quarter', 'PLAYING', '4강'),


### PR DESCRIPTION
## 🌍 이슈 번호
#328 

## 📝 구현 내용
- 리그 통계 생성 구현 (결승전 종료 시 해당 팀 승자가 리그 우승자, 패자가 2위팀으로 자동으로 등록되게하고, 최다응원팀, 최다댓글팀도 등록 ) 및 테스트 코드 작성
<img width="337" height="408" alt="스크린샷 2025-08-05 오후 9 21 44" src="https://github.com/user-attachments/assets/e259aae4-3c2e-4ac8-8d47-f43a77225954" />


- 리그 통계 쿼리 부분 구현 및 테스트 코드 작성
- 리그 fixture sql쿼리문 수정

## 🍀 확인해야 할 부분
- GameServiceTest 부분에서 스케줄러 작동 테스트하는 부분에 LeagueStatisticsService은 Mock Bean으로 넣었는데 괜찮을까요? 해당 서비스는 LeagueServiceTest에서 작동을 테스트하여서 목으로 넣었습니다

- 득점왕 리스트는 또 따로 화면이 있길래 다른 api로 빼겠습니다