### PR TITLE
[REFACTOR] 팀 unit 등록, 수정, 필터링 요청을 한글로 변경

### DIFF
--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -3,10 +3,7 @@ package com.sports.server.command.team.application;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.player.domain.PlayerRepository;
 import com.sports.server.command.player.exception.PlayerErrorMessages;
-import com.sports.server.command.team.domain.Team;
-import com.sports.server.command.team.domain.TeamPlayer;
-import com.sports.server.command.team.domain.TeamPlayerRepository;
-import com.sports.server.command.team.domain.TeamRepository;
+import com.sports.server.command.team.domain.*;
 import com.sports.server.command.team.dto.TeamRequest;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.application.S3Service;
@@ -18,10 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -56,7 +50,10 @@ public class TeamService {
     public void update(final TeamRequest.Update request, final Long teamId) {
         Team team = entityUtils.getEntity(teamId, Team.class);
         s3Service.doesFileExist(team.getLogoImageUrl());
-        team.update(request.name(), request.logoImageUrl(), originPrefix, replacePrefix, request.unit(), request.teamColor());
+        Unit unit = Optional.ofNullable(request.unit())
+                .map(Unit::from)
+                .orElse(null);
+        team.update(request.name(), request.logoImageUrl(), originPrefix, replacePrefix, unit, request.teamColor());
     }
 
     public void delete(final Long teamId) {

--- a/src/main/java/com/sports/server/command/team/domain/Unit.java
+++ b/src/main/java/com/sports/server/command/team/domain/Unit.java
@@ -29,9 +29,9 @@ public enum Unit {
 
     private final String name;
 
-    public static Unit from(String englishName) {
+    public static Unit from(String koreanName) {
         return Stream.of(values())
-                .filter(u -> u.name().equals(englishName))
+                .filter(u -> u.getName().equals(koreanName))
                 .findFirst()
                 .orElseThrow(() -> new NotFoundException(TeamErrorMessages.UNIT_NOT_FOUND_EXCEPTION));
     }

--- a/src/main/java/com/sports/server/command/team/dto/TeamRequest.java
+++ b/src/main/java/com/sports/server/command/team/dto/TeamRequest.java
@@ -9,7 +9,7 @@ public class TeamRequest {
     public record Register(
             String name,
             String logoImageUrl,
-            Unit unit,
+            String unit,
             String teamColor,
             List<TeamPlayerRegister> teamPlayers
     ) {
@@ -17,7 +17,7 @@ public class TeamRequest {
             return Team.builder()
                     .name(this.name)
                     .logoImageUrl(logoImageUrl)
-                    .unit(this.unit)
+                    .unit(Unit.from(this.unit))
                     .teamColor(this.teamColor)
                     .build();
         }
@@ -26,7 +26,7 @@ public class TeamRequest {
     public record Update(
             String name,
             String logoImageUrl,
-            Unit unit,
+            String unit,
             String teamColor
     ) {}
 

--- a/src/main/java/com/sports/server/command/team/presentation/TeamController.java
+++ b/src/main/java/com/sports/server/command/team/presentation/TeamController.java
@@ -10,35 +10,34 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/teams")
 public class TeamController {
     private final TeamService teamService;
 
-    @PostMapping
+    @PostMapping("/teams")
     @ResponseStatus(HttpStatus.CREATED)
     public void register(@RequestBody TeamRequest.Register request) {
         teamService.register(request);
     }
 
-    @PatchMapping("/{teamId}")
+    @PatchMapping("/teams/{teamId}")
     @ResponseStatus(HttpStatus.OK)
     public void update(@RequestBody TeamRequest.Update request, @PathVariable Long teamId) {
         teamService.update(request, teamId);
     }
 
-    @DeleteMapping("/{teamId}")
+    @DeleteMapping("/teams/{teamId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long teamId) {
         teamService.delete(teamId);
     }
 
-    @PostMapping("/{teamId}/delete-logo")
+    @PostMapping("/teams/{teamId}/delete-logo")
     @ResponseStatus(HttpStatus.OK)
     public void deleteLogo(@PathVariable Long teamId) {
         teamService.deleteLogoImage(teamId);
     }
 
-    @PostMapping("/{teamId}/players")
+    @PostMapping("/teams/{teamId}/players")
     @ResponseStatus(HttpStatus.OK)
     public void addPlayersToTeam(@PathVariable Long teamId,
                           @RequestBody List<TeamRequest.TeamPlayerRegister> request){

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -5462,7 +5462,7 @@ Host: www.api.hufstreaming.site
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: HCC_SES=testAccessToken; Path=/; Max-Age=604800; Expires=Wed, 27 Aug 2025 17:14:11 GMT; Secure; HttpOnly; SameSite=Strict</code></pre>
+Set-Cookie: HCC_SES=testAccessToken; Path=/; Max-Age=604800; Expires=Fri, 29 Aug 2025 04:38:26 GMT; Secure; HttpOnly; SameSite=Strict</code></pre>
 </div>
 </div>
 </div>
@@ -5963,14 +5963,14 @@ Content-Length: 449
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /teams HTTP/1.1
 Content-Type: application/json
-Content-Length: 309
+Content-Length: 312
 Host: www.api.hufstreaming.site
 Cookie: HCC_SES=temp-cookie
 
 {
   "name" : "정치외교학과 PSD",
   "logoImageUrl" : "logo-image-url",
-  "unit" : "SOCIAL_SCIENCES",
+  "unit" : "사회과학대학",
   "teamColor" : "team-color",
   "teamPlayers" : [ {
     "playerId" : 1,
@@ -6036,7 +6036,7 @@ Cookie: HCC_SES=temp-cookie
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>unit</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">팀의 소속 (ENGLISH, OCCIDENTAL_LANGUAGES, ASIAN_LANGUAGES_AND_CULTURE, CHINESE_STUDIES, JAPANESE_STUDIES, SOCIAL_SCIENCES, BUSINESS_AND_ECONOMICS, BUSINESS, EDUCATION, AI_CONVERGENCE, INTERNATIONAL_STUDIES, LANGUAGE_AND_DIPLOMACY, LANGUAGE_AND_TRADE, KOREAN_AS_A_FOREIGN_LANGUAGE, LIBERAL_ARTS, ETC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">팀의 소속 (영어대학, 서양어대학, 아시아언어문화대학, 중국학대학, 일본어대학, 사회과학대학, 상경대학, 경영대학, 사범대학, AI융합대학, 국제학부, LD학부, LT학부, KFL학부, 자유전공학부, 기타)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>teamColor</code></p></td>
@@ -6155,14 +6155,14 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /teams/1 HTTP/1.1
 Content-Type: application/json
-Content-Length: 135
+Content-Length: 139
 Host: www.api.hufstreaming.site
 Cookie: HCC_SES=temp-cookie
 
 {
   "name" : "국제통상학과 무역풍",
   "logoImageUrl" : "logo-image-url",
-  "unit" : "BUSINESS",
+  "unit" : "경영대학",
   "teamColor" : "team-color"
 }</code></pre>
 </div>
@@ -6379,7 +6379,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <h4 id="_팀_선수_삭제_http_request"><a class="link" href="#_팀_선수_삭제_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /teams/team-players/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /team-players/1 HTTP/1.1
 Host: www.api.hufstreaming.site
 Cookie: HCC_SES=temp-cookie</code></pre>
 </div>
@@ -6409,7 +6409,7 @@ Cookie: HCC_SES=temp-cookie</code></pre>
 <div class="sect3">
 <h4 id="_팀_선수_삭제_path_parameters"><a class="link" href="#_팀_선수_삭제_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /teams/team-players/{teamPlayerId}</caption>
+<caption class="title">Table 1. /team-players/{teamPlayerId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -7044,7 +7044,7 @@ Content-Length: 1143
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-08-21 01:23:35 +0900
+Last updated 2025-08-22 11:44:12 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/sports/server/command/team/acceptance/TeamAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/team/acceptance/TeamAcceptanceTest.java
@@ -39,7 +39,7 @@ public class TeamAcceptanceTest extends AcceptanceTest {
         TeamRequest.Register request = new TeamRequest.Register(
                 "경영 야생마",
                 originPrefix + "logo-url",
-                Unit.BUSINESS,
+                "경영대학",
                 "#FF0000",
                 playersToRegister
         );
@@ -71,7 +71,7 @@ public class TeamAcceptanceTest extends AcceptanceTest {
         TeamRequest.Update request = new TeamRequest.Update(
                 "국제통상학과 무역풍",
                 originPrefix + "logo-url",
-                Unit.BUSINESS,
+                "경영대학",
                 "#FFFFFF"
         );
         configureMockJwtForEmail("john@example.com");

--- a/src/test/java/com/sports/server/command/team/application/TeamServiceTest.java
+++ b/src/test/java/com/sports/server/command/team/application/TeamServiceTest.java
@@ -3,6 +3,7 @@ package com.sports.server.command.team.application;
 import com.sports.server.command.player.exception.PlayerErrorMessages;
 import com.sports.server.command.team.domain.*;
 import com.sports.server.command.team.dto.TeamRequest;
+import com.sports.server.command.team.exception.TeamErrorMessages;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.application.S3Service;
 import com.sports.server.common.exception.CustomException;
@@ -62,12 +63,28 @@ public class TeamServiceTest extends ServiceTest {
                     new TeamRequest.TeamPlayerRegister(2L, 7));
 
             TeamRequest.Register request = new TeamRequest.Register("name", "invalid-logo-url",
-                    Unit.SOCIAL_SCIENCES,"color code", playerRegisterRequests);
+                    "사회과학대학","color code", playerRegisterRequests);
 
             // when & then
             assertThatThrownBy(() -> teamService.register(request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage("잘못된 이미지 url 입니다.");
+        }
+
+        @Test
+        void 존재하지_않는_단위를_요청할_경우_예외가_발생한다() {
+            // given
+            List<TeamRequest.TeamPlayerRegister> playerRegisterRequests = List.of(
+                    new TeamRequest.TeamPlayerRegister(1L, 10),
+                    new TeamRequest.TeamPlayerRegister(2L, 7));
+
+            TeamRequest.Register request = new TeamRequest.Register("name", imageUrl,
+                    "invalid unit","color code", playerRegisterRequests);
+
+            // when & then
+            assertThatThrownBy(() -> teamService.register(request))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(TeamErrorMessages.UNIT_NOT_FOUND_EXCEPTION);
         }
     }
 
@@ -116,6 +133,18 @@ public class TeamServiceTest extends ServiceTest {
             // when & then
             assertThatThrownBy(() -> teamService.update(request, teamId))
                     .isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        void 존재하지_않는_단위를_요청할_경우_예외가_발생한다(){
+            // given
+            Long teamId =  1L;
+            TeamRequest.Update request = new TeamRequest.Update(null, null, "invalid unit", null);
+
+            // when & then
+            assertThatThrownBy(() -> teamService.update(request, teamId))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage(TeamErrorMessages.UNIT_NOT_FOUND_EXCEPTION);
         }
     }
 

--- a/src/test/java/com/sports/server/command/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/sports/server/command/team/presentation/TeamControllerTest.java
@@ -38,7 +38,7 @@ public class TeamControllerTest extends DocumentationTest {
         TeamRequest.Register request = new TeamRequest.Register(
                 "정치외교학과 PSD",
                 "logo-image-url",
-                Unit.SOCIAL_SCIENCES,
+                "사회과학대학",
                 "team-color",
                 teamPlayersRequest
         );
@@ -57,11 +57,8 @@ public class TeamControllerTest extends DocumentationTest {
                                 requestFields(
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("팀 이름"),
                                         fieldWithPath("logoImageUrl").type(JsonFieldType.STRING).description("팀의 로고 이미지 url"),
-                                        fieldWithPath("unit").type(JsonFieldType.STRING).description("팀의 소속 (ENGLISH, OCCIDENTAL_LANGUAGES," +
-                                                " ASIAN_LANGUAGES_AND_CULTURE, CHINESE_STUDIES, JAPANESE_STUDIES," +
-                                                " SOCIAL_SCIENCES, BUSINESS_AND_ECONOMICS, BUSINESS, EDUCATION," +
-                                                " AI_CONVERGENCE, INTERNATIONAL_STUDIES, LANGUAGE_AND_DIPLOMACY," +
-                                                " LANGUAGE_AND_TRADE, KOREAN_AS_A_FOREIGN_LANGUAGE, LIBERAL_ARTS, ETC)"),
+                                        fieldWithPath("unit").type(JsonFieldType.STRING).description("팀의 소속 (영어대학, 서양어대학, 아시아언어문화대학, 중국학대학," +
+                                                " 일본어대학, 사회과학대학, 상경대학, 경영대학, 사범대학, AI융합대학, 국제학부, LD학부, LT학부, KFL학부, 자유전공학부, 기타)"),
                                         fieldWithPath("teamColor").type(JsonFieldType.STRING).description("팀의 대표 색의 hexCode"),
                                         fieldWithPath("teamPlayers").type(JsonFieldType.ARRAY).description("팀에 추가할 선수들 목록 (없다면 빈 리스트)"),
                                         fieldWithPath("teamPlayers[].playerId").type(JsonFieldType.NUMBER).description("추가할 선수의 Id"),
@@ -107,7 +104,7 @@ public class TeamControllerTest extends DocumentationTest {
         TeamRequest.Update request = new TeamRequest.Update(
                 "국제통상학과 무역풍",
                 "logo-image-url",
-                Unit.BUSINESS,
+                "경영대학",
                 "team-color"
         );
 
@@ -181,7 +178,7 @@ public class TeamControllerTest extends DocumentationTest {
         doNothing().when(teamService).deleteTeamPlayer(anyLong());
 
         // when
-        ResultActions result = mockMvc.perform(delete("/teams/team-players/{teamPlayerId}", teamPlayerId)
+        ResultActions result = mockMvc.perform(delete("/team-players/{teamPlayerId}", teamPlayerId)
                 .cookie(new Cookie(COOKIE_NAME, "temp-cookie")));
 
         // then

--- a/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
@@ -40,7 +40,7 @@ public class TeamQueryServiceTest extends ServiceTest {
         @Test
         void 하나의_단위로_필터링하여_조회한다() {
             // given
-            List<String> units = List.of("SOCIAL_SCIENCES");
+            List<String> units = List.of("사회과학대학");
 
             // when
             List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(units);
@@ -56,7 +56,7 @@ public class TeamQueryServiceTest extends ServiceTest {
         @Test
         void 여러_단위로_필터링하여_조회한다() {
             // given
-            List<String> units = List.of("SOCIAL_SCIENCES", "ETC");
+            List<String> units = List.of("사회과학대학", "기타");
 
             // when
             List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(units);
@@ -70,7 +70,7 @@ public class TeamQueryServiceTest extends ServiceTest {
         @Test
         void 존재하지_않는_단위로_필터링하면_예외가_발생한다() {
             // given
-            List<String> units = List.of("INVALID_UNIT");
+            List<String> units = List.of("INVALID UNIT");
 
             // when & then
             assertThatThrownBy(() -> teamQueryService.getAllTeamsByUnits(units))

--- a/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
@@ -26,7 +26,7 @@ public class TeamQueryControllerTest extends DocumentationTest {
     @Test
     void 모든_팀을_단위별로_조회한다() throws Exception {
         // given
-        List<String> units = List.of("SOCIAL_SCIENCES", "ENGLISH");
+        List<String> units = List.of("사회과학대학", "영어대학");
         List<TeamResponse> response = List.of(
                 new TeamResponse(1L, "정치외교학과 PSD", "s3:logoImageUrl1", "사회과학대학", "#F7CAC9"),
                 new TeamResponse(2L, "국제통상학과 무역풍", "s3:logoImageUrl2", "사회과학대학", "#92A8D1"),
@@ -37,19 +37,16 @@ public class TeamQueryControllerTest extends DocumentationTest {
 
         // when
         ResultActions result = mockMvc.perform(get("/teams")
-                .param("units", "SOCIAL_SCIENCES", "ENGLISH")
+                .param("units", "사회과학대학", "영어대학")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
         result.andExpect((status().isOk()))
                 .andDo(restDocsHandler.document(
                         queryParameters(
-                                parameterWithName("units").description("필터링할 소속 단위 리스트 (ENGLISH, OCCIDENTAL_LANGUAGES," +
-                                        " ASIAN_LANGUAGES_AND_CULTURE, CHINESE_STUDIES," +
-                                        " JAPANESE_STUDIES, SOCIAL_SCIENCES, BUSINESS_AND_ECONOMICS," +
-                                        " BUSINESS, EDUCATION, AI_CONVERGENCE, INTERNATIONAL_STUDIES," +
-                                        " LANGUAGE_AND_DIPLOMACY, LANGUAGE_AND_TRADE, KOREAN_AS_A_FOREIGN_LANGUAGE," +
-                                        " LIBERAL_ARTS, ETC)").optional()
+                                parameterWithName("units").description("필터링할 소속 리스트 (영어대학, 서양어대학, 아시아언어문화대학," +
+                                        " 중국학대학, 일본어대학, 사회과학대학, 상경대학, 경영대학, 사범대학, AI융합대학, 국제학부, LD학부, LT학부," +
+                                        " KFL학부, 자유전공학부, 기타)").optional()
                         ),
                         responseFields(
                                 fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("팀의 ID"),


### PR DESCRIPTION
## 🌍 이슈 번호
#352 

## 📝 구현 내용
- 팀 생성, 수정 로직 변경
- 팀 조회 시 유닛 필터링 로직 변경

