### PR TITLE
[FEATURE] '이전 리그'에 필요한 리그 통계, 득점왕 구현

### DIFF
--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.league.application.LeagueStatisticsService;
+import com.sports.server.command.league.application.LeagueTopScorerService;
 import com.sports.server.command.league.domain.Round;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,6 +17,7 @@ public class GameStatusScheduler {
 
     private final GameService gameService;
     private final LeagueStatisticsService leagueStatisticsService;
+    private final LeagueTopScorerService leagueTopScorerService;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void scheduleUpdateGameStatusToFinish() {
@@ -27,6 +29,9 @@ public class GameStatusScheduler {
     private void updateLeagueStatisticsForFinalGames(List<Game> finishedGames) {
         finishedGames.stream()
                 .filter(game -> Round.FINAL.equals(game.getRound()) && game.getLeague() != null)
-                .forEach(leagueStatisticsService::updateLeagueStatisticFromFinalGame);
+                .forEach(game -> {
+                    leagueStatisticsService.updateLeagueStatisticFromFinalGame(game);
+                    leagueTopScorerService.updateTopScorersForLeague(game.getLeague().getId());
+                });
     }
 }

--- a/src/main/java/com/sports/server/command/league/application/LeagueStatisticsService.java
+++ b/src/main/java/com/sports/server/command/league/application/LeagueStatisticsService.java
@@ -5,6 +5,7 @@ import com.sports.server.command.game.domain.GameResult;
 import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.league.domain.*;
 import com.sports.server.command.team.domain.Team;
+import com.sports.server.query.repository.GameTeamQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ import static com.sports.server.command.game.domain.Game.MINIMUM_TEAMS;
 public class LeagueStatisticsService {
     private final LeagueStatisticsRepository leagueStatisticsRepository;
     private final LeagueTeamRepository leagueTeamRepository;
+    private final GameTeamQueryRepository gameTeamQueryRepository;
 
     @Transactional
     public void updateLeagueStatisticFromFinalGame(Game finalGame) {
@@ -48,7 +50,7 @@ public class LeagueStatisticsService {
     }
 
     private void updateWinnerTeamsFromGame(Game finalGame, LeagueStatistics leagueStatistic) {
-        List<GameTeam> teams = finalGame.getGameTeams();
+        List<GameTeam> teams = gameTeamQueryRepository.findAllByGame(finalGame);
         if (teams.size() < MINIMUM_TEAMS) {
             return;
         }
@@ -75,7 +77,7 @@ public class LeagueStatisticsService {
     }
 
     private void updateMostCheeredAndTalkedTeams(League league, LeagueStatistics leagueStatistic) {
-        List<LeagueTeam> leagueTeams = league.getLeagueTeams();
+        List<LeagueTeam> leagueTeams = leagueTeamRepository.findByLeagueId(league.getId());
         if (leagueTeams.isEmpty()) {
             return;
         }

--- a/src/main/java/com/sports/server/command/league/application/LeagueTopScorerService.java
+++ b/src/main/java/com/sports/server/command/league/application/LeagueTopScorerService.java
@@ -1,0 +1,55 @@
+package com.sports.server.command.league.application;
+
+import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.LeagueRepository;
+import com.sports.server.command.league.domain.LeagueTopScorer;
+import com.sports.server.command.league.domain.LeagueTopScorerRepository;
+import com.sports.server.command.player.domain.PlayerRepository;
+import com.sports.server.command.team.domain.PlayerGoalCountWithRank;
+import com.sports.server.query.support.PlayerInfoProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LeagueTopScorerService {
+
+    private final LeagueTopScorerRepository leagueTopScorerRepository;
+    private final LeagueRepository leagueRepository;
+    private final PlayerRepository playerRepository;
+    private final PlayerInfoProvider playerInfoProvider;
+
+    public void updateTopScorersForLeague(Long leagueId) {
+        League league = leagueRepository.findWithTeamsById(leagueId)
+                .orElseThrow(() -> new IllegalArgumentException("League not found: " + leagueId));
+
+        List<PlayerGoalCountWithRank> topScorers = playerInfoProvider.getLeagueTop20Scorers(leagueId);
+        
+        leagueTopScorerRepository.deleteByLeagueId(leagueId);
+
+        List<Long> playerIds = topScorers.stream()
+                .map(PlayerGoalCountWithRank::playerId)
+                .toList();
+        
+        List<com.sports.server.command.player.domain.Player> players = playerRepository.findAllById(playerIds);
+
+        for (PlayerGoalCountWithRank scorerData : topScorers) {
+            com.sports.server.command.player.domain.Player player = players.stream()
+                    .filter(p -> p.getId().equals(scorerData.playerId()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("Player not found: " + scorerData.playerId()));
+
+            LeagueTopScorer topScorer = new LeagueTopScorer(
+                    league,
+                    player,
+                    scorerData.rank().intValue(),
+                    scorerData.goalCount().intValue()
+            );
+            leagueTopScorerRepository.save(topScorer);
+        }
+    }
+}

--- a/src/main/java/com/sports/server/command/league/domain/LeagueTeamRepository.java
+++ b/src/main/java/com/sports/server/command/league/domain/LeagueTeamRepository.java
@@ -9,7 +9,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface LeagueTeamRepository extends JpaRepository<LeagueTeam, Long> {
-    Optional<LeagueTeam> findByLeagueAndTeam(League league, Team team);
+    @Query("SELECT lt FROM LeagueTeam lt WHERE lt.league = :league AND lt.team = :team")
+    Optional<LeagueTeam> findByLeagueAndTeam(@Param("league") League league, @Param("team") Team team);
 
     @Query("SELECT lt.team.id FROM LeagueTeam lt WHERE lt.league.id = :leagueId AND lt.team.id IN :teamIds")
     List<Long> findTeamIdsByLeagueIdAndTeamIdIn(@Param("leagueId") Long leagueId, @Param("teamIds") List<Long> teamIds);
@@ -20,4 +21,6 @@ public interface LeagueTeamRepository extends JpaRepository<LeagueTeam, Long> {
 
     @Query("SELECT lt.team.id FROM LeagueTeam lt WHERE lt.league.id = :leagueId")
     List<Long> findTeamIdsByLeagueId(@Param("leagueId") Long leagueId);
+
+    List<LeagueTeam> findByLeagueId(Long id);
 }

--- a/src/main/java/com/sports/server/command/league/domain/LeagueTopScorerRepository.java
+++ b/src/main/java/com/sports/server/command/league/domain/LeagueTopScorerRepository.java
@@ -1,0 +1,15 @@
+package com.sports.server.command.league.domain;
+
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface LeagueTopScorerRepository extends Repository<LeagueTopScorer, Long> {
+    LeagueTopScorer save(LeagueTopScorer leagueTopScorer);
+    
+    void delete(LeagueTopScorer leagueTopScorer);
+    
+    List<LeagueTopScorer> findByLeagueId(Long leagueId);
+    
+    void deleteByLeagueId(Long leagueId);
+}

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import com.sports.server.query.support.PlayerInfoProvider;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -135,21 +133,30 @@ public class LeagueQueryService {
                 .leagueStatisticsId(statistics.getId())
                 .firstWinnerTeam(new TeamResponse(statistics.getFirstWinnerTeam()))
                 .secondWinnerTeam(new TeamResponse(statistics.getSecondWinnerTeam()))
-                .mostCheeredTeam(createLeagueTeamResponse(statistics.getMostCheeredTeam(), leagueTeams))
-                .mostCheerTalksTeam(createLeagueTeamResponse(statistics.getMostCheerTalksTeam(), leagueTeams))
+                .mostCheeredTeam(createLeagueTeamResponseWithCheerCount(statistics.getMostCheeredTeam(), leagueTeams))
+                .mostCheerTalksTeam(createLeagueTeamResponseWithTotalTalkCount(statistics.getMostCheerTalksTeam(), leagueTeams))
                 .build();
     }
 
-    private LeagueTeamResponse createLeagueTeamResponse(Team team, List<LeagueTeam> leagueTeams) {
+    private LeagueTeamResponse createLeagueTeamResponseWithCheerCount(Team team, List<LeagueTeam> leagueTeams) {
         LeagueTeam leagueTeam = leagueTeams.stream()
                 .filter(lt -> lt.getTeam().equals(team))
                 .findFirst()
-                .orElseThrow(() -> new NotFoundException("LeagueTeam not found"));
+                .orElseThrow(() -> new NotFoundException("리그팀을 찾을 수 없습니다"));
 
-        return new LeagueTeamResponse(leagueTeam);
+        return LeagueTeamResponse.ofWithCheerCount(leagueTeam);
     }
 
-    public List<LeagueTopScorerResponse> findTopScorersByLeagueId(Long leagueId) {
+    private LeagueTeamResponse createLeagueTeamResponseWithTotalTalkCount(Team team, List<LeagueTeam> leagueTeams) {
+        LeagueTeam leagueTeam = leagueTeams.stream()
+                .filter(lt -> lt.getTeam().equals(team))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("리그팀을 찾을 수 없습니다"));
+
+        return LeagueTeamResponse.ofWithTotalTalkCount(leagueTeam);
+    }
+
+    public List<LeagueTopScorerResponse> findTop20ScorersByLeagueId(Long leagueId) {
         return leagueTopScorerRepository.findByLeagueId(leagueId)
                 .stream()
                 .map(LeagueTopScorerResponse::from)

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -6,13 +6,13 @@ import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.league.domain.*;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.team.domain.Team;
-
 import com.sports.server.command.team.domain.TeamPlayer;
 import com.sports.server.command.team.domain.TeamPlayerRepository;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.exception.NotFoundException;
 
 import com.sports.server.query.dto.response.*;
+import com.sports.server.query.dto.response.LeagueTopScorerResponse;
 import com.sports.server.query.repository.*;
 
 import java.time.LocalDateTime;
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import com.sports.server.query.support.PlayerInfoProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +42,7 @@ public class LeagueQueryService {
     private final TeamPlayerRepository teamPlayerRepository;
     private final LeagueTeamQueryRepository leagueTeamQueryRepository;
     private final PlayerInfoProvider playerInfoProvider;
+    private final LeagueTopScorerRepository leagueTopScorerRepository;
 
     public List<LeagueResponse> findLeagues(Integer year) {
         return leagueQueryRepository.findByYear(year)
@@ -144,6 +147,13 @@ public class LeagueQueryService {
                 .orElseThrow(() -> new NotFoundException("LeagueTeam not found"));
 
         return new LeagueTeamResponse(leagueTeam);
+    }
+
+    public List<LeagueTopScorerResponse> findTopScorersByLeagueId(Long leagueId) {
+        return leagueTopScorerRepository.findByLeagueId(leagueId)
+                .stream()
+                .map(LeagueTopScorerResponse::from)
+                .toList();
     }
 
     public static Map<String, Integer> leagueProgressOrderMap = Map.ofEntries(

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -3,10 +3,7 @@ package com.sports.server.query.application;
 import static java.util.stream.Collectors.toMap;
 
 import com.sports.server.command.game.domain.Game;
-import com.sports.server.command.league.domain.League;
-import com.sports.server.command.league.domain.LeagueProgress;
-import com.sports.server.command.league.domain.LeagueTeam;
-import com.sports.server.command.league.domain.LeagueTeamRepository;
+import com.sports.server.command.league.domain.*;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.team.domain.Team;
 
@@ -127,27 +124,27 @@ public class LeagueQueryService {
                 .toList();
     }
 
-//    public LeagueStatisticsResponse findLeagueStatistic(Long leagueId) {
-//        LeagueStatistics statistics = leagueStatisticsQueryRepository.findByLeagueId(leagueId);
-//        List<LeagueTeam> leagueTeams = leagueTeamQueryRepository.findByLeagueId(leagueId);
-//
-//        return LeagueStatisticsResponse.builder()
-//                .leagueStatisticsId(statistics.getId())
-//                .firstWinnerTeam(TeamResponse.from(statistics.getFirstWinnerTeam()))
-//                .secondWinnerTeam(TeamResponse.from(statistics.getSecondWinnerTeam()))
-//                .mostCheeredTeam(createTeamResponseWithStats(statistics.getMostCheeredTeam(), leagueTeams))
-//                .mostCheerTalksTeam(createTeamResponseWithStats(statistics.getMostCheerTalksTeam(), leagueTeams))
-//                .build();
-//    }
+    public LeagueStatisticsResponse findLeagueStatistic(Long leagueId) {
+        LeagueStatistics statistics = leagueStatisticsQueryRepository.findByLeagueId(leagueId);
+        List<LeagueTeam> leagueTeams = leagueTeamQueryRepository.findByLeagueId(leagueId);
 
-//    private TeamResponse createTeamResponseWithStats(Team team, List<LeagueTeam> leagueTeams) {
-//        LeagueTeam leagueTeam = leagueTeams.stream()
-//                .filter(lt -> lt.getTeam().equals(team))
-//                .findFirst()
-//                .orElseThrow(() -> new NotFoundException("LeagueTeam not found"));
-//
-//        return TeamResponse.from(leagueTeam);
-//    }
+        return LeagueStatisticsResponse.builder()
+                .leagueStatisticsId(statistics.getId())
+                .firstWinnerTeam(new TeamResponse(statistics.getFirstWinnerTeam()))
+                .secondWinnerTeam(new TeamResponse(statistics.getSecondWinnerTeam()))
+                .mostCheeredTeam(createLeagueTeamResponse(statistics.getMostCheeredTeam(), leagueTeams))
+                .mostCheerTalksTeam(createLeagueTeamResponse(statistics.getMostCheerTalksTeam(), leagueTeams))
+                .build();
+    }
+
+    private LeagueTeamResponse createLeagueTeamResponse(Team team, List<LeagueTeam> leagueTeams) {
+        LeagueTeam leagueTeam = leagueTeams.stream()
+                .filter(lt -> lt.getTeam().equals(team))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("LeagueTeam not found"));
+
+        return new LeagueTeamResponse(leagueTeam);
+    }
 
     public static Map<String, Integer> leagueProgressOrderMap = Map.ofEntries(
             Map.entry(LeagueProgress.IN_PROGRESS.getDescription(), 1),

--- a/src/main/java/com/sports/server/query/dto/response/LeagueStatisticsResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueStatisticsResponse.java
@@ -7,7 +7,7 @@ public record LeagueStatisticsResponse(
         Long leagueStatisticsId,
         TeamResponse firstWinnerTeam,
         TeamResponse secondWinnerTeam,
-        TeamResponse mostCheeredTeam,
-        TeamResponse mostCheerTalksTeam
+        LeagueTeamResponse mostCheeredTeam,
+        LeagueTeamResponse mostCheerTalksTeam
 ) {
 }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueTeamResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueTeamResponse.java
@@ -1,5 +1,6 @@
 package com.sports.server.query.dto.response;
 
+import com.sports.server.command.league.domain.LeagueTeam;
 import com.sports.server.command.team.domain.Team;
 
 public record LeagueTeamResponse(
@@ -7,12 +8,27 @@ public record LeagueTeamResponse(
         Long leagueTeamId,
         String teamName,
         String logoImageUrl,
-        Integer sizeOfTeamPlayers
+        Integer sizeOfTeamPlayers,
+        Integer cheerCount,
+        Integer cheerTalksCount
 ) {
     public LeagueTeamResponse(final Team team, final Long leagueTeamId) {
         this(
                 team.getId(), leagueTeamId, team.getName(),
-                team.getLogoImageUrl(), team.getTeamPlayers().size()
+                team.getLogoImageUrl(), team.getTeamPlayers().size(),
+                0, 0
+        );
+    }
+
+    public LeagueTeamResponse(final LeagueTeam leagueTeam) {
+        this(
+                leagueTeam.getTeam().getId(),
+                leagueTeam.getId(),
+                leagueTeam.getTeam().getName(),
+                leagueTeam.getTeam().getLogoImageUrl(),
+                leagueTeam.getTeam().getTeamPlayers().size(),
+                leagueTeam.getTotalCheerCount(),
+                leagueTeam.getTotalTalkCount()
         );
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueTeamResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueTeamResponse.java
@@ -1,8 +1,10 @@
 package com.sports.server.query.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sports.server.command.league.domain.LeagueTeam;
 import com.sports.server.command.team.domain.Team;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record LeagueTeamResponse(
         Long teamId,
         Long leagueTeamId,
@@ -16,18 +18,30 @@ public record LeagueTeamResponse(
         this(
                 team.getId(), leagueTeamId, team.getName(),
                 team.getLogoImageUrl(), team.getTeamPlayers().size(),
-                0, 0
+                null, null
         );
     }
 
-    public LeagueTeamResponse(final LeagueTeam leagueTeam) {
-        this(
+    public static LeagueTeamResponse ofWithCheerCount(final LeagueTeam leagueTeam) {
+        return new LeagueTeamResponse(
                 leagueTeam.getTeam().getId(),
                 leagueTeam.getId(),
                 leagueTeam.getTeam().getName(),
                 leagueTeam.getTeam().getLogoImageUrl(),
                 leagueTeam.getTeam().getTeamPlayers().size(),
                 leagueTeam.getTotalCheerCount(),
+                null
+        );
+    }
+
+    public static LeagueTeamResponse ofWithTotalTalkCount(final LeagueTeam leagueTeam) {
+        return new LeagueTeamResponse(
+                leagueTeam.getTeam().getId(),
+                leagueTeam.getId(),
+                leagueTeam.getTeam().getName(),
+                leagueTeam.getTeam().getLogoImageUrl(),
+                leagueTeam.getTeam().getTeamPlayers().size(),
+                null,
                 leagueTeam.getTotalTalkCount()
         );
     }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueTopScorerResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueTopScorerResponse.java
@@ -9,13 +9,26 @@ public record LeagueTopScorerResponse(
         Integer ranking,
         Integer goalCount
 ) {
+    private static final int ADMISSION_YEAR_START_INDEX = 2;
+    private static final int ADMISSION_YEAR_END_INDEX = 4;
+
     public static LeagueTopScorerResponse from(LeagueTopScorer leagueTopScorer) {
+        String studentNumber = leagueTopScorer.getPlayer().getStudentNumber();
+        String admissionYear = extractAdmissionYear(studentNumber);
+
         return new LeagueTopScorerResponse(
                 leagueTopScorer.getPlayer().getId(),
                 leagueTopScorer.getPlayer().getName(),
-                leagueTopScorer.getPlayer().getStudentNumber(),
+                admissionYear,
                 leagueTopScorer.getRanking(),
                 leagueTopScorer.getGoalCount()
         );
+    }
+
+    private static String extractAdmissionYear(String studentNumber) {
+        if (studentNumber == null || studentNumber.length() < ADMISSION_YEAR_END_INDEX) {
+            return null;
+        }
+        return studentNumber.substring(ADMISSION_YEAR_START_INDEX, ADMISSION_YEAR_END_INDEX);
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueTopScorerResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueTopScorerResponse.java
@@ -1,0 +1,21 @@
+package com.sports.server.query.dto.response;
+
+import com.sports.server.command.league.domain.LeagueTopScorer;
+
+public record LeagueTopScorerResponse(
+        Long playerId,
+        String playerName,
+        String studentNumber,
+        Integer ranking,
+        Integer goalCount
+) {
+    public static LeagueTopScorerResponse from(LeagueTopScorer leagueTopScorer) {
+        return new LeagueTopScorerResponse(
+                leagueTopScorer.getPlayer().getId(),
+                leagueTopScorer.getPlayer().getName(),
+                leagueTopScorer.getPlayer().getStudentNumber(),
+                leagueTopScorer.getRanking(),
+                leagueTopScorer.getGoalCount()
+        );
+    }
+}

--- a/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
@@ -42,6 +42,11 @@ public class LeagueQueryController {
         return ResponseEntity.ok(leagueQueryService.findLeagueStatistic(leagueId));
     }
 
+    @GetMapping("/{leagueId}/top-scorers")
+    public ResponseEntity<List<LeagueTopScorerResponse>> findTopScorersByLeague(@PathVariable Long leagueId) {
+        return ResponseEntity.ok(leagueQueryService.findTopScorersByLeagueId(leagueId));
+    }
+
     @GetMapping("/teams/{leagueTeamId}/players")
     public ResponseEntity<List<PlayerResponse>> findPlayersByLeagueTeam(@PathVariable Long leagueTeamId) {
         return ResponseEntity.ok(leagueQueryService.findPlayersByLeagueTeam(leagueTeamId));

--- a/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
@@ -44,7 +44,7 @@ public class LeagueQueryController {
 
     @GetMapping("/{leagueId}/top-scorers")
     public ResponseEntity<List<LeagueTopScorerResponse>> findTopScorersByLeague(@PathVariable Long leagueId) {
-        return ResponseEntity.ok(leagueQueryService.findTopScorersByLeagueId(leagueId));
+        return ResponseEntity.ok(leagueQueryService.findTop20ScorersByLeagueId(leagueId));
     }
 
     @GetMapping("/teams/{leagueTeamId}/players")

--- a/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
@@ -37,12 +37,11 @@ public class LeagueQueryController {
         return ResponseEntity.ok(leagueQueryService.findLeagueDetail(leagueId));
     }
 
-    // TODO: 필요없으면 삭제
-//    @GetMapping("/{leagueId}/statistics")
-//    public ResponseEntity<LeagueStatisticsResponse> findLeagueStatistics(@PathVariable Long leagueId) {
-//        return ResponseEntity.ok(leagueQueryService.findLeagueStatistic(leagueId));
-//    }
-//
+    @GetMapping("/{leagueId}/statistics")
+    public ResponseEntity<LeagueStatisticsResponse> findLeagueStatistics(@PathVariable Long leagueId) {
+        return ResponseEntity.ok(leagueQueryService.findLeagueStatistic(leagueId));
+    }
+
     @GetMapping("/teams/{leagueTeamId}/players")
     public ResponseEntity<List<PlayerResponse>> findPlayersByLeagueTeam(@PathVariable Long leagueTeamId) {
         return ResponseEntity.ok(leagueQueryService.findPlayersByLeagueTeam(leagueTeamId));

--- a/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
@@ -44,4 +44,21 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             "ORDER BY COUNT(st.id) DESC, p.name ASC")
     List<PlayerGoalCountWithRank> findTopScorersByTeamId(@Param("teamId") Long teamId, Pageable pageable);
 
+    @Query("SELECT new com.sports.server.command.team.domain.PlayerGoalCountWithRank(" +
+            "       p.id, " +
+            "       p.studentNumber, " +
+            "       p.name, " +
+            "       COUNT(st.id), " +
+            "       RANK() OVER (ORDER BY COUNT(st.id) DESC)) " +
+            "FROM ScoreTimeline st " +
+            "JOIN st.scorer sc " +
+            "JOIN sc.player p " +
+            "JOIN p.teamPlayers tp " +
+            "JOIN tp.team t " +
+            "WHERE t.league.id = :leagueId " +
+            "GROUP BY p.id, p.studentNumber, p.name " +
+            "HAVING COUNT(st.id) > 0 " +
+            "ORDER BY COUNT(st.id) DESC, p.name ASC")
+    List<PlayerGoalCountWithRank> findTopScorersByLeagueId(@Param("leagueId") Long leagueId, Pageable pageable);
+
 }

--- a/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
@@ -55,7 +55,8 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             "JOIN sc.player p " +
             "JOIN p.teamPlayers tp " +
             "JOIN tp.team t " +
-            "WHERE t.league.id = :leagueId " +
+            "JOIN t.leagueTeams lt " +
+            "WHERE lt.league.id = :leagueId " +
             "GROUP BY p.id, p.studentNumber, p.name " +
             "HAVING COUNT(st.id) > 0 " +
             "ORDER BY COUNT(st.id) DESC, p.name ASC")

--- a/src/main/java/com/sports/server/query/support/PlayerInfoProvider.java
+++ b/src/main/java/com/sports/server/query/support/PlayerInfoProvider.java
@@ -38,4 +38,9 @@ public class PlayerInfoProvider {
         Pageable top20Request = PageRequest.of(0, 20);
         return timelineQueryRepository.findTopScorersByTeamId(teamId, top20Request);
     }
+
+    public List<PlayerGoalCountWithRank> getLeagueTop20Scorers(Long leagueId) {
+        Pageable top20Request = PageRequest.of(0, 20);
+        return timelineQueryRepository.findTopScorersByLeagueId(leagueId, top20Request);
+    }
 }

--- a/src/test/java/com/sports/server/command/league/application/LeagueStatisticsServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueStatisticsServiceTest.java
@@ -1,138 +1,138 @@
-//package com.sports.server.command.league.application;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.assertj.core.api.Assertions.assertThatThrownBy;
-//
-//import com.sports.server.command.game.domain.Game;
-//import com.sports.server.command.league.domain.League;
-//import com.sports.server.command.league.domain.LeagueStatistics;
-//import com.sports.server.command.league.domain.LeagueStatisticsRepository;
-//import com.sports.server.command.league.domain.LeagueTeam;
-//import com.sports.server.command.league.domain.LeagueTeamRepository;
-//import com.sports.server.command.team.domain.Team;
-//import com.sports.server.common.application.EntityUtils;
-//import com.sports.server.support.ServiceTest;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.test.context.jdbc.Sql;
-//
-//@Sql("/league-fixture.sql")
-//public class LeagueStatisticsServiceTest extends ServiceTest {
-//
-//    @Autowired
-//    private LeagueStatisticsService leagueStatisticsService;
-//
-//    @Autowired
-//    private LeagueStatisticsRepository leagueStatisticsRepository;
-//
-//    @Autowired
-//    private LeagueTeamRepository leagueTeamRepository;
-//
-//    @Autowired
-//    private EntityUtils entityUtils;
-//
-//    @Nested
-//    @DisplayName("최종 게임으로부터 리그 통계를 업데이트할 때")
-//    class UpdateLeagueStatisticFromFinalGameTest {
-//
-//        @Test
-//        @DisplayName("유효한 게임이 주어지면 리그 통계가 업데이트된다")
-//        void 유효한_게임이_주어지면_리그_통계가_업데이트된다() {
-//            // given
-//            Game finalGame = entityUtils.getEntity(1L, Game.class);
-//            League league = finalGame.getLeague();
-//
-//            // when
-//            leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGame);
-//
-//            // then
-//            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
-//            assertThat(statistics).isNotNull();
-//        }
-//
-//        @Test
-//        @DisplayName("승리팀과 준우승팀이 올바르게 업데이트된다")
-//        void 승리팀과_준우승팀이_올바르게_업데이트된다() {
-//            // given
-//            Game finalGame = entityUtils.getEntity(1L, Game.class);
-//            League league = finalGame.getLeague();
-//
-//            // when
-//            leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGame);
-//
-//            // then
-//            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
-//            assertThat(statistics.getFirstWinnerTeam()).isNotNull();
-//            assertThat(statistics.getSecondWinnerTeam()).isNotNull();
-//
-//            // 승리팀의 랭킹이 1위로 업데이트되었는지 확인
-//            Team winnerTeam = statistics.getFirstWinnerTeam();
-//            LeagueTeam winnerLeagueTeam = leagueTeamRepository.findByLeagueAndTeam(league, winnerTeam).orElse(null);
-//            assertThat(winnerLeagueTeam).isNotNull();
-//            assertThat(winnerLeagueTeam.getRanking()).isEqualTo(1);
-//
-//            // 준우승팀의 랭킹이 2위로 업데이트되었는지 확인
-//            Team secondTeam = statistics.getSecondWinnerTeam();
-//            LeagueTeam secondLeagueTeam = leagueTeamRepository.findByLeagueAndTeam(league, secondTeam).orElse(null);
-//            assertThat(secondLeagueTeam).isNotNull();
-//            assertThat(secondLeagueTeam.getRanking()).isEqualTo(2);
-//        }
-//
-//        @Test
-//        @DisplayName("최다 응원팀과 최다 대화팀이 올바르게 업데이트된다")
-//        void 최다_응원팀과_최다_대화팀이_올바르게_업데이트된다() {
-//            // given
-//            Game finalGame = entityUtils.getEntity(1L, Game.class);
-//            League league = finalGame.getLeague();
-//
-//            // when
-//            leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGame);
-//
-//            // then
-//            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
-//            assertThat(statistics.getMostCheeredTeam()).isNotNull();
-//            assertThat(statistics.getMostCheerTalksTeam()).isNotNull();
-//        }
-//
-//        @Test
-//        @DisplayName("게임이 null이면 예외가 발생한다")
-//        void 게임이_null이면_예외가_발생한다() {
-//            // when & then
-//            assertThatThrownBy(() -> leagueStatisticsService.updateLeagueStatisticFromFinalGame(null))
-//                    .isInstanceOf(IllegalArgumentException.class)
-//                    .hasMessage("유효한 게임 또는 리그 정보가 없습니다.");
-//        }
-//
-//        @Test
-//        @DisplayName("게임에 리그 정보가 없으면 예외가 발생한다")
-//        void 게임에_리그_정보가_없으면_예외가_발생한다() {
-//            // given
-//            Game gameWithoutLeague = Game.builder()
-//                    .league(null)
-//                    .build();
-//
-//            // when & then
-//            assertThatThrownBy(() -> leagueStatisticsService.updateLeagueStatisticFromFinalGame(gameWithoutLeague))
-//                    .isInstanceOf(IllegalArgumentException.class)
-//                    .hasMessage("유효한 게임 또는 리그 정보가 없습니다.");
-//        }
-//
-//        @Test
-//        @DisplayName("게임팀이 최소 팀 수보다 적으면 업데이트하지 않는다")
-//        void 게임팀이_최소_팀_수보다_적으면_업데이트하지_않는다() {
-//            // given
-//            Game gameWithInsufficientTeams = entityUtils.getEntity(2L, Game.class); // 팀 수가 부족한 게임
-//            League league = gameWithInsufficientTeams.getLeague();
-//
-//            // when
-//            leagueStatisticsService.updateLeagueStatisticFromFinalGame(gameWithInsufficientTeams);
-//
-//            // then
-//            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
-//            // 통계는 생성되지만 승리팀 정보는 업데이트되지 않음
-//            assertThat(statistics).isNotNull();
-//        }
-//    }
-//}
+package com.sports.server.command.league.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.LeagueStatistics;
+import com.sports.server.command.league.domain.LeagueStatisticsRepository;
+import com.sports.server.command.league.domain.LeagueTeam;
+import com.sports.server.command.league.domain.LeagueTeamRepository;
+import com.sports.server.command.team.domain.Team;
+import com.sports.server.common.application.EntityUtils;
+import com.sports.server.support.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql("/league-fixture.sql")
+public class LeagueStatisticsServiceTest extends ServiceTest {
+
+    @Autowired
+    private LeagueStatisticsService leagueStatisticsService;
+
+    @Autowired
+    private LeagueStatisticsRepository leagueStatisticsRepository;
+
+    @Autowired
+    private LeagueTeamRepository leagueTeamRepository;
+
+    @Autowired
+    private EntityUtils entityUtils;
+
+    @Nested
+    @DisplayName("최종 게임으로부터 리그 통계를 업데이트할 때")
+    class UpdateLeagueStatisticFromFinalGameTest {
+
+        @Test
+        @DisplayName("유효한 게임이 주어지면 리그 통계가 업데이트된다")
+        void 유효한_게임이_주어지면_리그_통계가_업데이트된다() {
+            // given
+            Game finalGame = entityUtils.getEntity(1L, Game.class);
+            League league = finalGame.getLeague();
+
+            // when
+            leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGame);
+
+            // then
+            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
+            assertThat(statistics).isNotNull();
+        }
+
+        @Test
+        @DisplayName("승리팀과 준우승팀이 올바르게 업데이트된다")
+        void 승리팀과_준우승팀이_올바르게_업데이트된다() {
+            // given
+            Game finalGame = entityUtils.getEntity(1L, Game.class);
+            League league = finalGame.getLeague();
+
+            // when
+            leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGame);
+
+            // then
+            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
+            assertThat(statistics.getFirstWinnerTeam()).isNotNull();
+            assertThat(statistics.getSecondWinnerTeam()).isNotNull();
+
+            // 승리팀의 랭킹이 1위로 업데이트되었는지 확인
+            Team winnerTeam = statistics.getFirstWinnerTeam();
+            LeagueTeam winnerLeagueTeam = leagueTeamRepository.findByLeagueAndTeam(league, winnerTeam).orElse(null);
+            assertThat(winnerLeagueTeam).isNotNull();
+            assertThat(winnerLeagueTeam.getRanking()).isEqualTo(1);
+
+            // 준우승팀의 랭킹이 2위로 업데이트되었는지 확인
+            Team secondTeam = statistics.getSecondWinnerTeam();
+            LeagueTeam secondLeagueTeam = leagueTeamRepository.findByLeagueAndTeam(league, secondTeam).orElse(null);
+            assertThat(secondLeagueTeam).isNotNull();
+            assertThat(secondLeagueTeam.getRanking()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("최다 응원팀과 최다 대화팀이 올바르게 업데이트된다")
+        void 최다_응원팀과_최다_대화팀이_올바르게_업데이트된다() {
+            // given
+            Game finalGame = entityUtils.getEntity(1L, Game.class);
+            League league = finalGame.getLeague();
+
+            // when
+            leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGame);
+
+            // then
+            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
+            assertThat(statistics.getMostCheeredTeam()).isNotNull();
+            assertThat(statistics.getMostCheerTalksTeam()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("게임이 null이면 예외가 발생한다")
+        void 게임이_null이면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> leagueStatisticsService.updateLeagueStatisticFromFinalGame(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("유효한 게임 또는 리그 정보가 없습니다.");
+        }
+
+        @Test
+        @DisplayName("게임에 리그 정보가 없으면 예외가 발생한다")
+        void 게임에_리그_정보가_없으면_예외가_발생한다() {
+            // given
+            Game gameWithoutLeague = Game.builder()
+                    .league(null)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> leagueStatisticsService.updateLeagueStatisticFromFinalGame(gameWithoutLeague))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("유효한 게임 또는 리그 정보가 없습니다.");
+        }
+
+        @Test
+        @DisplayName("게임팀이 최소 팀 수보다 적으면 업데이트하지 않는다")
+        void 게임팀이_최소_팀_수보다_적으면_업데이트하지_않는다() {
+            // given
+            Game gameWithInsufficientTeams = entityUtils.getEntity(2L, Game.class); // 팀 수가 부족한 게임
+            League league = gameWithInsufficientTeams.getLeague();
+
+            // when
+            leagueStatisticsService.updateLeagueStatisticFromFinalGame(gameWithInsufficientTeams);
+
+            // then
+            LeagueStatistics statistics = leagueStatisticsRepository.findByLeagueId(league.getId());
+            // 통계는 생성되지만 승리팀 정보는 업데이트되지 않음
+            assertThat(statistics).isNotNull();
+        }
+    }
+}

--- a/src/test/java/com/sports/server/command/league/application/LeagueStatisticsServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueStatisticsServiceTest.java
@@ -38,7 +38,6 @@ public class LeagueStatisticsServiceTest extends ServiceTest {
     class UpdateLeagueStatisticFromFinalGameTest {
 
         @Test
-        @DisplayName("유효한 게임이 주어지면 리그 통계가 업데이트된다")
         void 유효한_게임이_주어지면_리그_통계가_업데이트된다() {
             // given
             Game finalGame = entityUtils.getEntity(1L, Game.class);
@@ -53,7 +52,6 @@ public class LeagueStatisticsServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("승리팀과 준우승팀이 올바르게 업데이트된다")
         void 승리팀과_준우승팀이_올바르게_업데이트된다() {
             // given
             Game finalGame = entityUtils.getEntity(1L, Game.class);
@@ -81,7 +79,6 @@ public class LeagueStatisticsServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("최다 응원팀과 최다 대화팀이 올바르게 업데이트된다")
         void 최다_응원팀과_최다_대화팀이_올바르게_업데이트된다() {
             // given
             Game finalGame = entityUtils.getEntity(1L, Game.class);
@@ -97,7 +94,6 @@ public class LeagueStatisticsServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("게임이 null이면 예외가 발생한다")
         void 게임이_null이면_예외가_발생한다() {
             // when & then
             assertThatThrownBy(() -> leagueStatisticsService.updateLeagueStatisticFromFinalGame(null))
@@ -106,7 +102,6 @@ public class LeagueStatisticsServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("게임에 리그 정보가 없으면 예외가 발생한다")
         void 게임에_리그_정보가_없으면_예외가_발생한다() {
             // given
             Game gameWithoutLeague = Game.builder()
@@ -120,7 +115,6 @@ public class LeagueStatisticsServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("게임팀이 최소 팀 수보다 적으면 업데이트하지 않는다")
         void 게임팀이_최소_팀_수보다_적으면_업데이트하지_않는다() {
             // given
             Game gameWithInsufficientTeams = entityUtils.getEntity(2L, Game.class); // 팀 수가 부족한 게임

--- a/src/test/java/com/sports/server/command/league/application/LeagueTopScorerServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueTopScorerServiceTest.java
@@ -1,0 +1,84 @@
+package com.sports.server.command.league.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.LeagueTopScorer;
+import com.sports.server.command.league.domain.LeagueTopScorerRepository;
+import com.sports.server.common.application.EntityUtils;
+import com.sports.server.support.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+@Sql("/timeline-fixture.sql")
+public class LeagueTopScorerServiceTest extends ServiceTest {
+
+    @Autowired
+    private LeagueTopScorerService leagueTopScorerService;
+
+    @Autowired
+    private LeagueTopScorerRepository leagueTopScorerRepository;
+
+    @Autowired
+    private EntityUtils entityUtils;
+
+    @Nested
+    @DisplayName("리그 득점왕을 업데이트할 때")
+    class UpdateTopScorersForLeagueTest {
+
+        @Test
+        @DisplayName("유효한 리그 ID가 주어지면 득점왕 정보가 업데이트된다")
+        void 유효한_리그_ID가_주어지면_득점왕_정보가_업데이트된다() {
+            // given
+            Long leagueId = 1L;
+            League league = entityUtils.getEntity(leagueId, League.class);
+
+            // when
+            leagueTopScorerService.updateTopScorersForLeague(leagueId);
+
+            // then
+            List<LeagueTopScorer> topScorers = leagueTopScorerRepository.findByLeagueId(leagueId);
+            assertThat(topScorers).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리그 ID가 주어지면 예외가 발생한다")
+        void 존재하지_않는_리그_ID가_주어지면_예외가_발생한다() {
+            // given
+            Long invalidLeagueId = 999L;
+
+            // when & then
+            assertThatThrownBy(() -> leagueTopScorerService.updateTopScorersForLeague(invalidLeagueId))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("League not found");
+        }
+
+        @Test
+        @DisplayName("리그의 득점왕이 순위별로 올바르게 저장된다")
+        void 리그의_득점왕이_순위별로_올바르게_저장된다() {
+            // given
+            Long leagueId = 1L;
+
+            // when
+            leagueTopScorerService.updateTopScorersForLeague(leagueId);
+
+            // then
+            List<LeagueTopScorer> topScorers = leagueTopScorerRepository.findByLeagueId(leagueId);
+            assertThat(topScorers).isNotEmpty();
+            
+            // 순위가 올바르게 설정되었는지 확인
+            for (LeagueTopScorer topScorer : topScorers) {
+                assertThat(topScorer.getRanking()).isPositive();
+                assertThat(topScorer.getGoalCount()).isNotNegative();
+                assertThat(topScorer.getPlayer()).isNotNull();
+                assertThat(topScorer.getLeague().getId()).isEqualTo(leagueId);
+            }
+        }
+    }
+}

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -71,8 +71,8 @@ public class LeagueQueryControllerTest extends DocumentationTest {
         Long leagueId = 1L;
 
         List<LeagueTeamResponse> responses = List.of(
-                new LeagueTeamResponse(1L, 10L, "경영 야생마", "s3:logoImageUrl1", 3),
-                new LeagueTeamResponse(2L, 11L, "서어 뻬데뻬", "s3:logoImageUrl2", 6)
+                new LeagueTeamResponse(1L, 10L, "경영 야생마", "s3:logoImageUrl1", 3, 0, 0),
+                new LeagueTeamResponse(2L, 11L, "서어 뻬데뻬", "s3:logoImageUrl2", 6, 0, 0)
         );
 
         given(leagueQueryService.findTeamsByLeagueRound(leagueId, 2))

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -1,7 +1,6 @@
 package com.sports.server.query.presentation;
 
 import com.sports.server.command.member.domain.Member;
-import com.sports.server.command.team.domain.Unit;
 import com.sports.server.query.dto.response.*;
 import com.sports.server.query.dto.response.LeagueResponseWithGames.GameDetail;
 import com.sports.server.query.dto.response.LeagueResponseWithGames.GameDetail.GameTeam;
@@ -185,7 +184,7 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                 new LeagueTopScorerResponse(3L, "이현제", "202202001", 3, 2)
         );
         
-        given(leagueQueryService.findTopScorersByLeagueId(leagueId))
+        given(leagueQueryService.findTop20ScorersByLeagueId(leagueId))
                 .willReturn(responses);
 
         // when

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -1,6 +1,7 @@
 package com.sports.server.query.presentation;
 
 import com.sports.server.command.member.domain.Member;
+import com.sports.server.command.team.domain.Unit;
 import com.sports.server.query.dto.response.*;
 import com.sports.server.query.dto.response.LeagueResponseWithGames.GameDetail;
 import com.sports.server.query.dto.response.LeagueResponseWithGames.GameDetail.GameTeam;
@@ -100,71 +101,112 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].logoImageUrl").type(JsonFieldType.STRING)
                                         .description("리그의 팀 로고 이미지 URL"),
                                 fieldWithPath("[].sizeOfTeamPlayers").type(JsonFieldType.NUMBER)
-                                        .description("리그팀 선수의 인원수")
+                                        .description("리그팀 선수의 인원수"),
+                                fieldWithPath("[].cheerCount").type(JsonFieldType.NUMBER).description("응원 수"),
+                                fieldWithPath("[].cheerTalksCount").description("치어톡 수")
                         )
                 ));
     }
 
-//    @Test
-//    void 리그_통계를_조회한다() throws Exception {
-//        // given
-//        Long leagueId = 1L;
-//        TeamResponse firstWinnerTeam = new TeamResponse(1L, "우승팀", "logo1.png", Unit.BUSINESS, "#FF0000", null, null);
-//        TeamResponse secondWinnerTeam = new TeamResponse(2L, "준우승팀", "logo2.png", Unit.ENGLISH, "#00FF00", null, null);
-//        TeamResponse mostCheeredTeam = new TeamResponse(3L, "최다응원팀", "logo3.png", Unit.AI_CONVERGENCE, "#0000FF", 100, null);
-//        TeamResponse mostCheerTalksTeam = new TeamResponse(4L, "최다응원톡팀", "logo4.png", Unit.SOCIAL_SCIENCES, "#FFFF00", null, 50);
-//
-//        LeagueStatisticsResponse response = new LeagueStatisticsResponse(
-//                1L,
-//                firstWinnerTeam,
-//                secondWinnerTeam,
-//                mostCheeredTeam,
-//                mostCheerTalksTeam
-//        );
-//
-//        given(leagueQueryService.findLeagueStatistic(leagueId))
-//                .willReturn(response);
-//
-//        // when
-//        ResultActions result = mockMvc.perform(get("/leagues/{leagueId}/statistics", leagueId)
-//                .contentType(MediaType.APPLICATION_JSON)
-//        );
-//
-//        // then
-//        result.andExpect((status().isOk()))
-//                .andDo(restDocsHandler.document(
-//                        pathParameters(
-//                                parameterWithName("leagueId").description("리그의 ID")
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("leagueStatisticsId").type(JsonFieldType.NUMBER).description("리그 통계 ID"),
-//                                fieldWithPath("firstWinnerTeam").type(JsonFieldType.OBJECT).description("우승팀 정보"),
-//                                fieldWithPath("firstWinnerTeam.id").type(JsonFieldType.NUMBER).description("우승팀 ID"),
-//                                fieldWithPath("firstWinnerTeam.name").type(JsonFieldType.STRING).description("우승팀 이름"),
-//                                fieldWithPath("firstWinnerTeam.logoImageUrl").type(JsonFieldType.STRING).description("우승팀 로고 이미지 URL"),
-//                                fieldWithPath("firstWinnerTeam.unit").type(JsonFieldType.STRING).description("우승팀 소속 단과대학"),
-//                                fieldWithPath("firstWinnerTeam.teamColor").type(JsonFieldType.STRING).description("우승팀 색상"),
-//                                fieldWithPath("secondWinnerTeam").type(JsonFieldType.OBJECT).description("준우승팀 정보"),
-//                                fieldWithPath("secondWinnerTeam.id").type(JsonFieldType.NUMBER).description("준우승팀 ID"),
-//                                fieldWithPath("secondWinnerTeam.name").type(JsonFieldType.STRING).description("준우승팀 이름"),
-//                                fieldWithPath("secondWinnerTeam.logoImageUrl").type(JsonFieldType.STRING).description("준우승팀 로고 이미지 URL"),
-//                                fieldWithPath("secondWinnerTeam.unit").type(JsonFieldType.STRING).description("준우승팀 소속 단과대학"),
-//                                fieldWithPath("secondWinnerTeam.teamColor").type(JsonFieldType.STRING).description("준우승팀 색상"),
-//                                fieldWithPath("mostCheeredTeam").type(JsonFieldType.OBJECT).description("최다 응원받은 팀 정보"),
-//                                fieldWithPath("mostCheeredTeam.id").type(JsonFieldType.NUMBER).description("최다 응원받은 팀 ID"),
-//                                fieldWithPath("mostCheeredTeam.name").type(JsonFieldType.STRING).description("최다 응원받은 팀 이름"),
-//                                fieldWithPath("mostCheeredTeam.logoImageUrl").type(JsonFieldType.STRING).description("최다 응원받은 팀 로고 이미지 URL"),
-//                                fieldWithPath("mostCheeredTeam.unit").type(JsonFieldType.STRING).description("최다 응원받은 팀 소속 단과대학"),
-//                                fieldWithPath("mostCheeredTeam.teamColor").type(JsonFieldType.STRING).description("최다 응원받은 팀 색상"),
-//                                fieldWithPath("mostCheerTalksTeam").type(JsonFieldType.OBJECT).description("최다 응원톡 팀 정보"),
-//                                fieldWithPath("mostCheerTalksTeam.id").type(JsonFieldType.NUMBER).description("최다 응원톡 팀 ID"),
-//                                fieldWithPath("mostCheerTalksTeam.name").type(JsonFieldType.STRING).description("최다 응원톡 팀 이름"),
-//                                fieldWithPath("mostCheerTalksTeam.logoImageUrl").type(JsonFieldType.STRING).description("최다 응원톡 팀 로고 이미지 URL"),
-//                                fieldWithPath("mostCheerTalksTeam.unit").type(JsonFieldType.STRING).description("최다 응원톡 팀 소속 단과대학"),
-//                                fieldWithPath("mostCheerTalksTeam.teamColor").type(JsonFieldType.STRING).description("최다 응원톡 팀 색상")
-//                        )
-//                ));
-//    }
+    @Test
+    void 리그_통계를_조회한다() throws Exception {
+        // given
+        Long leagueId = 1L;
+        
+        TeamResponse firstWinnerTeam = new TeamResponse(1L, "경영 야생마", "s3:logoImageUrl1", "경영", "#FF0000");
+        TeamResponse secondWinnerTeam = new TeamResponse(2L, "서어 뻬데뻬", "s3:logoImageUrl2", "경영", "#0000FF");
+        
+        LeagueTeamResponse mostCheeredTeam = new LeagueTeamResponse(1L, 1L, "경영 야생마", "s3:logoImageUrl1", 3, 100, 50);
+        LeagueTeamResponse mostCheerTalksTeam = new LeagueTeamResponse(2L, 2L, "서어 뻬데뻬", "s3:logoImageUrl2", 4, 80, 120);
+        
+        LeagueStatisticsResponse response = LeagueStatisticsResponse.builder()
+                .leagueStatisticsId(1L)
+                .firstWinnerTeam(firstWinnerTeam)
+                .secondWinnerTeam(secondWinnerTeam)
+                .mostCheeredTeam(mostCheeredTeam)
+                .mostCheerTalksTeam(mostCheerTalksTeam)
+                .build();
+        
+        given(leagueQueryService.findLeagueStatistic(leagueId))
+                .willReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/leagues/{leagueId}/statistics", leagueId)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("leagueId").description("리그의 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("leagueStatisticsId").type(JsonFieldType.NUMBER).description("리그 통계 ID"),
+                                fieldWithPath("firstWinnerTeam").type(JsonFieldType.OBJECT).description("1위 팀 정보"),
+                                fieldWithPath("firstWinnerTeam.id").type(JsonFieldType.NUMBER).description("1위 팀 ID"),
+                                fieldWithPath("firstWinnerTeam.name").type(JsonFieldType.STRING).description("1위 팀 이름"),
+                                fieldWithPath("firstWinnerTeam.logoImageUrl").type(JsonFieldType.STRING).description("1위 팀 로고 이미지 URL"),
+                                fieldWithPath("firstWinnerTeam.unit").type(JsonFieldType.STRING).description("1위 팀 단위"),
+                                fieldWithPath("firstWinnerTeam.teamColor").type(JsonFieldType.STRING).description("1위 팀 컬러"),
+                                fieldWithPath("secondWinnerTeam").type(JsonFieldType.OBJECT).description("2위 팀 정보"),
+                                fieldWithPath("secondWinnerTeam.id").type(JsonFieldType.NUMBER).description("2위 팀 ID"),
+                                fieldWithPath("secondWinnerTeam.name").type(JsonFieldType.STRING).description("2위 팀 이름"),
+                                fieldWithPath("secondWinnerTeam.logoImageUrl").type(JsonFieldType.STRING).description("2위 팀 로고 이미지 URL"),
+                                fieldWithPath("secondWinnerTeam.unit").type(JsonFieldType.STRING).description("2위 팀 단위"),
+                                fieldWithPath("secondWinnerTeam.teamColor").type(JsonFieldType.STRING).description("2위 팀 컬러"),
+                                fieldWithPath("mostCheeredTeam").type(JsonFieldType.OBJECT).description("최다 응원 팀 정보"),
+                                fieldWithPath("mostCheeredTeam.leagueTeamId").type(JsonFieldType.NUMBER).description("최다 응원 팀의 리그팀 ID"),
+                                fieldWithPath("mostCheeredTeam.teamId").type(JsonFieldType.NUMBER).description("최다 응원 팀 ID"),
+                                fieldWithPath("mostCheeredTeam.teamName").type(JsonFieldType.STRING).description("최다 응원 팀 이름"),
+                                fieldWithPath("mostCheeredTeam.logoImageUrl").type(JsonFieldType.STRING).description("최다 응원 팀 로고 이미지 URL"),
+                                fieldWithPath("mostCheeredTeam.sizeOfTeamPlayers").type(JsonFieldType.NUMBER).description("최다 응원 팀 선수 수"),
+                                fieldWithPath("mostCheeredTeam.cheerCount").type(JsonFieldType.NUMBER).description("최다 응원 팀 응원 수"),
+                                fieldWithPath("mostCheeredTeam.cheerTalksCount").type(JsonFieldType.NUMBER).description("최다 응원 팀 치어톡 수"),
+                                fieldWithPath("mostCheerTalksTeam").type(JsonFieldType.OBJECT).description("최다 치어톡 팀 정보"),
+                                fieldWithPath("mostCheerTalksTeam.leagueTeamId").type(JsonFieldType.NUMBER).description("최다 치어톡 팀의 리그팀 ID"),
+                                fieldWithPath("mostCheerTalksTeam.teamId").type(JsonFieldType.NUMBER).description("최다 치어톡 팀 ID"),
+                                fieldWithPath("mostCheerTalksTeam.teamName").type(JsonFieldType.STRING).description("최다 치어톡 팀 이름"),
+                                fieldWithPath("mostCheerTalksTeam.logoImageUrl").type(JsonFieldType.STRING).description("최다 치어톡 팀 로고 이미지 URL"),
+                                fieldWithPath("mostCheerTalksTeam.sizeOfTeamPlayers").type(JsonFieldType.NUMBER).description("최다 치어톡 팀 선수 수"),
+                                fieldWithPath("mostCheerTalksTeam.cheerCount").type(JsonFieldType.NUMBER).description("최다 치어톡 팀 응원 수"),
+                                fieldWithPath("mostCheerTalksTeam.cheerTalksCount").type(JsonFieldType.NUMBER).description("최다 치어톡 팀 치어톡 수")
+                        )
+                ));
+    }
+
+    @Test
+    void 리그_득점왕을_조회한다() throws Exception {
+        // given
+        Long leagueId = 1L;
+        
+        List<LeagueTopScorerResponse> responses = List.of(
+                new LeagueTopScorerResponse(1L, "진승희", "202101001", 1, 5),
+                new LeagueTopScorerResponse(2L, "이동규", "202101002", 2, 3),
+                new LeagueTopScorerResponse(3L, "이현제", "202202001", 3, 2)
+        );
+        
+        given(leagueQueryService.findTopScorersByLeagueId(leagueId))
+                .willReturn(responses);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/leagues/{leagueId}/top-scorers", leagueId)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("leagueId").description("리그의 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].playerId").type(JsonFieldType.NUMBER).description("선수 ID"),
+                                fieldWithPath("[].playerName").type(JsonFieldType.STRING).description("선수 이름"),
+                                fieldWithPath("[].studentNumber").type(JsonFieldType.STRING).description("선수 학번"),
+                                fieldWithPath("[].ranking").type(JsonFieldType.NUMBER).description("득점 순위"),
+                                fieldWithPath("[].goalCount").type(JsonFieldType.NUMBER).description("득점 수")
+                        )
+                ));
+    }
 
     @Test
     void 리그를_하나_조회한다() throws Exception {
@@ -341,55 +383,6 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                         )
                 ));
     }
-
-    // TODO: 필요없으면 삭제
-//    @Test
-//    void 리그팀을_상세_조회한다() throws Exception {
-//        // given
-//        Long leagueTeamId = 3L;
-//
-//        List<PlayerResponse> responses = List.of(
-//                new PlayerResponse(1L, "봄동나물진승희", "202022222", 10, null, null),
-//                new PlayerResponse(2L, "가을전어이동규", "202022221", 7, null, null)
-//        );
-//
-//        List<LeagueTeamDetailResponse.LeagueTeamPlayerResponse> leagueTeamPlayerResponses = List.of(
-//                new LeagueTeamDetailResponse.LeagueTeamPlayerResponse(1L, "봄동나물진승희", 0, "202100000"),
-//                new LeagueTeamDetailResponse.LeagueTeamPlayerResponse(2L, "가을전어이동규", 2, "202100001")
-//        );
-//        LeagueTeamDetailResponse leagueTeamDetailResponse = new LeagueTeamDetailResponse(
-//                "이미지이미지", "미컴 축구생각", "color code", leagueTeamPlayerResponses
-//        );
-//
-//        given(leagueQueryService.findLeagueTeam(leagueTeamId))
-//                .willReturn(leagueTeamDetailResponse);
-//
-//        // when
-//        ResultActions result = mockMvc.perform(get("/leagues/teams/{leagueTeamId}", leagueTeamId)
-//                .contentType(MediaType.APPLICATION_JSON));
-//
-//        // then
-//        result.andExpect((status().isOk()))
-//                .andDo(restDocsHandler.document(
-//                        pathParameters(
-//                                parameterWithName("leagueTeamId").description("리그 팀의 ID")
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("teamName").type(JsonFieldType.STRING).description("대회 팀의 이름"),
-//                                fieldWithPath("logoImageUrl").type(JsonFieldType.STRING).description("로고 이미지의 URL"),
-//                                fieldWithPath("teamColor").type(JsonFieldType.STRING).description("팀의 컬러 코드"),
-//                                fieldWithPath("leagueTeamPlayers").type(JsonFieldType.ARRAY).description("대회 팀 선수들"),
-//                                fieldWithPath("leagueTeamPlayers[].id").type(JsonFieldType.NUMBER)
-//                                        .description("대회 팀 선수 ID"),
-//                                fieldWithPath("leagueTeamPlayers[].name").type(JsonFieldType.STRING)
-//                                        .description("대회 팀 선수 이름"),
-//                                fieldWithPath("leagueTeamPlayers[].number").type(JsonFieldType.NUMBER)
-//                                        .description("대회 팀 선수 번호"),
-//                                fieldWithPath("leagueTeamPlayers[].studentNumber").type(JsonFieldType.STRING)
-//                                        .description("대회 팀 선수 학번")
-//                        )
-//                ));
-//    }
 
     @Test
     void 리그의_정보와_리그에_속한_모든_경기를_조회한다() throws Exception {

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -50,14 +50,14 @@ VALUES (1, 1, 1),
 
 -- 8. 경기
 INSERT INTO games (id, administrator_id, league_id, start_time, name, round, state)
-VALUES (1, 1, 1, '2025-08-05 18:00:00', '8강 1경기', '8강', 'SCHEDULED'),
+VALUES (1, 1, 1, '2025-08-05 18:00:00', '결승전', '결승', 'FINISHED'),
        (2, 1, 1, '2025-08-05 19:00:00', '8강 2경기', '8강', 'SCHEDULED');
 
--- 9. 경기-팀 연결 (2번 경기에 상대팀 추가)
-INSERT INTO game_teams (id, game_id, team_id, score)
-VALUES (1, 1, 1, 0),
-       (2, 1, 2, 0),
-       (3, 2, 3, 0),
-       (4, 2, 4, 0); -- 2번 경기에 4번 팀을 상대팀으로 추가
+-- 9. 경기-팀 연결
+INSERT INTO game_teams (id, game_id, team_id, score, result)
+VALUES (1, 1, 1, 2, 'WIN'),
+       (2, 1, 2, 1, 'LOSE'),
+       (3, 2, 3, 0, null),
+       (4, 2, 4, 0, null);
 
 SET foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
#351

## 📝 구현 내용
- 리그 통계, 득점왕 api 구현 및 테스트 작성
- 리그 득점왕도 리그 통계 업데이트되는 시점(결승전 종료)에 스케줄러가 자동으로 업데이트
- 1골 이상 득점한 선수만 포합합니다
<img width="317" height="769" alt="스크린샷 2025-08-22 오후 10 08 52" src="https://github.com/user-attachments/assets/0f56c9d4-1d50-4710-9254-e5a291ceb211" />

- 해당 화면에서 연도별 리그 조회 api -> 해당 리그들 통계, 득점왕 조회  api   요 순서로 사용할 것 같네요
 
## 🍀 확인해야 할 부분
- 양방향 매핑 사용으로 N+1 나기는 하는데 팀 수가 많지는 않아서 성능에 문제가 생길 것 같진 않습니다. 그래도 뭔가 최적화와 편의성 사이에서 타협점을 잡는 것이 항상 고민이네요
- 스케줄러 작동은 데이터 넣고 QA 따로 해봐야할 것 같습니다