### PR TITLE
[FEATURE] TotalCheerCount, TotalTalkCount 자동 업데이트 로직 구현

### DIFF
--- a/src/main/java/com/sports/server/command/cheertalk/domain/CheerTalkRepository.java
+++ b/src/main/java/com/sports/server/command/cheertalk/domain/CheerTalkRepository.java
@@ -1,8 +1,16 @@
 package com.sports.server.command.cheertalk.domain;
 
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 public interface CheerTalkRepository extends Repository<CheerTalk, Long> {
     void save(CheerTalk cheerTalk);
+
+    @Query("SELECT COUNT(ct) FROM CheerTalk ct " +
+           "JOIN GameTeam gt ON ct.gameTeamId = gt.id " +
+           "JOIN gt.game g " +
+           "WHERE gt.team.id = :teamId AND g.league.id = :leagueId AND ct.isBlocked = false")
+    Long countCheerTalksByTeamIdAndLeagueId(@Param("teamId") Long teamId, @Param("leagueId") Long leagueId);
 }

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.league.application.LeagueStatisticsService;
 import com.sports.server.command.league.application.LeagueTopScorerService;
+import com.sports.server.command.league.application.LeagueService;
 import com.sports.server.command.league.domain.Round;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,6 +19,7 @@ public class GameStatusScheduler {
     private final GameService gameService;
     private final LeagueStatisticsService leagueStatisticsService;
     private final LeagueTopScorerService leagueTopScorerService;
+    private final LeagueService leagueService;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void scheduleUpdateGameStatusToFinish() {
@@ -32,6 +34,7 @@ public class GameStatusScheduler {
                 .forEach(game -> {
                     leagueStatisticsService.updateLeagueStatisticFromFinalGame(game.getId());
                     leagueTopScorerService.updateTopScorersForLeague(game.getLeague().getId());
+                    leagueService.updateTotalCheerCountsAndTotalTalkCount(game.getLeague().getId());
                 });
     }
 }

--- a/src/main/java/com/sports/server/command/game/domain/GameTeamRepository.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeamRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface GameTeamRepository extends Repository<GameTeam, Long> {
     void save(GameTeam gameTeam);
 
@@ -13,4 +15,9 @@ public interface GameTeamRepository extends Repository<GameTeam, Long> {
     void updateCheerCount(@Param("gameTeamId") Long gameTeamId, @Param("cheerCount") int cheerCount);
 
     long countByTeamIdAndResult(Long teamId, GameResult result);
+
+    @Query("SELECT SUM(gt.cheerCount) FROM GameTeam gt " +
+           "JOIN gt.game g " +
+           "WHERE gt.team.id = :teamId AND g.league.id = :leagueId")
+    Integer sumCheerCountByTeamIdAndLeagueId(@Param("teamId") Long teamId, @Param("leagueId") Long leagueId);
 }

--- a/src/main/java/com/sports/server/command/game/domain/GameTeamRepository.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeamRepository.java
@@ -19,5 +19,5 @@ public interface GameTeamRepository extends Repository<GameTeam, Long> {
     @Query("SELECT SUM(gt.cheerCount) FROM GameTeam gt " +
            "JOIN gt.game g " +
            "WHERE gt.team.id = :teamId AND g.league.id = :leagueId")
-    Integer sumCheerCountByTeamIdAndLeagueId(@Param("teamId") Long teamId, @Param("leagueId") Long leagueId);
+    Long sumCheerCountByTeamIdAndLeagueId(@Param("teamId") Long teamId, @Param("leagueId") Long leagueId);
 }

--- a/src/main/java/com/sports/server/command/league/application/LeagueService.java
+++ b/src/main/java/com/sports/server/command/league/application/LeagueService.java
@@ -85,22 +85,7 @@ public class LeagueService {
 	}
 
 	public void updateTotalCheerCountsAndTotalTalkCount(final Long leagueId) {
-		List<LeagueTeam> leagueTeams = leagueTeamRepository.findByLeagueId(leagueId);
-		List<LeagueTeamStats> statsResults = leagueTeamRepository.findLeagueTeamStatsWithCounts(leagueId);
-
-		Map<Long, LeagueTeamStats> statsMap = statsResults.stream()
-			.collect(Collectors.toMap(
-				LeagueTeamStats::leagueTeamId,
-				stats -> stats
-			));
-
-		for (LeagueTeam leagueTeam : leagueTeams) {
-			LeagueTeamStats stats = statsMap.getOrDefault(leagueTeam.getId(),
-					new LeagueTeamStats(leagueTeam.getId(), 0L, 0L));
-
-			leagueTeam.updateTotalCheerCount(stats.totalCheerCount().intValue());
-			leagueTeam.updateTotalTalkCount(stats.totalTalkCount().intValue());
-		}
+		leagueTeamRepository.updateLeagueTeamStats(leagueId);
 	}
 
 	private void saveLeagueTeams(League league, List<Team> teams){

--- a/src/main/java/com/sports/server/command/league/application/LeagueService.java
+++ b/src/main/java/com/sports/server/command/league/application/LeagueService.java
@@ -95,14 +95,11 @@ public class LeagueService {
 			));
 
 		for (LeagueTeam leagueTeam : leagueTeams) {
-			LeagueTeamStats stats = statsMap.get(leagueTeam.getId());
-			if (stats != null) {
-				leagueTeam.updateTotalCheerCount(stats.totalCheerCount().intValue());
-				leagueTeam.updateTotalTalkCount(stats.totalTalkCount().intValue());
-			} else {
-				leagueTeam.updateTotalCheerCount(0);
-				leagueTeam.updateTotalTalkCount(0);
-			}
+			LeagueTeamStats stats = statsMap.getOrDefault(leagueTeam.getId(),
+					new LeagueTeamStats(leagueTeam.getId(), 0L, 0L));
+
+			leagueTeam.updateTotalCheerCount(stats.totalCheerCount().intValue());
+			leagueTeam.updateTotalTalkCount(stats.totalTalkCount().intValue());
 		}
 	}
 

--- a/src/main/java/com/sports/server/command/league/application/LeagueService.java
+++ b/src/main/java/com/sports/server/command/league/application/LeagueService.java
@@ -85,7 +85,8 @@ public class LeagueService {
 	}
 
 	public void updateTotalCheerCountsAndTotalTalkCount(final Long leagueId) {
-		leagueTeamRepository.updateLeagueTeamStats(leagueId);
+		leagueTeamRepository.updateTotalCheerCounts(leagueId);
+		leagueTeamRepository.updateTotalTalkCounts(leagueId);
 	}
 
 	private void saveLeagueTeams(League league, List<Team> teams){

--- a/src/main/java/com/sports/server/command/league/domain/LeagueTeamRepository.java
+++ b/src/main/java/com/sports/server/command/league/domain/LeagueTeamRepository.java
@@ -30,14 +30,18 @@ public interface LeagueTeamRepository extends JpaRepository<LeagueTeam, Long> {
     @Query("UPDATE LeagueTeam lt SET lt.totalCheerCount = " +
            "COALESCE((SELECT CAST(SUM(gt.cheerCount) AS int) " +
            "FROM GameTeam gt JOIN gt.game g " +
-           "WHERE gt.team.id = lt.team.id AND g.league.id = :leagueId), 0), " +
-           "lt.totalTalkCount = " +
+           "WHERE gt.team.id = lt.team.id AND g.league.id = :leagueId), 0) " +
+           "WHERE lt.league.id = :leagueId")
+    void updateTotalCheerCounts(@Param("leagueId") Long leagueId);
+
+    @Modifying
+    @Query("UPDATE LeagueTeam lt SET lt.totalTalkCount = " +
            "COALESCE((SELECT CAST(COUNT(ct.id) AS int) " +
            "FROM CheerTalk ct, GameTeam gt2 " +
            "WHERE ct.gameTeamId = gt2.id AND gt2.team.id = lt.team.id " +
            "AND gt2.game.league.id = :leagueId AND ct.isBlocked = false), 0) " +
            "WHERE lt.league.id = :leagueId")
-    void updateLeagueTeamStats(@Param("leagueId") Long leagueId);
+    void updateTotalTalkCounts(@Param("leagueId") Long leagueId);
 
     @Query("SELECT new com.sports.server.command.league.dto.LeagueTeamStats(" +
            "lt.id, CAST(lt.totalCheerCount AS long), CAST(lt.totalTalkCount AS long)) " +

--- a/src/main/java/com/sports/server/command/league/domain/LeagueTeamRepository.java
+++ b/src/main/java/com/sports/server/command/league/domain/LeagueTeamRepository.java
@@ -1,5 +1,6 @@
 package com.sports.server.command.league.domain;
 
+import com.sports.server.command.league.dto.LeagueTeamStats;
 import com.sports.server.command.team.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -23,4 +24,21 @@ public interface LeagueTeamRepository extends JpaRepository<LeagueTeam, Long> {
     List<Long> findTeamIdsByLeagueId(@Param("leagueId") Long leagueId);
 
     List<LeagueTeam> findByLeagueId(Long id);
+
+    @Query("SELECT new com.sports.server.command.league.dto.LeagueTeamStats(" +
+           "lt.id, " +
+           "COALESCE(" +
+           "  (SELECT SUM(CAST(gt2.cheerCount AS long)) " +
+           "   FROM GameTeam gt2 " +
+           "   JOIN gt2.game g2 " +
+           "   WHERE gt2.team.id = lt.team.id AND g2.league.id = :leagueId), 0L), " +
+           "COALESCE(" +
+           "  (SELECT COUNT(ct2.id) " +
+           "   FROM CheerTalk ct2 " +
+           "   JOIN GameTeam gt3 ON ct2.gameTeamId = gt3.id " +
+           "   JOIN gt3.game g3 " +
+           "   WHERE gt3.team.id = lt.team.id AND g3.league.id = :leagueId AND ct2.isBlocked = false), 0L)) " +
+           "FROM LeagueTeam lt " +
+           "WHERE lt.league.id = :leagueId")
+    List<LeagueTeamStats> findLeagueTeamStatsWithCounts(@Param("leagueId") Long leagueId);
 }

--- a/src/main/java/com/sports/server/command/league/dto/LeagueTeamStats.java
+++ b/src/main/java/com/sports/server/command/league/dto/LeagueTeamStats.java
@@ -1,0 +1,8 @@
+package com.sports.server.command.league.dto;
+
+public record LeagueTeamStats(
+    Long leagueTeamId,
+    Long totalCheerCount,
+    Long totalTalkCount
+) {
+}

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -6205,7 +6205,7 @@ Host: www.api.hufstreaming.site
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: HCC_SES=testAccessToken; Path=/; Max-Age=604800; Expires=Mon, 15 Sep 2025 05:00:09 GMT; Secure; HttpOnly; SameSite=Strict</code></pre>
+Set-Cookie: HCC_SES=testAccessToken; Path=/; Max-Age=604800; Expires=Wed, 17 Sep 2025 06:19:07 GMT; Secure; HttpOnly; SameSite=Strict</code></pre>
 </div>
 </div>
 </div>

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -6205,7 +6205,7 @@ Host: www.api.hufstreaming.site
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: HCC_SES=testAccessToken; Path=/; Max-Age=604800; Expires=Sun, 7 Sep 2025 09:03:54 GMT; Secure; HttpOnly; SameSite=Strict</code></pre>
+Set-Cookie: HCC_SES=testAccessToken; Path=/; Max-Age=604800; Expires=Mon, 15 Sep 2025 05:00:09 GMT; Secure; HttpOnly; SameSite=Strict</code></pre>
 </div>
 </div>
 </div>
@@ -7837,7 +7837,7 @@ Content-Length: 1179
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-08-31 18:03:39 +0900
+Last updated 2025-09-07 22:21:12 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/sports/server/command/league/application/LeagueServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueServiceTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.sports.server.auth.exception.AuthorizationErrorMessages;
 import com.sports.server.command.league.domain.League;
 import com.sports.server.command.league.domain.LeagueTeam;
+import com.sports.server.command.league.domain.LeagueTeamRepository;
 import com.sports.server.command.league.dto.LeagueRequest;
 import com.sports.server.command.league.exception.LeagueErrorMessages;
 import com.sports.server.command.member.domain.Member;
@@ -30,6 +31,9 @@ public class LeagueServiceTest extends ServiceTest {
 
     @Autowired
     private EntityUtils entityUtils;
+
+    @Autowired
+    private LeagueTeamRepository leagueTeamRepository;
 
     @Nested
     @DisplayName("리그를 삭제할 때")
@@ -156,6 +160,66 @@ public class LeagueServiceTest extends ServiceTest {
             assertThatThrownBy(
                     () -> entityUtils.getEntity(leagueTeamIdToRemove, LeagueTeam.class))
                     .isInstanceOf(NotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("리그의 총 응원수와 응원톡 수를 업데이트할 때")
+    class UpdateTotalCheerCountsAndTotalTalkCountTest {
+        @Test
+        void 리그의_모든_팀의_총_응원수와_응원톡_수가_정확히_집계된다() {
+            // given
+            Long leagueId = 1L; // 테스트 데이터: 팀1(150 응원, 2 응원톡), 팀2(100 응원, 2 응원톡), 팀3(75 응원, 1 응원톡)
+
+            // when
+            leagueService.updateTotalCheerCountsAndTotalTalkCount(leagueId);
+
+            // then
+            List<LeagueTeam> leagueTeams = leagueTeamRepository.findByLeagueId(leagueId);
+
+            LeagueTeam team1 = leagueTeams.stream()
+                    .filter(lt -> lt.getTeam().getId().equals(1L))
+                    .findFirst().orElseThrow();
+            LeagueTeam team2 = leagueTeams.stream()
+                    .filter(lt -> lt.getTeam().getId().equals(2L))
+                    .findFirst().orElseThrow();
+            LeagueTeam team3 = leagueTeams.stream()
+                    .filter(lt -> lt.getTeam().getId().equals(3L))
+                    .findFirst().orElseThrow();
+
+            assertThat(team1.getTotalCheerCount()).isEqualTo(150);
+            assertThat(team1.getTotalTalkCount()).isEqualTo(2);
+            
+            assertThat(team2.getTotalCheerCount()).isEqualTo(100);
+            assertThat(team2.getTotalTalkCount()).isEqualTo(2);
+            
+            assertThat(team3.getTotalCheerCount()).isEqualTo(75);
+            assertThat(team3.getTotalTalkCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 응원수나_응원톡이_없는_팀은_0으로_설정된다() {
+            // given
+            Long leagueId = 2L; // 테스트 데이터: 팀4(30 응원, 1 응원톡), 팀5(0 응원, 0 응원톡)
+
+            // when
+            leagueService.updateTotalCheerCountsAndTotalTalkCount(leagueId);
+
+            // then
+            List<LeagueTeam> leagueTeams = leagueTeamRepository.findByLeagueId(leagueId);
+
+            LeagueTeam team4 = leagueTeams.stream()
+                    .filter(lt -> lt.getTeam().getId().equals(4L))
+                    .findFirst().orElseThrow();
+            LeagueTeam team5 = leagueTeams.stream()
+                    .filter(lt -> lt.getTeam().getId().equals(5L))
+                    .findFirst().orElseThrow();
+
+            assertThat(team4.getTotalCheerCount()).isEqualTo(30);
+            assertThat(team4.getTotalTalkCount()).isEqualTo(1);
+            
+            assertThat(team5.getTotalCheerCount()).isEqualTo(0);
+            assertThat(team5.getTotalTalkCount()).isEqualTo(0);
         }
     }
 }

--- a/src/test/java/com/sports/server/command/league/application/LeagueServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueServiceTest.java
@@ -3,6 +3,7 @@ package com.sports.server.command.league.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.sports.server.auth.exception.AuthorizationErrorMessages;
 import com.sports.server.command.league.domain.League;
@@ -220,6 +221,15 @@ public class LeagueServiceTest extends ServiceTest {
             
             assertThat(team5.getTotalCheerCount()).isEqualTo(0);
             assertThat(team5.getTotalTalkCount()).isEqualTo(0);
+        }
+
+        @Test
+        void 리그팀이_없는_경우_정상_종료된다(){
+            //given
+            Long  leagueId = 10L; // 팀, 경기 등이 없는 삭제된 리그
+
+            //when & then
+            assertDoesNotThrow(() -> leagueService.updateTotalCheerCountsAndTotalTalkCount(leagueId));
         }
     }
 }

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -61,14 +61,17 @@ VALUES (1, 1, 1),
 
 INSERT INTO games (id, administrator_id, league_id, start_time, name, round, state)
 VALUES (1, 1, 1, '2025-08-05 18:00:00', '결승전', '결승', 'PLAYING'),
-       (2, 1, 1, '2025-08-05 19:00:00', '8강 2경기', '8강', 'SCHEDULED');
+       (2, 1, 1, '2025-08-05 19:00:00', '8강 2경기', '8강', 'SCHEDULED'),
+       (3, 1, 2, '2025-02-10 18:00:00', '리그2 경기', '4강', 'FINISHED');
 
 
-INSERT INTO game_teams (id, game_id, team_id, score, result)
-VALUES (1, 1, 1, 2, 'WIN'),
-       (2, 1, 2, 1, 'LOSE'),
-       (3, 2, 3, 0, null),
-       (4, 2, 4, 0, null);
+INSERT INTO game_teams (id, game_id, team_id, score, result, cheer_count)
+VALUES (1, 1, 1, 2, 'WIN', 150),
+       (2, 1, 2, 1, 'LOSE', 100),
+       (3, 2, 3, 0, null, 75),
+       (4, 2, 4, 0, null, 50),
+       (5, 3, 4, 1, 'WIN', 30),
+       (6, 3, 5, 0, 'LOSE', 0);
 
 
 INSERT INTO league_statistics (league_id, first_winner_team_id, second_winner_team_id, most_cheered_team_id, most_cheer_talks_team_id)
@@ -87,6 +90,17 @@ VALUES (1, 1, 1, 1, 5),
        (3, 1, 3, 3, 2),
        (4, 2, 4, 1, 4),
        (5, 2, 5, 2, 2);
+
+
+INSERT INTO cheer_talks (id, created_at, content, is_blocked, game_team_id)
+VALUES (1, '2025-08-05 18:10:00', '경영 야생마 화이팅!', false, 1),
+       (2, '2025-08-05 18:15:00', '멋진 골이었어요!', false, 1),
+       (3, '2025-08-05 18:20:00', '서어 뻬데뻬 응원합니다!', false, 2),
+       (4, '2025-08-05 18:25:00', '다음 골 기대합니다!', false, 2),
+       (5, '2025-08-05 19:10:00', '미컴 축구생각 파이팅!', false, 3),
+       (6, '2025-08-05 19:15:00', '스팸 메시지', true, 3),
+       (7, '2025-08-05 19:20:00', '체교 불사조 응원!', false, 4),
+       (8, '2025-02-10 18:10:00', '체교 불사조 화이팅!', false, 5);
 
 
 SET foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호
#370 

## 📝 구현 내용
- 리그 통계와 마찬가지로 결승전 종료 시에 집계하도록 구현했습니다.
- 테스트 메소드 내용은 아래와 같습니다

### 테스트 케이스 1: 리그의_모든_팀의_총_응원수와_응원톡_수가_정확히_집계된다

  - 리그 1의 팀들이 올바르게 집계되는지 확인
  - 팀1: 150 응원, 2 응원톡
  - 팀2: 100 응원, 2 응원톡
  - 팀3: 75 응원, 1 응원톡

### 테스트 케이스 2: 응원수나_응원톡이_없는_팀은_0으로_설정된다

  - 팀4: 리그 2에서 총 30 응원수, 1 응원톡
  - 팀5: 리그 2에서 총 0 응원수, 0 응원톡

## 🍀 확인해야 할 부분
- 기존 대회들 업데이트 하는 방식 같이 생각해봐요