### PR TITLE
[FIX] 다른 리그에서의 득점은 포함하지 않도록 수정

### DIFF
--- a/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
@@ -56,10 +56,8 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             "FROM ScoreTimeline st " +
             "JOIN st.scorer sc " +
             "JOIN sc.player p " +
-            "JOIN p.teamPlayers tp " +
-            "JOIN tp.team t " +
-            "JOIN t.leagueTeams lt " +
-            "WHERE lt.league.id = :leagueId " +
+            "JOIN st.game g " +
+            "WHERE g.league.id = :leagueId " +
             "GROUP BY p.id, p.studentNumber, p.name " +
             "HAVING COUNT(st.id) > 0 " +
             "ORDER BY COUNT(st.id) DESC, p.name ASC")

--- a/src/test/java/com/sports/server/command/league/application/LeagueTopScorerServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueTopScorerServiceTest.java
@@ -73,10 +73,10 @@ public class LeagueTopScorerServiceTest extends ServiceTest {
             for (int i = 0; i < topScorers.size() - 1; i++) {
                 LeagueTopScorer current = topScorers.get(i);
                 LeagueTopScorer next = topScorers.get(i + 1);
-                
+
                 // 골 수가 내림차순으로 정렬되었는지 확인
                 assertThat(current.getGoalCount()).isGreaterThanOrEqualTo(next.getGoalCount());
-                
+
                 // 동점이 아닌 경우 순위가 증가하는지 확인
                 if (!current.getGoalCount().equals(next.getGoalCount())) {
                     assertThat(next.getRanking()).isGreaterThan(current.getRanking());
@@ -85,6 +85,40 @@ public class LeagueTopScorerServiceTest extends ServiceTest {
                 else {
                     assertThat(next.getRanking()).isEqualTo(current.getRanking());
                 }
+            }
+        }
+
+        @Test
+        void 다른_리그의_득점은_집계에_포함되지_않는다() {
+            // given
+            Long league1Id = 1L;
+
+            // when
+            leagueTopScorerService.updateTopScorersForLeague(league1Id);
+
+            // then
+            List<LeagueTopScorer> topScorers = leagueTopScorerRepository.findByLeagueId(league1Id);
+
+            // 선수1(id=1)은 리그1에서 2골, 다른 리그2에서 5골을 넣었지만 리그1 집계에는 2골만 반영되어야 함
+            // 선수2(id=2)는 리그1에서 2골, 다른 리그2에서 3골을 넣었지만 리그1 집계에는 2골만 반영되어야 함
+            LeagueTopScorer player1TopScorer = topScorers.stream()
+                    .filter(scorer -> scorer.getPlayer().getId().equals(1L))
+                    .findFirst()
+                    .orElse(null);
+
+            LeagueTopScorer player2TopScorer = topScorers.stream()
+                    .filter(scorer -> scorer.getPlayer().getId().equals(2L))
+                    .findFirst()
+                    .orElse(null);
+
+            // 선수1과 선수2 모두 리그1에서만 2골씩 넣었으므로 2골로 집계되어야 함
+            // 다른 리그에서 넣은 골(선수1: 5골, 선수2: 3골)은 포함되지 않아야 함
+            if (player1TopScorer != null) {
+                assertThat(player1TopScorer.getGoalCount()).isEqualTo(2); // 리그1에서만 2골
+            }
+
+            if (player2TopScorer != null) {
+                assertThat(player2TopScorer.getGoalCount()).isEqualTo(2); // 리그1에서만 2골
             }
         }
     }

--- a/src/test/java/com/sports/server/command/league/application/LeagueTopScorerServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueTopScorerServiceTest.java
@@ -99,27 +99,17 @@ public class LeagueTopScorerServiceTest extends ServiceTest {
             // then
             List<LeagueTopScorer> topScorers = leagueTopScorerRepository.findByLeagueId(league1Id);
 
-            // 선수1(id=1)은 리그1에서 2골, 다른 리그2에서 5골을 넣었지만 리그1 집계에는 2골만 반영되어야 함
-            // 선수2(id=2)는 리그1에서 2골, 다른 리그2에서 3골을 넣었지만 리그1 집계에는 2골만 반영되어야 함
             LeagueTopScorer player1TopScorer = topScorers.stream()
                     .filter(scorer -> scorer.getPlayer().getId().equals(1L))
                     .findFirst()
-                    .orElse(null);
+                    .orElseThrow(() -> new AssertionError("선수1이 득점왕 목록에 없습니다."));
+            assertThat(player1TopScorer.getGoalCount()).isEqualTo(2); // 리그1에서만 2골
 
             LeagueTopScorer player2TopScorer = topScorers.stream()
                     .filter(scorer -> scorer.getPlayer().getId().equals(2L))
                     .findFirst()
-                    .orElse(null);
-
-            // 선수1과 선수2 모두 리그1에서만 2골씩 넣었으므로 2골로 집계되어야 함
-            // 다른 리그에서 넣은 골(선수1: 5골, 선수2: 3골)은 포함되지 않아야 함
-            if (player1TopScorer != null) {
-                assertThat(player1TopScorer.getGoalCount()).isEqualTo(2); // 리그1에서만 2골
-            }
-
-            if (player2TopScorer != null) {
-                assertThat(player2TopScorer.getGoalCount()).isEqualTo(2); // 리그1에서만 2골
-            }
+                    .orElseThrow(() -> new AssertionError("선수2가 득점왕 목록에 없습니다."));
+            assertThat(player2TopScorer.getGoalCount()).isEqualTo(2); // 리그1에서만 2골
         }
     }
 }

--- a/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.util.List;
+
 @Sql(scripts = "/timeline-fixture.sql")
 class TimelineServiceTest extends ServiceTest {
     @Autowired
@@ -301,15 +303,17 @@ class TimelineServiceTest extends ServiceTest {
         @Test
         void 마지막_타임라인을_차례로_삭제한다() {
             // given
-            long lastId = 13L;
+            List<Timeline> game1Timelines = timelineFixtureRepository.findAllLatest(gameId);
 
             // when
-            for (long i = lastId; i > 0; i--) {
-                timelineService.deleteTimeline(manager, gameId, i);
+            while (!game1Timelines.isEmpty()) {
+                Timeline lastTimeline = game1Timelines.get(0);
+                timelineService.deleteTimeline(manager, gameId, lastTimeline.getId());
+                game1Timelines = timelineFixtureRepository.findAllLatest(gameId);
             }
 
             // then
-            assertThat(timelineFixtureRepository.findAll()).isEmpty();
+            assertThat(timelineFixtureRepository.findAllLatest(gameId)).isEmpty();
         }
 
         @ParameterizedTest

--- a/src/test/resources/timeline-fixture.sql
+++ b/src/test/resources/timeline-fixture.sql
@@ -42,28 +42,39 @@ VALUES (1, 1, 1, 1), -- 팀 1 선수들
        (7, 2, 7, 7),
        (8, 2, 8, 8),
        (9, 2, 9, 9),
-       (10, 2, 10, 10);
+       (10, 2, 10, 10),
+
+       (11, 3, 1, 11), -- 팀 3 선수들 (선수1이 다른 팀에도 속함)
+       (12, 3, 2, 12), -- 팀 3에 선수2도 속함
+       (13, 4, 3, 13), -- 팀 4 선수들 (선수3이 다른 팀에도 속함)
+       (14, 4, 4, 14); -- 팀 4에 선수4도 속함
 
 -- 리그 생성
 INSERT INTO leagues (id, organization_id, administrator_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)
-VALUES (1, 1, 1, '테스트 리그', '2023-11-01 00:00:00', '2023-11-30 23:59:59', FALSE, '결승', '4강');
+VALUES (1, 1, 1, '테스트 리그', '2023-11-01 00:00:00', '2023-11-30 23:59:59', FALSE, '결승', '4강'),
+       (2, 1, 1, '다른 리그', '2023-12-01 00:00:00', '2023-12-31 23:59:59', FALSE, '결승', '준결승');
 
 -- 리그 팀 연결
 INSERT INTO league_teams (id, league_id, team_id, total_cheer_count, total_talk_count, ranking)
 VALUES (1, 1, 1, 10, 5, 1),
-       (2, 1, 2, 8, 3, 2);
+       (2, 1, 2, 8, 3, 2),
+       (3, 2, 3, 5, 2, 1),  -- 다른 리그에 팀C 참여
+       (4, 2, 4, 3, 1, 2);  -- 다른 리그에 팀D 참여
 
 -- 경기 생성
 INSERT INTO games (id, administrator_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter, state, round, is_pk_taken)
 VALUES (1, 1, 1, '농구 대전', '2023-11-12 10:00:00', 'abc123', '2023-11-12 10:15:00', '후반전', 'PLAYING', '4강', FALSE),
-       (2, 1, 1, '농구 대전 2', '2023-11-12 14:00:00', 'def456', '2023-11-12 14:15:00', '후반전', 'FINISHED', '4강', FALSE);
+       (2, 1, 1, '농구 대전 2', '2023-11-12 14:00:00', 'def456', '2023-11-12 14:15:00', '후반전', 'FINISHED', '4강', FALSE),
+       (3, 1, 2, '다른 리그 경기', '2023-12-10 10:00:00', 'ghi789', '2023-12-10 10:15:00', '전반전', 'FINISHED', '준결승', FALSE);
 
 -- 경기 팀 연결
 INSERT INTO game_teams (id, game_id, team_id, cheer_count, score, pk_score, result)
 VALUES (1, 1, 1, 1, 15, 0, null), -- 팀 A
        (2, 1, 2, 2, 10, 0, null), -- 팀 B
        (3, 2, 1, 5, 20, 0, 'WIN'), -- 팀 A (2번 경기)
-       (4, 2, 2, 3, 15, 0, 'LOSE'); -- 팀 B (2번 경기)
+       (4, 2, 2, 3, 15, 0, 'LOSE'), -- 팀 B (2번 경기)
+       (5, 3, 3, 2, 12, 0, 'WIN'), -- 팀 C (다른 리그 경기)
+       (6, 3, 4, 1, 8, 0, 'LOSE');  -- 팀 D (다른 리그 경기)
 
 -- 라인업 선수 (1번 경기 - 팀A)
 INSERT INTO lineup_players (id, game_team_id, player_id, jersey_number, is_captain, state, is_playing, replaced_player_id)
@@ -81,6 +92,21 @@ VALUES (6, 2, 6, 6, TRUE, 'STARTER', FALSE, null),
        (9, 2, 9, 9, FALSE, 'STARTER', FALSE, null),
        (10, 2, 10, 10, FALSE, 'CANDIDATE', FALSE, null);
 
+-- 라인업 선수 (2번 경기 - 팀A)
+INSERT INTO lineup_players (id, game_team_id, player_id, jersey_number, is_captain, state, is_playing, replaced_player_id)
+VALUES (11, 3, 1, 1, TRUE, 'STARTER', FALSE, null),  -- 선수1이 2번 경기에서 뛰게 됨
+       (12, 3, 2, 2, FALSE, 'STARTER', FALSE, null); -- 선수2가 2번 경기에서 뛰게 됨
+
+-- 라인업 선수 (3번 경기 - 다른 리그, 팀C)
+INSERT INTO lineup_players (id, game_team_id, player_id, jersey_number, is_captain, state, is_playing, replaced_player_id)
+VALUES (13, 5, 1, 11, TRUE, 'STARTER', FALSE, null),  -- 선수1이 다른 리그에서도 뛰게 됨
+       (14, 5, 2, 12, FALSE, 'STARTER', FALSE, null); -- 선수2가 다른 리그에서도 뛰게 됨
+
+-- 라인업 선수 (3번 경기 - 다른 리그, 팀D)
+INSERT INTO lineup_players (id, game_team_id, player_id, jersey_number, is_captain, state, is_playing, replaced_player_id)
+VALUES (15, 6, 3, 13, TRUE, 'STARTER', FALSE, null),  -- 선수3이 다른 리그에서도 뛰게 됨
+       (16, 6, 4, 14, FALSE, 'STARTER', FALSE, null); -- 선수4가 다른 리그에서도 뛰게 됨
+
 -- 타임라인 생성
 
 -- 경기 시작 (PRE_GAME)
@@ -91,9 +117,13 @@ VALUES ('GAME_PROGRESS', 1, 'PRE_GAME', 0, 'QUARTER_START', 1, 2, 0, 0, null, nu
 INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, game_progress_type, game_team1_id, game_team2_id, snapshot_score1, snapshot_score2, previous_quarter, previous_quarter_changed_at)
 VALUES ('GAME_PROGRESS', 1, 'FIRST_HALF', 0, 'QUARTER_START', 1, 2, 0, 0, 'PRE_GAME', null);
 
--- A팀 선수 2의 2득점 (전반전)
+-- A팀 선수 2의 1득점 (전반전)
 INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, score, game_team1_id, snapshot_score1, game_team2_id, snapshot_score2)
-VALUES ('SCORE', 1, 'FIRST_HALF', 22, 2, 2, 1, 2, 2, 0);
+VALUES ('SCORE', 1, 'FIRST_HALF', 22, 2, 1, 1, 1, 2, 0);
+
+-- A팀 선수 1의 1득점 (전반전)
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, score, game_team1_id, snapshot_score1, game_team2_id, snapshot_score2)
+VALUES ('SCORE', 1, 'FIRST_HALF', 25, 1, 1, 1, 2, 2, 0);
 
 -- B팀 6선수 OUT 7선수 IN (전반전)
 INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, origin_lineup_player_id, replaced_lineup_player_id)
@@ -107,9 +137,18 @@ VALUES ('GAME_PROGRESS', 1, 'SECOND_HALF', 30, 'QUARTER_START', 1, 2, 2, 0, 'FIR
 INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, origin_lineup_player_id, replaced_lineup_player_id)
 VALUES ('REPLACEMENT', 1, 'SECOND_HALF', 10, 2, 3);
 
--- B팀 선수 10의 3득점 (후반전)
+-- B팀 선수 10의 1득점 (후반전)
 INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, score, game_team1_id, snapshot_score1, game_team2_id, snapshot_score2)
-VALUES ('SCORE', 1, 'SECOND_HALF', 13, 10, 3, 1, 2, 2, 3);
+VALUES ('SCORE', 1, 'SECOND_HALF', 13, 10, 1, 1, 2, 2, 1);
+
+-- 2번 경기에서 선수1과 선수2 추가 득점 (리그1에서 각각 총 2골씩 만들기 위함)
+-- A팀 선수 1의 1득점 (2번 경기)
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, score, game_team1_id, snapshot_score1, game_team2_id, snapshot_score2)
+VALUES ('SCORE', 2, 'FIRST_HALF', 15, 1, 1, 3, 1, 4, 0);
+
+-- A팀 선수 2의 1득점 (2번 경기)
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, score, game_team1_id, snapshot_score1, game_team2_id, snapshot_score2)
+VALUES ('SCORE', 2, 'FIRST_HALF', 20, 2, 1, 3, 2, 4, 0);
 
 -- 연장전 시작
 INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, game_progress_type, game_team1_id, game_team2_id, snapshot_score1, snapshot_score2, previous_quarter, previous_quarter_changed_at)
@@ -134,6 +173,21 @@ VALUES ('WARNING_CARD', 1, 'SECOND_HALF', 25, 10, 'YELLOW');
 -- 레드 카드 (전반전)
 INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, warning_card_type)
 VALUES ('WARNING_CARD', 1, 'FIRST_HALF', 25, 10, 'RED');
+
+-- 다른 리그 경기 (3번 경기) 득점 타임라인들
+-- 선수1이 다른 리그에서 5골 득점 (이 골들은 리그1 득점왕 집계에 포함되면 안됨)
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, score, game_team1_id, snapshot_score1, game_team2_id, snapshot_score2)
+VALUES ('SCORE', 3, 'FIRST_HALF', 10, 13, 1, 5, 1, 6, 0),
+       ('SCORE', 3, 'FIRST_HALF', 15, 13, 1, 5, 2, 6, 0),
+       ('SCORE', 3, 'FIRST_HALF', 20, 13, 1, 5, 3, 6, 0),
+       ('SCORE', 3, 'FIRST_HALF', 25, 13, 1, 5, 4, 6, 0),
+       ('SCORE', 3, 'FIRST_HALF', 30, 13, 1, 5, 5, 6, 0);
+
+-- 선수2도 다른 리그에서 3골 득점 (이 골들도 리그1 득점왕 집계에 포함되면 안됨)
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, score, game_team1_id, snapshot_score1, game_team2_id, snapshot_score2)
+VALUES ('SCORE', 3, 'SECOND_HALF', 5, 14, 1, 5, 6, 6, 0),
+       ('SCORE', 3, 'SECOND_HALF', 10, 14, 1, 5, 7, 6, 0),
+       ('SCORE', 3, 'SECOND_HALF', 15, 14, 1, 5, 8, 6, 0);
 
 -- 응원톡 생성
 INSERT INTO cheer_talks (id, game_team_id, content, created_at, is_blocked)


### PR DESCRIPTION
## 🌍 이슈 번호
#391 

## 📝 구현 내용
- 레포지토리 메소드에 join 시 조건을 추가했습니다
- 테스트 코드에 다른 리그의 득점도 추가하여 검증했습니다
- 추가적으로 타임라인 fixture 변경으로 타임라인 갯수가 바뀌어도 '마지막_타임라인을_차례로_삭제한다' 메소드 실패하지 않도록 동적으로 타임라인 갯수 계산하도록 변경했습니다
