### PR TITLE
[REFACTOR] Comparator 구현 및 N+1 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: spring server cd
 on:
   workflow_dispatch:
   push:
-    branches: [ "main", "5th-release", "chore/#386" ]
+    branches: [ "main", "5th-release" ]
 
 jobs:
   deploy:

--- a/src/main/java/com/sports/server/command/league/domain/LeagueProgress.java
+++ b/src/main/java/com/sports/server/command/league/domain/LeagueProgress.java
@@ -15,22 +15,22 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum LeagueProgress {
-	BEFORE_START("시작 전", (
-		(today, league) -> today.isBefore(league.getStartAt()))),
-	IN_PROGRESS("진행 중", (
-		(today, league) -> (today.isEqual(league.getStartAt()) || today.isAfter(league.getStartAt()))
-			&& (today.isBefore(league.getEndAt())))),
-	FINISHED("종료", (
-		(today, league) -> (today.isEqual(league.getEndAt()) || today.isAfter(league.getEndAt()))));
+    BEFORE_START("시작 전", (
+            (today, league) -> today.isBefore(league.getStartAt())), 2),
+    IN_PROGRESS("진행 중", (
+            (today, league) -> (today.isEqual(league.getStartAt()) || today.isAfter(league.getStartAt()))
+                    && (today.isBefore(league.getEndAt()))), 1),
+    FINISHED("종료", (
+            (today, league) -> (today.isEqual(league.getEndAt()) || today.isAfter(league.getEndAt()))), 3);
 
-	private final String description;
-	private final BiFunction<LocalDateTime, League, Boolean> InProgressFunction;
+    private final String description;
+    private final BiFunction<LocalDateTime, League, Boolean> InProgressFunction;
+    private final int order;
 
-	public static String getProgressDescription(final LocalDateTime localDateTime, final League league) {
-		return Stream.of(LeagueProgress.values())
-			.filter(lp -> lp.getInProgressFunction().apply(localDateTime, league))
-			.map(LeagueProgress::getDescription)
-			.findFirst()
-			.orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, LeagueErrorMessages.PROGRESS_NOT_FOUND_EXCEPTION));
-	}
+    public static LeagueProgress fromDate(final LocalDateTime localDateTime, final League league) {
+        return Stream.of(LeagueProgress.values())
+                .filter(lp -> lp.getInProgressFunction().apply(localDateTime, league))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, LeagueErrorMessages.PROGRESS_NOT_FOUND_EXCEPTION));
+    }
 }

--- a/src/main/java/com/sports/server/common/config/CloudWatchCustomConfig.java
+++ b/src/main/java/com/sports/server/common/config/CloudWatchCustomConfig.java
@@ -9,9 +9,11 @@ import java.time.Duration;
 import io.micrometer.core.instrument.config.MeterFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 
+@Profile("prod")
 @Configuration
 public class CloudWatchCustomConfig {
 

--- a/src/main/java/com/sports/server/query/application/LeagueProgressComparator.java
+++ b/src/main/java/com/sports/server/query/application/LeagueProgressComparator.java
@@ -1,0 +1,19 @@
+package com.sports.server.query.application;
+
+import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.LeagueProgress;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+
+public class LeagueProgressComparator implements Comparator<League> {
+
+    @Override
+    public int compare(League o1, League o2) {
+
+        LeagueProgress leagueProgressOfO1 = LeagueProgress.fromDate(LocalDateTime.now(), o1);
+        LeagueProgress leagueProgressOfO2 = LeagueProgress.fromDate(LocalDateTime.now(), o2);
+
+        return leagueProgressOfO1.getOrder() - leagueProgressOfO2.getOrder();
+    }
+}

--- a/src/main/java/com/sports/server/query/application/LeagueProgressComparator.java
+++ b/src/main/java/com/sports/server/query/application/LeagueProgressComparator.java
@@ -8,12 +8,16 @@ import java.util.Comparator;
 
 public class LeagueProgressComparator implements Comparator<League> {
 
+    private final LocalDateTime baseTime;
+
+    public LeagueProgressComparator(LocalDateTime baseTime) {
+        this.baseTime = baseTime;
+    }
+
     @Override
     public int compare(League o1, League o2) {
-
-        LeagueProgress leagueProgressOfO1 = LeagueProgress.fromDate(LocalDateTime.now(), o1);
-        LeagueProgress leagueProgressOfO2 = LeagueProgress.fromDate(LocalDateTime.now(), o2);
-
-        return leagueProgressOfO1.getOrder() - leagueProgressOfO2.getOrder();
+        LeagueProgress p1 = LeagueProgress.fromDate(baseTime, o1);
+        LeagueProgress p2 = LeagueProgress.fromDate(baseTime, o2);
+        return Integer.compare(p1.getOrder(), p2.getOrder());
     }
 }

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -19,7 +19,6 @@ import com.sports.server.query.repository.*;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -52,35 +51,22 @@ public class LeagueQueryService {
         }
 
         List<Long> leagueIds = leagues.stream().map(League::getId).toList();
-        Map<Long, String> firstWinnerTeamsInfo = leagueStatisticsQueryRepository.findWinnerTeamInfoByLeagueIds(leagueIds)
-                .stream()
-                .collect(Collectors.toMap(
-                        LeagueWinnerInfo::leagueId,
-                        LeagueWinnerInfo::winnerTeamName
-                ));
+        Map<Long, String> firstWinnerTeamsInfo = leagueStatisticsQueryRepository.findWinnerTeamInfoByLeagueIds(leagueIds).stream().collect(Collectors.toMap(LeagueWinnerInfo::leagueId, LeagueWinnerInfo::winnerTeamName));
 
-        return leagues.stream()
-                .map(league -> {
-                    String winnerTeamName = firstWinnerTeamsInfo.get(league.getId());
-                    return new LeagueResponse(league, winnerTeamName);
-                })
-                .toList();
+        return leagues.stream().map(league -> {
+            String winnerTeamName = firstWinnerTeamsInfo.get(league.getId());
+            return new LeagueResponse(league, winnerTeamName);
+        }).toList();
     }
 
     public List<LeagueTeamResponse> findTeamsByLeagueRound(Long leagueId, Integer round) {
         League league = entityUtils.getEntity(leagueId, League.class);
 
-        return teamDynamicRepository.findByLeagueAndRound(league, round)
-                .stream()
-                .map(leagueTeam -> new LeagueTeamResponse(leagueTeam.getTeam(), leagueTeam.getId()))
-                .toList();
+        return teamDynamicRepository.findByLeagueAndRound(league, round).stream().map(leagueTeam -> new LeagueTeamResponse(leagueTeam.getTeam(), leagueTeam.getId())).toList();
     }
 
     public LeagueDetailResponse findLeagueDetail(Long leagueId) {
-        return leagueQueryRepository.findById(leagueId)
-                .map(league -> LeagueDetailResponse.of(league,
-                        teamDynamicRepository.findByLeagueAndRound(league, null).size()))
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 리그입니다"));
+        return leagueQueryRepository.findById(leagueId).map(league -> LeagueDetailResponse.of(league, teamDynamicRepository.findByLeagueAndRound(league, null).size())).orElseThrow(() -> new NotFoundException("존재하지 않는 리그입니다"));
     }
 
     public List<PlayerResponse> findPlayersByLeagueTeam(Long leagueTeamId) {
@@ -92,40 +78,35 @@ public class LeagueQueryService {
             return Collections.emptyList();
         }
 
-        List<Long> playerIds = teamPlayers.stream()
-                .map(tp -> tp.getPlayer().getId())
-                .toList();
+        List<Long> playerIds = teamPlayers.stream().map(tp -> tp.getPlayer().getId()).toList();
 
         Map<Long, Integer> goalCountMap = playerInfoProvider.getPlayersTotalGoalInfo(playerIds);
-        return teamPlayers.stream()
-                .map(teamPlayer -> {
-                    int totalGoals = goalCountMap.getOrDefault(teamPlayer.getPlayer().getId(), 0);
-                    return PlayerResponse.of(teamPlayer, totalGoals);
-                })
-                .toList();
+        return teamPlayers.stream().map(teamPlayer -> {
+            int totalGoals = goalCountMap.getOrDefault(teamPlayer.getPlayer().getId(), 0);
+            return PlayerResponse.of(teamPlayer, totalGoals);
+        }).toList();
     }
 
     public List<LeagueResponseWithInProgressGames> findLeaguesByManager(final Member member) {
         List<League> leagues = leagueQueryRepository.findByManager(member);
-        Map<League, List<Game>> gamesForLeagues = getGamesForLeague(leagues);
+        Map<League, List<Game>> gamesForLeagues = getPlayingGamesOfLeagues(leagues);
 
-        return leagues.stream()
-                .map(league -> LeagueResponseWithInProgressGames.of(
-                        league,
-                        LeagueProgress.fromDate(LocalDateTime.now(), league).getDescription(),
-                        gamesForLeagues.get(league)))
-                .toList();
+        return leagues.stream().map(league -> LeagueResponseWithInProgressGames.of(league, LeagueProgress.fromDate(LocalDateTime.now(), league).getDescription(), gamesForLeagues.get(league))).toList();
     }
 
-    private Map<League, List<Game>> getGamesForLeague(List<League> leagues) {
-        return leagues.stream()
-                .collect(toMap(league -> league,
-                        gameQueryRepository::findPlayingGamesByLeagueWithGameTeams));
+    private Map<League, List<Game>> getPlayingGamesOfLeagues(List<League> leagues) {
+        List<Long> leagueIds = leagues.stream().map(League::getId).toList();
+        List<Game> games = gameQueryRepository.findPlayingGamesByLeagueIdsWithGameTeams(leagueIds);
+
+        return leagues.stream().collect(toMap(league -> league, league -> getPlayingGamesOfLeague(league, games)));
+    }
+
+    private List<Game> getPlayingGamesOfLeague(League league, List<Game> games) {
+        return games.stream().filter(game -> game.getLeague().equals(league)).toList();
     }
 
     public LeagueResponseWithGames findLeagueAndGames(final Long leagueId) {
-        League league = leagueQueryRepository.findByIdWithLeagueTeam(leagueId)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 리그입니다"));
+        League league = leagueQueryRepository.findByIdWithLeagueTeam(leagueId).orElseThrow(() -> new NotFoundException("존재하지 않는 리그입니다"));
         List<Game> games = gameQueryRepository.findByLeagueWithGameTeams(league);
         return LeagueResponseWithGames.of(league, games);
     }
@@ -133,28 +114,16 @@ public class LeagueQueryService {
     public List<LeagueResponseToManage> findLeaguesByManagerToManage(final Member manager) {
         List<League> leagues = leagueQueryRepository.findByManagerToManage(manager);
 
-        return leagues.stream()
-                .sorted(new LeagueProgressComparator(LocalDateTime.now()))
-                .map(LeagueResponseToManage::of)
-                .toList();
+        return leagues.stream().sorted(new LeagueProgressComparator(LocalDateTime.now())).map(LeagueResponseToManage::of).toList();
     }
 
     public LeagueStatisticsResponse findLeagueStatistic(Long leagueId) {
         entityUtils.getEntity(leagueId, League.class);
-        LeagueStatistics statistics = leagueStatisticsQueryRepository.findByLeagueId(leagueId)
-                .orElseThrow(() -> new NotFoundException("리그 통계 데이터가 아직 업데이트되지 않았습니다."));
+        LeagueStatistics statistics = leagueStatisticsQueryRepository.findByLeagueId(leagueId).orElseThrow(() -> new NotFoundException("리그 통계 데이터가 아직 업데이트되지 않았습니다."));
 
-        Map<Long, LeagueTeam> leagueTeamsInfo = leagueTeamQueryRepository.findByLeagueId(leagueId).stream()
-                .collect(Collectors.toMap(lt -> lt.getTeam().getId(), lt -> lt));
+        Map<Long, LeagueTeam> leagueTeamsInfo = leagueTeamQueryRepository.findByLeagueId(leagueId).stream().collect(Collectors.toMap(lt -> lt.getTeam().getId(), lt -> lt));
 
-        return LeagueStatisticsResponse.builder()
-                .firstWinnerTeam(createLeagueTeamResponseForWinner(statistics.getFirstWinnerTeam(), leagueTeamsInfo))
-                .secondWinnerTeam(createLeagueTeamResponseForWinner(statistics.getSecondWinnerTeam(), leagueTeamsInfo))
-                .mostCheeredTeam(LeagueTeamResponse.ofWithCheerCount(
-                        findLeagueTeamFor(statistics.getMostCheeredTeam(), leagueTeamsInfo)))
-                .mostCheerTalksTeam(LeagueTeamResponse.ofWithTotalTalkCount(
-                        findLeagueTeamFor(statistics.getMostCheerTalksTeam(), leagueTeamsInfo)))
-                .build();
+        return LeagueStatisticsResponse.builder().firstWinnerTeam(createLeagueTeamResponseForWinner(statistics.getFirstWinnerTeam(), leagueTeamsInfo)).secondWinnerTeam(createLeagueTeamResponseForWinner(statistics.getSecondWinnerTeam(), leagueTeamsInfo)).mostCheeredTeam(LeagueTeamResponse.ofWithCheerCount(findLeagueTeamFor(statistics.getMostCheeredTeam(), leagueTeamsInfo))).mostCheerTalksTeam(LeagueTeamResponse.ofWithTotalTalkCount(findLeagueTeamFor(statistics.getMostCheerTalksTeam(), leagueTeamsInfo))).build();
     }
 
     private LeagueTeamResponse createLeagueTeamResponseForWinner(Team team, Map<Long, LeagueTeam> leagueTeamsInfo) {
@@ -177,17 +146,12 @@ public class LeagueQueryService {
     }
 
     public List<TopScorerResponse> findTop20ScorersByLeagueId(Long leagueId) {
-        return leagueTopScorerRepository.findByLeagueId(leagueId)
-                .stream()
-                .map(TopScorerResponse::from)
-                .toList();
+        return leagueTopScorerRepository.findByLeagueId(leagueId).stream().map(TopScorerResponse::from).toList();
     }
 
     public List<TopScorerResponse> findTopScorersByYear(Integer year, Integer limit) {
         List<PlayerGoalCountWithRank> results = leagueTopScorerRepository.findTopPlayersByYearWithTotalGoals(year, PageRequest.of(0, limit));
 
-        return results.stream()
-                .map(result -> TopScorerResponse.of(result.playerId(), result.studentNumber(), result.playerName(), result.goalCount().intValue(), result.rank().intValue()))
-                .toList();
+        return results.stream().map(result -> TopScorerResponse.of(result.playerId(), result.studentNumber(), result.playerName(), result.goalCount().intValue(), result.rank().intValue())).toList();
     }
 }

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -134,7 +134,7 @@ public class LeagueQueryService {
         List<League> leagues = leagueQueryRepository.findByManagerToManage(manager);
 
         return leagues.stream()
-                .sorted(new LeagueProgressComparator())
+                .sorted(new LeagueProgressComparator(LocalDateTime.now()))
                 .map(LeagueResponseToManage::of)
                 .toList();
     }

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -51,7 +51,11 @@ public class LeagueQueryService {
         }
 
         List<Long> leagueIds = leagues.stream().map(League::getId).toList();
-        Map<Long, String> firstWinnerTeamsInfo = leagueStatisticsQueryRepository.findWinnerTeamInfoByLeagueIds(leagueIds).stream().collect(Collectors.toMap(LeagueWinnerInfo::leagueId, LeagueWinnerInfo::winnerTeamName));
+        Map<Long, String> firstWinnerTeamsInfo = leagueStatisticsQueryRepository.findWinnerTeamInfoByLeagueIds(leagueIds).stream()
+                .collect(Collectors.toMap(
+                        LeagueWinnerInfo::leagueId,
+                        LeagueWinnerInfo::winnerTeamName
+                ));
 
         return leagues.stream().map(league -> {
             String winnerTeamName = firstWinnerTeamsInfo.get(league.getId());
@@ -95,18 +99,23 @@ public class LeagueQueryService {
         List<League> leagues = leagueQueryRepository.findByManager(member);
         Map<League, List<Game>> gamesForLeagues = getPlayingGamesOfLeagues(leagues);
 
-        return leagues.stream().map(league -> LeagueResponseWithInProgressGames.of(league, LeagueProgress.fromDate(LocalDateTime.now(), league).getDescription(), gamesForLeagues.get(league))).toList();
+        return leagues.stream()
+                .map(league -> LeagueResponseWithInProgressGames.of(league, LeagueProgress.fromDate(LocalDateTime.now(), league).getDescription(), gamesForLeagues.get(league)))
+                .toList();
     }
 
     private Map<League, List<Game>> getPlayingGamesOfLeagues(List<League> leagues) {
         List<Long> leagueIds = leagues.stream().map(League::getId).toList();
         List<Game> games = gameQueryRepository.findPlayingGamesByLeagueIdsWithGameTeams(leagueIds);
 
-        return leagues.stream().collect(toMap(league -> league, league -> getPlayingGamesOfLeague(league, games)));
+        return leagues.stream()
+                .collect(toMap(league -> league, league -> getPlayingGamesOfLeague(league, games)));
     }
 
     private List<Game> getPlayingGamesOfLeague(League league, List<Game> games) {
-        return games.stream().filter(game -> game.getLeague().equals(league)).toList();
+        return games.stream()
+                .filter(game -> game.getLeague().equals(league))
+                .toList();
     }
 
     public LeagueResponseWithGames findLeagueAndGames(final Long leagueId) {
@@ -118,7 +127,9 @@ public class LeagueQueryService {
     public List<LeagueResponseToManage> findLeaguesByManagerToManage(final Member manager) {
         List<League> leagues = leagueQueryRepository.findByManagerToManage(manager);
 
-        return leagues.stream().sorted(new LeagueProgressComparator(LocalDateTime.now())).map(LeagueResponseToManage::of).toList();
+        return leagues.stream()
+                .sorted(new LeagueProgressComparator(LocalDateTime.now())).map(LeagueResponseToManage::of)
+                .toList();
     }
 
     public LeagueStatisticsResponse findLeagueStatistic(Long leagueId) {
@@ -150,12 +161,15 @@ public class LeagueQueryService {
     }
 
     public List<TopScorerResponse> findTop20ScorersByLeagueId(Long leagueId) {
-        return leagueTopScorerRepository.findByLeagueId(leagueId).stream().map(TopScorerResponse::from).toList();
+        return leagueTopScorerRepository.findByLeagueId(leagueId).stream()
+                .map(TopScorerResponse::from).toList();
     }
 
     public List<TopScorerResponse> findTopScorersByYear(Integer year, Integer limit) {
         List<PlayerGoalCountWithRank> results = leagueTopScorerRepository.findTopPlayersByYearWithTotalGoals(year, PageRequest.of(0, limit));
 
-        return results.stream().map(result -> TopScorerResponse.of(result.playerId(), result.studentNumber(), result.playerName(), result.goalCount().intValue(), result.rank().intValue())).toList();
+        return results.stream()
+                .map(result -> TopScorerResponse.of(result.playerId(), result.studentNumber(), result.playerName(), result.goalCount().intValue(), result.rank().intValue()))
+                .toList();
     }
 }

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -62,11 +62,15 @@ public class LeagueQueryService {
     public List<LeagueTeamResponse> findTeamsByLeagueRound(Long leagueId, Integer round) {
         League league = entityUtils.getEntity(leagueId, League.class);
 
-        return teamDynamicRepository.findByLeagueAndRound(league, round).stream().map(leagueTeam -> new LeagueTeamResponse(leagueTeam.getTeam(), leagueTeam.getId())).toList();
+        return teamDynamicRepository.findByLeagueAndRound(league, round).stream()
+                .map(leagueTeam -> new LeagueTeamResponse(leagueTeam.getTeam(), leagueTeam.getId()))
+                .toList();
     }
 
     public LeagueDetailResponse findLeagueDetail(Long leagueId) {
-        return leagueQueryRepository.findById(leagueId).map(league -> LeagueDetailResponse.of(league, teamDynamicRepository.findByLeagueAndRound(league, null).size())).orElseThrow(() -> new NotFoundException("존재하지 않는 리그입니다"));
+        return leagueQueryRepository.findById(leagueId)
+                .map(league -> LeagueDetailResponse.of(league, teamDynamicRepository.findByLeagueAndRound(league, null).size()))
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 리그입니다"));
     }
 
     public List<PlayerResponse> findPlayersByLeagueTeam(Long leagueTeamId) {

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -112,7 +112,7 @@ public class LeagueQueryService {
         return leagues.stream()
                 .map(league -> LeagueResponseWithInProgressGames.of(
                         league,
-                        LeagueProgress.getProgressDescription(LocalDateTime.now(), league),
+                        LeagueProgress.fromDate(LocalDateTime.now(), league).getDescription(),
                         gamesForLeagues.get(league)))
                 .toList();
     }
@@ -133,12 +133,8 @@ public class LeagueQueryService {
     public List<LeagueResponseToManage> findLeaguesByManagerToManage(final Member manager) {
         List<League> leagues = leagueQueryRepository.findByManagerToManage(manager);
 
-        Comparator<League> comparator = Comparator.comparing(
-                league -> leagueProgressOrderMap.get(
-                        LeagueProgress.getProgressDescription(LocalDateTime.now(), league)));
-
         return leagues.stream()
-                .sorted(comparator)
+                .sorted(new LeagueProgressComparator())
                 .map(LeagueResponseToManage::of)
                 .toList();
     }
@@ -189,15 +185,9 @@ public class LeagueQueryService {
 
     public List<TopScorerResponse> findTopScorersByYear(Integer year, Integer limit) {
         List<PlayerGoalCountWithRank> results = leagueTopScorerRepository.findTopPlayersByYearWithTotalGoals(year, PageRequest.of(0, limit));
-        
+
         return results.stream()
                 .map(result -> TopScorerResponse.of(result.playerId(), result.studentNumber(), result.playerName(), result.goalCount().intValue(), result.rank().intValue()))
                 .toList();
     }
-
-    public static Map<String, Integer> leagueProgressOrderMap = Map.ofEntries(
-            Map.entry(LeagueProgress.IN_PROGRESS.getDescription(), 1),
-            Map.entry(LeagueProgress.BEFORE_START.getDescription(), 2),
-            Map.entry(LeagueProgress.FINISHED.getDescription(), 3)
-    );
 }

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -105,17 +105,19 @@ public class LeagueQueryService {
     }
 
     private Map<League, List<Game>> getPlayingGamesOfLeagues(List<League> leagues) {
+        if (leagues.isEmpty()) {
+            return Collections.emptyMap();
+        }
         List<Long> leagueIds = leagues.stream().map(League::getId).toList();
         List<Game> games = gameQueryRepository.findPlayingGamesByLeagueIdsWithGameTeams(leagueIds);
+        Map<Long, List<Game>> gamesByLeagueId = games.stream()
+                .collect(Collectors.groupingBy(game -> game.getLeague().getId()));
 
         return leagues.stream()
-                .collect(toMap(league -> league, league -> getPlayingGamesOfLeague(league, games)));
-    }
-
-    private List<Game> getPlayingGamesOfLeague(League league, List<Game> games) {
-        return games.stream()
-                .filter(game -> game.getLeague().equals(league))
-                .toList();
+                .collect(Collectors.toMap(
+                        league -> league,
+                        league -> gamesByLeagueId.getOrDefault(league.getId(), Collections.emptyList())
+                ));
     }
 
     public LeagueResponseWithGames findLeagueAndGames(final Long leagueId) {

--- a/src/main/java/com/sports/server/query/application/TeamQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TeamQueryService.java
@@ -44,15 +44,15 @@ public class TeamQueryService {
     private final LeagueStatisticsQueryRepository leagueStatisticsQueryRepository;
     private final GameQueryRepository gameQueryRepository;
 
-    public List<TeamResponse> getAllTeamsByUnits(final List<String> units){
+    public List<TeamResponse> getAllTeamsByUnits(final List<String> units) {
         List<Team> teams = findTeamsByUnits(units);
         return teams.stream()
                 .map(TeamResponse::new)
                 .toList();
     }
 
-    public List<PlayerResponse> getAllTeamPlayers(Long teamId){
-        List<TeamPlayer> teamPlayers = teamQueryRepository.findAllTeamPlayer(teamId);
+    public List<PlayerResponse> getAllTeamPlayers(Long teamId) {
+        List<TeamPlayer> teamPlayers = teamQueryRepository.findTeamPlayersByTeamId(teamId);
         List<Long> playerIds = teamPlayerRepository.findPlayerIdsByTeamId(teamId);
 
         Map<Long, Integer> playerTotalGoalCountInfo = playerInfoProvider.getPlayersTotalGoalInfo(playerIds);
@@ -65,7 +65,7 @@ public class TeamQueryService {
                 .toList();
     }
 
-    public TeamDetailResponse getTeamDetail(Long teamId){
+    public TeamDetailResponse getTeamDetail(Long teamId) {
         Team team = entityUtils.getEntity(teamId, Team.class);
 
         TeamDetailResponse.TeamGameResult teamGameResult = getTeamGameResults(List.of(teamId)).get(teamId);
@@ -76,7 +76,7 @@ public class TeamQueryService {
         return new TeamDetailResponse(team, teamPlayers, teamGameResult, scorers, trophies);
     }
 
-    public List<TeamSummaryResponse> getAllTeamsSummary(final List<String> units){
+    public List<TeamSummaryResponse> getAllTeamsSummary(final List<String> units) {
         List<Team> teams = findTeamsByUnits(units);
         if (teams.isEmpty()) return Collections.emptyList();
 
@@ -93,21 +93,21 @@ public class TeamQueryService {
     }
 
     private TeamStatistics getTeamStatistics(List<Long> teamIds) {
-            return new TeamStatistics(
-                    getTeamGameResults(teamIds),
-                    getTeamTopScorers(teamIds, TEAM_SUMMARY_TOP_SCORERS_COUNT),
-                    getTrophies(teamIds),
-                    getRecentGames(teamIds)
-            );
+        return new TeamStatistics(
+                getTeamGameResults(teamIds),
+                getTeamTopScorers(teamIds, TEAM_SUMMARY_TOP_SCORERS_COUNT),
+                getTrophies(teamIds),
+                getRecentGames(teamIds)
+        );
     }
 
-    private List<Team> findTeamsByUnits(final List<String> units){
+    private List<Team> findTeamsByUnits(final List<String> units) {
         if (units == null || units.isEmpty()) return teamQueryRepository.findAll();
         List<Unit> targetUnits = Unit.fromNames(units);
         return teamQueryDynamicRepository.findAllByUnits(targetUnits);
     }
 
-    private Map<Long, TeamDetailResponse.TeamGameResult> getTeamGameResults(List<Long> teamIds){
+    private Map<Long, TeamDetailResponse.TeamGameResult> getTeamGameResults(List<Long> teamIds) {
         List<TeamGameResult> results = gameTeamRepository.findGameResultsByTeamIds(teamIds);
 
         Map<Long, Map<GameResult, Integer>> teamResult = new HashMap<>();
@@ -132,7 +132,7 @@ public class TeamQueryService {
                 ));
     }
 
-    private Map<Long, List<TeamDetailResponse.TeamTopScorer>> getTeamTopScorers(List<Long> teamIds, int size){
+    private Map<Long, List<TeamDetailResponse.TeamTopScorer>> getTeamTopScorers(List<Long> teamIds, int size) {
         Map<Long, List<PlayerGoalCountWithRank>> topScorersMap = playerInfoProvider.getTeamsTopScorers(teamIds, size);
 
         return teamIds.stream()
@@ -208,7 +208,7 @@ public class TeamQueryService {
                 ));
     }
 
-    private List<GameDetailResponse> getSortedRecentGames(List<GameTeam> gameTeams, 
+    private List<GameDetailResponse> getSortedRecentGames(List<GameTeam> gameTeams,
                                                           Map<Long, GameDetailResponse> gameDetailsMap) {
         return gameTeams.stream()
                 .map(gt -> gameDetailsMap.get(gt.getGame().getId()))

--- a/src/main/java/com/sports/server/query/dto/response/LeagueDetailResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueDetailResponse.java
@@ -14,15 +14,15 @@ public record LeagueDetailResponse(
         String leagueProgress,
         Integer leagueTeamCount
 ) {
-	public static LeagueDetailResponse of(League league, Integer leagueTeamCount) {
-		return new LeagueDetailResponse(
-			league.getName(),
-			league.getStartAt(),
-			league.getEndAt(),
-			league.getMaxRound().getNumber(),
-			league.getInProgressRound().getNumber(),
-			LeagueProgress.getProgressDescription(LocalDateTime.now(), league),
-			leagueTeamCount
-		);
-	}
+    public static LeagueDetailResponse of(League league, Integer leagueTeamCount) {
+        return new LeagueDetailResponse(
+                league.getName(),
+                league.getStartAt(),
+                league.getEndAt(),
+                league.getMaxRound().getNumber(),
+                league.getInProgressRound().getNumber(),
+                LeagueProgress.fromDate(LocalDateTime.now(), league).getDescription(),
+                leagueTeamCount
+        );
+    }
 }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueResponse.java
@@ -8,20 +8,20 @@ import com.sports.server.command.league.domain.LeagueProgress;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LeagueResponse(
-	Long leagueId,
-	String name,
-	int maxRound,
-	int inProgressRound,
-	String leagueProgress,
-	String winnerTeamName
+        Long leagueId,
+        String name,
+        int maxRound,
+        int inProgressRound,
+        String leagueProgress,
+        String winnerTeamName
 ) {
-	public LeagueResponse(League league, String winnerTeamName) {
-		this(
-			league.getId(),
-			league.getName(),
-			league.getMaxRound().getNumber(),
-			league.getInProgressRound().getNumber(),
-			LeagueProgress.getProgressDescription(LocalDateTime.now(), league), winnerTeamName
-		);
-	}
+    public LeagueResponse(League league, String winnerTeamName) {
+        this(
+                league.getId(),
+                league.getName(),
+                league.getMaxRound().getNumber(),
+                league.getInProgressRound().getNumber(),
+                LeagueProgress.fromDate(LocalDateTime.now(), league).getDescription(), winnerTeamName
+        );
+    }
 }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueResponseToManage.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueResponseToManage.java
@@ -16,13 +16,13 @@ public record LeagueResponseToManage(
 ) {
     public static LeagueResponseToManage of(League league) {
         return new LeagueResponseToManage(
-            league.getId(),
-            league.getName(),
-            LeagueProgress.getProgressDescription(LocalDateTime.now(), league),
-            league.getLeagueTeams().size(),
-            league.getMaxRound().getNumber(),
-            league.getStartAt(),
-            league.getEndAt()
+                league.getId(),
+                league.getName(),
+                LeagueProgress.fromDate(LocalDateTime.now(), league).getDescription(),
+                league.getLeagueTeams().size(),
+                league.getMaxRound().getNumber(),
+                league.getStartAt(),
+                league.getEndAt()
         );
     }
 }

--- a/src/main/java/com/sports/server/query/repository/GameQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/GameQueryRepository.java
@@ -2,6 +2,7 @@ package com.sports.server.query.repository;
 
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.league.domain.League;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -17,6 +18,14 @@ public interface GameQueryRepository extends Repository<Game, Long> {
                     + "AND g.state = 'PLAYING'"
     )
     List<Game> findPlayingGamesByLeagueWithGameTeams(@Param("league") League league);
+
+    @Query(
+            "SELECT g FROM Game g "
+                    + "JOIN FETCH g.gameTeams "
+                    + "WHERE g.league.id in :leagueIds "
+                    + "AND g.state = 'PLAYING'"
+    )
+    List<Game> findPlayingGamesByLeagueIdsWithGameTeams(@Param("leagueIds") List<Long> leagueIds);
 
     @Query(
             "SELECT g FROM Game g "

--- a/src/main/java/com/sports/server/query/repository/LeagueQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueQueryRepository.java
@@ -2,8 +2,10 @@ package com.sports.server.query.repository;
 
 import com.sports.server.command.league.domain.League;
 import com.sports.server.command.member.domain.Member;
+
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/sports/server/query/repository/TeamQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TeamQueryRepository.java
@@ -12,5 +12,5 @@ public interface TeamQueryRepository extends Repository<Team, Long> {
     List<Team> findAll();
 
     @Query("SELECT tp FROM TeamPlayer tp JOIN FETCH tp.player WHERE tp.team.id = :teamId")
-    List<TeamPlayer> findAllTeamPlayer(@Param("teamId") Long teamId);
+    List<TeamPlayer> findTeamPlayersByTeamId(@Param("teamId") Long teamId);
 }

--- a/src/test/java/com/sports/server/command/league/domain/LeagueProgressTest.java
+++ b/src/test/java/com/sports/server/command/league/domain/LeagueProgressTest.java
@@ -14,51 +14,51 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class LeagueProgressTest {
-	@Mock
-	private League league;
+    @Mock
+    private League league;
 
-	@BeforeEach
-	void init() {
-		doReturn(LocalDateTime.of(2024, 2, 24, 0, 0, 0)).when(league).getStartAt();
-		lenient().doReturn(LocalDateTime.of(2024, 2, 28, 0, 0, 0)).when(league).getEndAt();
-	}
+    @BeforeEach
+    void init() {
+        doReturn(LocalDateTime.of(2024, 2, 24, 0, 0, 0)).when(league).getStartAt();
+        lenient().doReturn(LocalDateTime.of(2024, 2, 28, 0, 0, 0)).when(league).getEndAt();
+    }
 
-	@ParameterizedTest
-	@ValueSource(ints = {22, 23})
-	void 리그가_시작_전인지_확인한다(int dayOfMonth) {
-		// given
-		LocalDateTime now = LocalDateTime.of(2024, 2, dayOfMonth, 0, 0, 0);
+    @ParameterizedTest
+    @ValueSource(ints = {22, 23})
+    void 리그가_시작_전인지_확인한다(int dayOfMonth) {
+        // given
+        LocalDateTime now = LocalDateTime.of(2024, 2, dayOfMonth, 0, 0, 0);
 
-		// when
-		String actual = LeagueProgress.getProgressDescription(now, league);
+        // when
+        String actual = LeagueProgress.fromDate(now, league).getDescription();
 
-		// then
-		assertThat(actual).isEqualTo(LeagueProgress.BEFORE_START.getDescription());
-	}
+        // then
+        assertThat(actual).isEqualTo(LeagueProgress.BEFORE_START.getDescription());
+    }
 
-	@ParameterizedTest
-	@ValueSource(ints = {24, 25, 26, 27})
-	void 리그가_진행_중임을_확인_한다(int dayOfMonth) {
-		// given
-		LocalDateTime now = LocalDateTime.of(2024, 2, dayOfMonth, 0, 0, 0);
+    @ParameterizedTest
+    @ValueSource(ints = {24, 25, 26, 27})
+    void 리그가_진행_중임을_확인_한다(int dayOfMonth) {
+        // given
+        LocalDateTime now = LocalDateTime.of(2024, 2, dayOfMonth, 0, 0, 0);
 
-		// when
-		String actual = LeagueProgress.getProgressDescription(now, league);
+        // when
+        String actual = LeagueProgress.fromDate(now, league).getDescription();
 
-		// then
-		assertThat(actual).isEqualTo(LeagueProgress.IN_PROGRESS.getDescription());
-	}
+        // then
+        assertThat(actual).isEqualTo(LeagueProgress.IN_PROGRESS.getDescription());
+    }
 
-	@ParameterizedTest
-	@ValueSource(ints = {28, 29})
-	void 리그가_종료됐는지_확인_한다(int dayOfMonth) {
-		// given
-		LocalDateTime now = LocalDateTime.of(2024, 2, dayOfMonth, 0, 0, 0);
+    @ParameterizedTest
+    @ValueSource(ints = {28, 29})
+    void 리그가_종료됐는지_확인_한다(int dayOfMonth) {
+        // given
+        LocalDateTime now = LocalDateTime.of(2024, 2, dayOfMonth, 0, 0, 0);
 
-		// when
-		String actual = LeagueProgress.getProgressDescription(now, league);
+        // when
+        String actual = LeagueProgress.fromDate(now, league).getDescription();
 
-		// then
-		assertThat(actual).isEqualTo(LeagueProgress.FINISHED.getDescription());
-	}
+        // then
+        assertThat(actual).isEqualTo(LeagueProgress.FINISHED.getDescription());
+    }
 }

--- a/src/test/java/com/sports/server/query/acceptance/CheerTalkEventHandlerTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/CheerTalkEventHandlerTest.java
@@ -10,8 +10,10 @@ import com.sports.server.command.cheertalk.application.CheerTalkService;
 import com.sports.server.command.cheertalk.dto.CheerTalkRequest;
 import com.sports.server.query.dto.response.CheerTalkResponse;
 import com.sports.server.support.AcceptanceTest;
+
 import java.lang.reflect.Type;
 import java.util.concurrent.CompletableFuture;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/sports/server/query/application/LeagueQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/LeagueQueryServiceTest.java
@@ -1,6 +1,5 @@
 package com.sports.server.query.application;
 
-import static com.sports.server.query.application.LeagueQueryService.leagueProgressOrderMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -19,6 +18,7 @@ import com.sports.server.query.dto.request.LeagueQueryRequestDto;
 import com.sports.server.support.ServiceTest;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -187,7 +187,12 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 리그가_진행중_시작전_종료_순으로_조회된다() {
             // given
-            Comparator<String> comparator = Comparator.comparingInt(leagueProgressOrderMap::get);
+            Map<String, Integer> ordersOfProgress = Arrays.stream(LeagueProgress.values())
+                    .collect(Collectors.toMap(
+                            LeagueProgress::getDescription,
+                            LeagueProgress::getOrder
+                    ));
+            Comparator<String> comparator = Comparator.comparingInt(ordersOfProgress::get);
 
             // then
             assertAll(


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #389 

## 📝 구현 내용

### 1. Comparator 구현

- `LeagueProgress` 의 우선순위가 Map 형태로 서비스 레이어에 존재 -> `LeagueProgress` 내부로 옮김
- `LeagueProgress` 의 우선순위에 따른 Map 을 통해 정렬 -> Comparator 따로 구현

### 2. N+1 쿼리 개선

- `https://www.hufscheer.com/leagues/165` 이 페이지에서의 로딩 속도가 너무 느려서 확인해보니, 호출하는 API 가 1.32s 가 걸리는 것을 확인
 
<img width="645" height="242" alt="스크린샷 2025-09-25 오후 2 03 02" src="https://github.com/user-attachments/assets/c828fa5f-aace-4a7d-ab4c-19a5ef0faad2" />
<br>

- k6 로 100번 쐈을 때에는 평균 약 3s 까지 걸리는 것을 확인

<img width="1063" height="483" alt="스크린샷 2025-09-25 오후 2 02 32" src="https://github.com/user-attachments/assets/1aff68bd-2f32-48c9-b090-753dd28a6246" />

- N+1 문제가 발생하는 것을 확인해 in 절을 통해 쿼리 단축


