### PR TITLE
[REFACTOR] 비동기로 로깅이 처리되도록 수정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -19,22 +19,29 @@
         </root>
     </springProfile>
 
+    <appender name="FILE-LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./log/today-${BY_DATE}.log</file>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/history-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>5</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
     <springProfile name="prod">
-        <appender name="FILE-LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>./log/today-${BY_DATE}.log</file>
-            <encoder>
-                <pattern>${FILE_LOG_PATTERN}</pattern>
-            </encoder>
-            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                <fileNamePattern> ./log/history-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-                <maxFileSize>100MB</maxFileSize>
-                <maxHistory>5</maxHistory>
-                <totalSizeCap>500MB</totalSizeCap>
-            </rollingPolicy>
+        <appender name="ASYNC-FILE" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="FILE-LOG"/>
+            <queueSize>8192</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
         </appender>
 
         <root level="INFO">
-            <appender-ref ref="FILE-LOG"/>
+            <appender-ref ref="ASYNC-FILE"/>
         </root>
     </springProfile>
 </configuration>


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #396 

## 문제 상황
- EBS 의 IOPS 성능으로 인해 CPU 100% 가 되는 상황 발생
- 더 나은 서비스를 위해 시행하는 로깅이 서비스에 영향을 주는 것에 대한 의문을 가짐

## 개선 사항
- 로깅을 비동기로 처리해 애플리케이션 성능에 영향을 주지 않도록 변경
- 큐가 꽉 차거나 로깅에 이상이 생길 경우에도 애플리케이션 처리를 우선하도록 설정 추가