### PR TITLE
[Fix] 선발 등록 시 is_playing 1로 변경 + 리그 통계 수동 업데이트 api 추가

### DIFF
--- a/src/main/java/com/sports/server/command/game/application/GameService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameService.java
@@ -63,6 +63,11 @@ public class GameService {
         return games;
     }
 
+    @Transactional(readOnly = true)
+    public List<Game> findGamesByIds(List<Long> gameIds) {
+        return gameRepository.findAllByIdIn(gameIds);
+    }
+
     @Transactional
     public void updateGame(Long leagueId, Long gameId, GameRequest.Update request, Member administrator) {
         League league = entityUtils.getEntity(leagueId, League.class);

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -37,4 +37,9 @@ public class GameStatusScheduler {
                     leagueService.updateTotalCheerCountsAndTotalTalkCount(game.getLeague().getId());
                 });
     }
+
+    public void manualUpdateLeagueStatisticsForFinalGames(List<Long> gameIds) {
+        List<Game> games = gameService.findGamesByIds(gameIds);
+        updateLeagueStatisticsForFinalGames(games);
+    }
 }

--- a/src/main/java/com/sports/server/command/game/domain/GameRepository.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameRepository.java
@@ -18,6 +18,5 @@ public interface GameRepository extends Repository<Game, Long> {
     )
     List<Game> findGamesOlderThanFiveHours(@Param("cutoffTime") LocalDateTime cutoffTime);
 
-    @Query("SELECT g FROM Game g WHERE g.id IN :gameIds")
-    List<Game> findAllByIdIn(@Param("gameIds") List<Long> gameIds);
+    List<Game> findAllByIdIn(List<Long> gameIds);
 }

--- a/src/main/java/com/sports/server/command/game/domain/GameRepository.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameRepository.java
@@ -17,4 +17,7 @@ public interface GameRepository extends Repository<Game, Long> {
                     "AND g.state = 'PLAYING'"
     )
     List<Game> findGamesOlderThanFiveHours(@Param("cutoffTime") LocalDateTime cutoffTime);
+
+    @Query("SELECT g FROM Game g WHERE g.id IN :gameIds")
+    List<Game> findAllByIdIn(@Param("gameIds") List<Long> gameIds);
 }

--- a/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
+++ b/src/main/java/com/sports/server/command/game/domain/LineupPlayer.java
@@ -52,6 +52,7 @@ public class LineupPlayer extends BaseEntity<LineupPlayer> {
         this.state = state;
         this.jerseyNumber = jerseyNumber;
         this.isCaptain = isCaptain;
+        this.isPlaying = (state == LineupPlayerState.STARTER);
     }
 
     public static LineupPlayer of(GameTeam gameTeam, Player player, LineupPlayerState state, Integer jerseyNumber, boolean isCaptain) {

--- a/src/main/java/com/sports/server/command/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/command/game/presentation/GameController.java
@@ -1,6 +1,7 @@
 package com.sports.server.command.game.presentation;
 
 import com.sports.server.command.game.application.GameService;
+import com.sports.server.command.game.application.GameStatusScheduler;
 import com.sports.server.command.game.application.GameTeamService;
 import com.sports.server.command.game.application.LineupPlayerService;
 import com.sports.server.command.game.dto.CheerCountUpdateRequest;
@@ -8,6 +9,7 @@ import com.sports.server.command.game.dto.GameRequest;
 import com.sports.server.command.member.domain.Member;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +23,7 @@ public class GameController {
     private final GameTeamService gameTeamService;
     private final LineupPlayerService lineupPlayerService;
     private final GameService gameService;
+    private final GameStatusScheduler gameStatusScheduler;
 
     @PostMapping("/games/{gameId}/cheer")
     @ResponseStatus(HttpStatus.OK)
@@ -97,5 +100,11 @@ public class GameController {
     public void removePlayerFromLineup(@PathVariable final Long gameTeamId,
                                        @PathVariable final Long lineupPlayerId) {
         lineupPlayerService.removePlayerFromLineup(gameTeamId, lineupPlayerId);
+    }
+
+            @PostMapping("/admin/games/statistics/update")
+    @ResponseStatus(HttpStatus.OK)
+    public void updateLeagueStatisticsForGames(@RequestBody List<Long> gameIds) {
+        gameStatusScheduler.manualUpdateLeagueStatisticsForFinalGames(gameIds);
     }
 }

--- a/src/main/java/com/sports/server/command/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/command/game/presentation/GameController.java
@@ -102,7 +102,7 @@ public class GameController {
         lineupPlayerService.removePlayerFromLineup(gameTeamId, lineupPlayerId);
     }
 
-            @PostMapping("/admin/games/statistics/update")
+    @PostMapping("/admin/games/statistics/update")
     @ResponseStatus(HttpStatus.OK)
     public void updateLeagueStatisticsForGames(@RequestBody List<Long> gameIds) {
         gameStatusScheduler.manualUpdateLeagueStatisticsForFinalGames(gameIds);

--- a/src/test/java/com/sports/server/support/DocumentationTest.java
+++ b/src/test/java/com/sports/server/support/DocumentationTest.java
@@ -8,6 +8,7 @@ import com.sports.server.auth.utils.JwtUtil;
 import com.sports.server.command.cheertalk.application.CheerTalkService;
 import com.sports.server.command.cheertalk.presentation.CheerTalkController;
 import com.sports.server.command.game.application.GameService;
+import com.sports.server.command.game.application.GameStatusScheduler;
 import com.sports.server.command.game.application.GameTeamService;
 import com.sports.server.command.game.application.LineupPlayerService;
 import com.sports.server.command.game.presentation.GameController;
@@ -152,6 +153,9 @@ public class DocumentationTest {
 
     @MockBean
     protected GameService gameService;
+
+    @MockBean
+    protected GameStatusScheduler gameStatusScheduler;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## 🌍 이슈 번호
#402

## 📝 구현 내용
- 리그 통계 수동 업데이트 api 추가는 기존에 작업했던 거라 같이 올렸어요 양해좀..
- 선발 등록 관련 커밋은 두 번째 커밋만 봐도 될 듯

## 🍀 확인해야 할 부분
- 무서우면 오늘 경기 끝나고 머지하죠
