### PR TITLE
[DEL] 응원톡 저장 시 필터링을 제거해요

### DIFF
--- a/src/main/java/com/sports/server/command/cheertalk/application/CheerTalkService.java
+++ b/src/main/java/com/sports/server/command/cheertalk/application/CheerTalkService.java
@@ -29,24 +29,16 @@ public class CheerTalkService {
     private final CheerTalkRepository cheerTalkRepository;
     private final ReportRepository reportRepository;
     private final GameTeamRepository gameTeamRepository;
-    private final LanguageFilter languageFilter;
     private final EntityUtils entityUtils;
     private final ApplicationEventPublisher eventPublisher;
 
     public void register(final CheerTalkRequest cheerTalkRequest) {
-        validateContent(cheerTalkRequest.content());
         GameTeam gameTeam = getGameTeam(cheerTalkRequest.gameTeamId());
 
         CheerTalk cheerTalk = new CheerTalk(cheerTalkRequest.content(), gameTeam.getId());
         cheerTalkRepository.save(cheerTalk);
 
         eventPublisher.publishEvent(new CheerTalkCreateEvent(cheerTalk, gameTeam.getGame().getId()));
-    }
-
-    private void validateContent(final String content) {
-        if (languageFilter.containsBadWord(content)) {
-            throw new BadRequestException(CHEER_TALK_CONTAINS_BAD_WORD);
-        }
     }
 
     public void block(final Long leagueId, final Long cheerTalkId, final Member manager) {

--- a/src/main/java/com/sports/server/command/cheertalk/domain/LanguageFilter.java
+++ b/src/main/java/com/sports/server/command/cheertalk/domain/LanguageFilter.java
@@ -1,5 +1,6 @@
 package com.sports.server.command.cheertalk.domain;
 
+@Deprecated
 public interface LanguageFilter {
 
     boolean containsBadWord(final String content);

--- a/src/main/java/com/sports/server/command/cheertalk/infra/LanguageFilterImpl.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/LanguageFilterImpl.java
@@ -4,6 +4,7 @@ import com.sports.server.command.cheertalk.domain.LanguageFilter;
 import com.vane.badwordfiltering.BadWordFiltering;
 import org.springframework.stereotype.Component;
 
+@Deprecated
 @Component
 public class LanguageFilterImpl implements LanguageFilter {
 

--- a/src/test/java/com/sports/server/command/cheertalk/application/CheerTalkServiceTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/application/CheerTalkServiceTest.java
@@ -6,6 +6,7 @@ import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.exception.CustomException;
 import com.sports.server.support.ServiceTest;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +36,7 @@ public class CheerTalkServiceTest extends ServiceTest {
         manager = entityUtils.getEntity(1L, Member.class);
     }
 
+    @Disabled(value = "욕설 필터링 기능을 LLM 으로 대체해 스킵")
     @ParameterizedTest
     @ValueSource(strings = {"ㅅㅂ", "개새", "ㅆㅂ"})
     void 욕설이_포함된_응원톡을_저장하려고_하면_예외가_발생한다(String content) {
@@ -47,6 +49,7 @@ public class CheerTalkServiceTest extends ServiceTest {
 
     }
 
+    @Disabled(value = "욕설 필터링 기능을 LLM 으로 대체해 스킵")
     @ParameterizedTest
     @ValueSource(strings = {"안녕", "파이팅", "할 수 있어!"})
     void 욕설이_포함되지_않은_응원톡은_정상적으로_저장된다(String content) {


### PR DESCRIPTION
## 📝 구현 내용

- 추후 필터링 기능을 다시 켤 수 있도록 우선은 Deprecated 처리만 해뒀어요

### as-is
- 외부 라이브러리에서 제공하는 필터링 기능을 통해 직접적인 욕설의 저장 자체를 막았었어요

### to-be
- LLM 호출을 통해서 욕설의 저장을 막지 않고 마스킹 해요 [관련 PR](https://github.com/hufscheer/spectator-server/pull/423)

### 제거의 배경
- 스포츠 경기라는 특성 상, 욕설이 섞인 코멘트를 달 가능성이 있어요
   - ex) ㅅㅂ ㅈㄴ 잘하네 -> 기존에는 아예 저장 불가능
   - ex) ** ** 잘하네 -> 마스킹을 통해 기존의 의도는 살리되, 불쾌감은 경감할 수 있도록 변경
