### PR TITLE
refactor: 학번 중복 시 프리뷰에서 제거하도록 변경

### DIFF
--- a/src/main/java/com/sports/server/command/nl/application/NlService.java
+++ b/src/main/java/com/sports/server/command/nl/application/NlService.java
@@ -192,11 +192,9 @@ public class NlService {
                 continue;
             }
 
-            if (seenStudentNumbers.contains(parsed.studentNumber())) {
-                playerPreviews.add(toPlayerPreview(parsed, PlayerStatus.DUPLICATE_IN_INPUT, null));
+            if (!seenStudentNumbers.add(parsed.studentNumber())) {
                 continue;
             }
-            seenStudentNumbers.add(parsed.studentNumber());
 
             Player existingPlayer = existingPlayerMap.get(parsed.studentNumber());
             playerPreviews.add(classifyPlayer(parsed, existingPlayer, teamPlayerIdSet));

--- a/src/main/java/com/sports/server/command/nl/domain/PlayerStatus.java
+++ b/src/main/java/com/sports/server/command/nl/domain/PlayerStatus.java
@@ -3,6 +3,5 @@ package com.sports.server.command.nl.domain;
 public enum PlayerStatus {
     NEW,
     EXISTS,
-    ALREADY_IN_TEAM,
-    DUPLICATE_IN_INPUT
+    ALREADY_IN_TEAM
 }

--- a/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
+++ b/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
@@ -168,8 +168,8 @@ class NlServiceTest {
         }
 
         @Test
-        @DisplayName("입력 내 학번이 중복되면 DUPLICATE_IN_INPUT으로 분류한다")
-        void 입력_내_학번_중복() {
+        @DisplayName("입력 내 학번이 중복되면 첫 번째만 남기고 제거한다")
+        void 입력_내_학번_중복_제거() {
             // given
             NlProcessRequest request = new NlProcessRequest(
                     186L, 1L, List.of(),
@@ -189,8 +189,9 @@ class NlServiceTest {
             NlProcessResponse response = nlService.process(request, mockMember);
 
             // then
+            assertThat(response.preview().players()).hasSize(1);
+            assertThat(response.preview().players().get(0).name()).isEqualTo("홍길동");
             assertThat(response.preview().players().get(0).status()).isEqualTo(PlayerStatus.NEW);
-            assertThat(response.preview().players().get(1).status()).isEqualTo(PlayerStatus.DUPLICATE_IN_INPUT);
         }
 
         @Test


### PR DESCRIPTION
## 이슈 배경                                                                                              
  ---                                                                                                       
  ### 기존의 문제                              
  - 학번이 중복된 선수가 입력되면 `DUPLICATE_IN_INPUT` 상태로 프리뷰에 포함되어, 프론트에서 오류 UI를 별도로
   처리해야 했습니다.
  - 사용자에게 중복을 수정하라고 넛지를 주는 것보다, 시스템이 자동으로 처리하는 것이 UX상 더 적절하다는
  판단이 있었습니다.

  ### 해결 방식
  - `buildPreview()` 단계에서 학번 중복 선수를 프리뷰에 포함하지 않고, 첫 번째만 남기고 나머지는 제거합니다.
  - 프론트에서 총 인원수를 보여주면 사용자가 자연스럽게 인지할 수 있습니다.
  - `PlayerStatus.DUPLICATE_IN_INPUT` enum 값을 제거했습니다.

  ## 변경 사항
  - `NlService.classifyParsedPlayers()`: 중복 학번 → 프리뷰 포함(DUPLICATE_IN_INPUT) 대신 skip 처리
  - `PlayerStatus`: `DUPLICATE_IN_INPUT` 제거
  - `NlServiceTest`: 중복 학번 테스트를 "첫 번째만 남는지" 검증으로 변경

  ## 확인해야 할 부분
  - process API 호출 시 동일 학번이 여러 번 입력되면 첫 번째 선수만 프리뷰에 포함되는지
  - 기존 정상 플로우(신규/기존/이미 팀에 있는 선수)가 영향받지 않는지