### PR TITLE
fix: Gemini API 키 로테이션 및 429 에러 핸들링

### DIFF
--- a/src/main/java/com/sports/server/command/nl/infra/NlGeminiClient.java
+++ b/src/main/java/com/sports/server/command/nl/infra/NlGeminiClient.java
@@ -62,11 +62,6 @@ public class NlGeminiClient implements NlClient {
         return result;
     }
 
-    private String getNextApiKey() {
-        int index = keyIndex.getAndUpdate(i -> (i + 1) % apiKeys.size());
-        return apiKeys.get(index);
-    }
-
     private static final Map<String, Object> FUNCTION_SCHEMA = Map.of(
             "name", "parse_players",
             "description", "텍스트에서 추출한 선수 정보 목록",
@@ -101,7 +96,8 @@ public class NlGeminiClient implements NlClient {
         Map<String, Object> body = buildRequestBody(contents);
 
         for (int attempt = 0; attempt <= MAX_RETRY; attempt++) {
-            String apiKey = getNextApiKey();
+            int currentKeyIndex = keyIndex.getAndUpdate(i -> (i + 1) % apiKeys.size());
+            String apiKey = apiKeys.get(currentKeyIndex);
             try {
                 return geminiWebClient.post()
                         .header("x-goog-api-key", apiKey)
@@ -110,11 +106,9 @@ public class NlGeminiClient implements NlClient {
                         .bodyToMono(GeminiFunctionCallResponse.class)
                         .block(Duration.ofSeconds(30));
             } catch (WebClientResponseException.TooManyRequests e) {
-                log.warn("Gemini API rate limit (429). attempt={}, keyIndex={}", attempt + 1, keyIndex.get());
+                log.warn("Gemini API rate limit (429). attempt={}/{}, keyIndex={}", attempt + 1, MAX_RETRY + 1, currentKeyIndex);
                 if (attempt < MAX_RETRY) {
                     sleep(RETRY_DELAY);
-                } else {
-                    throw new CustomException(HttpStatus.TOO_MANY_REQUESTS, "AI 서비스가 일시적으로 사용량이 많습니다. 잠시 후 다시 시도해주세요.");
                 }
             }
         }


### PR DESCRIPTION
## 이슈 배경
---
### 기존의 문제
- Gemini API 무료 tier의 rate limit(분당 10회)이 빡빡하여, 프론트에서 parse를 연속 호출하면 429 에러가 발생합니다.
- 429 에러가 서버에서 별도 처리 없이 500으로 던져져서, 프론트에서 원인 파악이 어려웠습니다.

### 해결 방식
- **API 키 로테이션**: 복수 Gemini API 키를 라운드 로빈으로 돌려쓰도록 변경
- **429 retry**: rate limit 발생 시 다음 키로 최대 2회 재시도 (2초 간격)
- **에러 핸들링**: 재시도 실패 시 500 대신 429 상태코드 + 안내 메시지 반환

## 변경 사항

### NlGeminiClient.java
- 복수 API 키 지원 (`gemini.api.keys`, 콤마 구분)
- 기존 단일 키(`gemini.api.key`)도 하위 호환 유지
- `AtomicInteger` 라운드 로빈으로 키 로테이션
- `WebClientResponseException.TooManyRequests` catch → 다음 키로 재시도
- 최종 실패 시 `CustomException(429, "AI 서비스가 일시적으로 사용량이 많습니다.")` 반환

## 설정 방법

### 단일 키 (기존, 하위 호환)
```yaml
gemini:
  api:
    key: "AIzaSy..."
```

### 복수 키 (신규, 권장)
```yaml
gemini:
  api:
    keys: "AIzaSy...key1,AIzaSy...key2,AIzaSy...key3"
```

`keys`가 설정되면 `key`보다 우선합니다. 키가 많을수록 rate limit 한도가 키 수만큼 배로 늘어납니다.

## 확인해야 할 부분
- 429 발생 시 500이 아닌 429로 응답하는지
- 복수 키 설정 시 로테이션이 정상 동작하는지
- 기존 단일 키 설정에서도 정상 동작하는지

## 영향 범위 / 사이드 이펙트
- NlGeminiClient 내부 변경만 포함
- 기존 API 동작 변경 없음

## Breaking Change 여부
- 없음 (기존 단일 키 설정 하위 호환)