### PR TITLE
fix: NL 에러 메시지 개선

### DIFF
--- a/src/main/java/com/sports/server/command/nl/exception/NlErrorMessages.java
+++ b/src/main/java/com/sports/server/command/nl/exception/NlErrorMessages.java
@@ -1,9 +1,11 @@
 package com.sports.server.command.nl.exception;
 
 public class NlErrorMessages {
+    private static final String PLAYER_INFO_FORMAT_HINT = "'이름 학번(9자리) 등번호' 형식으로 입력해주세요. (예: 홍길동 202600001 10)";
+
     public static final String TEAM_NOT_IN_LEAGUE = "해당 팀은 이 리그에 소속되어 있지 않습니다.";
-    public static final String PARSE_FAILED = "선수 정보를 인식하지 못했습니다. '이름 학번(9자리) 등번호' 형식으로 입력해주세요. (예: 홍길동 202600001 10)";
-    public static final String NO_PLAYER_INFO = "입력한 텍스트에서 선수 정보를 찾지 못했습니다. '이름 학번(9자리) 등번호' 형식으로 입력해주세요. (예: 홍길동 202600001 10)";
+    public static final String PARSE_FAILED = "선수 정보를 인식하지 못했습니다. " + PLAYER_INFO_FORMAT_HINT;
+    public static final String NO_PLAYER_INFO = "입력한 텍스트에서 선수 정보를 찾지 못했습니다. " + PLAYER_INFO_FORMAT_HINT;
     public static final String STUDENT_NUMBER_INVALID = "학번이 9자리가 아닙니다. 학번을 확인해주세요.";
     public static final String STUDENT_NUMBER_NOT_IN_ORIGINAL = "입력한 텍스트에서 해당 학번을 찾을 수 없습니다. 학번이 정확한지 확인해주세요.";
     public static final String INVALID_PLAYER_NAME = "선수 이름이 유효하지 않습니다. 한글 또는 영문으로 입력해주세요.";


### PR DESCRIPTION
## 이슈 배경
- NL API 에러 메시지가 모호하여 사용자가 원인을 파악하기 어려웠습니다.

## 변경 사항

| 상황 | 기존 | 변경 |
|------|------|------|
| 파싱 실패 | 선수 정보를 파싱할 수 없습니다. 이름과 학번(9자리)을 포함하여 다시 입력해주세요. | 선수 정보를 인식하지 못했습니다. '이름 학번(9자리) 등번호' 형식으로 입력해주세요. (예: 홍길동 202600001 10) |
| 선수 없음 | 선수 정보를 찾을 수 없습니다. 다시 입력해주세요. | 입력한 텍스트에서 선수 정보를 찾지 못했습니다. '이름 학번(9자리) 등번호' 형식으로 입력해주세요. (예: 홍길동 202600001 10) |
| 학번 9자리 아님 | 학번이 9자리가 아닙니다 | 학번이 9자리가 아닙니다. 학번을 확인해주세요. |
| 학번 원본 불일치 | 원본 텍스트에서 해당 학번을 찾을 수 없습니다 | 입력한 텍스트에서 해당 학번을 찾을 수 없습니다. 학번이 정확한지 확인해주세요. |
| 이름 유효하지 않음 | 선수 이름이 유효하지 않습니다 | 선수 이름이 유효하지 않습니다. 한글 또는 영문으로 입력해주세요. |

## 영향 범위
- 에러 메시지 텍스트 변경만 포함, 로직 변경 없음

## Breaking Change 여부
- 없음