### PR TITLE
fix: 삭제된 리그의 게임이 팀 요약 조회 시 500 에러 유발 (#446)

### DIFF
--- a/src/main/java/com/sports/server/query/repository/GameQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/GameQueryRepository.java
@@ -58,16 +58,17 @@ public interface GameQueryRepository extends Repository<Game, Long> {
     Optional<Game> findGameDetailsById(@Param("gameId") Long gameId);
 
     @Query(value = """
-            SELECT g.* 
+            SELECT g.*
             FROM (
-                SELECT g_inner.*, 
+                SELECT g_inner.*,
                        gt.team_id,
                        ROW_NUMBER() OVER (
-                           PARTITION BY gt.team_id 
+                           PARTITION BY gt.team_id
                            ORDER BY g_inner.start_time DESC, g_inner.id DESC
                        ) as rn
-                FROM games g_inner 
+                FROM games g_inner
                 JOIN game_teams gt ON g_inner.id = gt.game_id
+                JOIN leagues l ON g_inner.league_id = l.id AND l.is_deleted = 0
                 WHERE gt.team_id IN :teamIds
             ) g
             WHERE g.rn <= :limit


### PR DESCRIPTION
## 이슈 배경
- `GET /teams/summary` 호출 시 500 에러 발생
- 소프트 딜리트된 리그(`is_deleted = 1`)의 게임이 native query에서 필터링되지 않아, `game.getLeague()` Lazy Loading 시 `EntityNotFoundException` 발생

## 원인
- `findRecentGamesByTeamIds`가 native query라 `@Where(clause = "is_deleted = 0")` 필터가 적용되지 않음
- 삭제된 리그의 게임이 조회되고, 이후 `GameDetailResponse` 생성 시 `game.getLeague()`에서 예외 발생

## 해결 방식
- native query에 `JOIN leagues l ON g_inner.league_id = l.id AND l.is_deleted = 0` 조건 추가
- 삭제된 리그의 게임은 조회 단계에서 제외

## 영향 범위
- `GameQueryRepository.findRecentGamesByTeamIds()` 쿼리 변경만 포함
- 기존 동작에 영향 없음 (삭제된 리그의 게임이 노출되지 않는 것이 정상)

## Breaking Change 여부
- 없음