### PR TITLE
fix: 게임 캘린더 조회 시 삭제된 리그 게임 필터링 (#451)

### DIFF
--- a/src/main/java/com/sports/server/query/repository/GameDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/GameDynamicRepositoryImpl.java
@@ -34,7 +34,7 @@ public class GameDynamicRepositoryImpl implements GameDynamicRepository {
     public List<Game> findByYearAndMonth(Integer year, Integer month) {
         return jpaQueryFactory
                 .selectFrom(game)
-                .join(game.league, league)
+                .join(game.league, league).fetchJoin()
                 .where(DynamicBooleanBuilder.builder()
                         .and(() -> game.startTime.year().eq(year))
                         .and(() -> game.startTime.month().eq(month))


### PR DESCRIPTION
Closes #451

## 이슈 배경
- `GET /games/search?year=2026&month=3` 호출 시 500 에러 발생
- 삭제된 리그(id=196)의 게임이 조회되어 `game.getLeague()`에서 `EntityNotFoundException` 발생

## 원인
- `findByYearAndMonth` QueryDSL 쿼리에서 league join이 없어 `@Where(clause = "is_deleted = 0")` 필터가 적용되지 않음
- #446과 동일한 유형의 문제 (소프트 딜리트된 리그 참조)

## 해결 방식
- `.join(game.league, league)` 추가하여 League의 `@Where` 필터가 적용되도록 수정

## 영향 범위
- `GameDynamicRepositoryImpl.findByYearAndMonth()` 쿼리 변경만 포함

## Breaking Change 여부
- 없음