### PR TITLE
fix: 매니저 응원톡 조회 시 삭제된 리그로 인한 NPE 수정 (#453)

### DIFF
--- a/src/main/java/com/sports/server/query/application/CheerTalkQueryService.java
+++ b/src/main/java/com/sports/server/query/application/CheerTalkQueryService.java
@@ -2,10 +2,7 @@ package com.sports.server.query.application;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
-
-import com.sports.server.command.game.domain.Game;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,7 +42,9 @@ public class CheerTalkQueryService {
 				admin.getId(), pageRequest.cursor(), pageRequest.size()
 		);
 
-		return toManagerResponses(reportedCheerTalks);
+		return reportedCheerTalks.stream()
+			.map(cheerTalk -> new CheerTalkResponse.ForManager(cheerTalk,
+				gameQueryRepository.findByGameTeamIdWithLeague(cheerTalk.getGameTeamId()))).toList();
 	}
 
 	public List<CheerTalkResponse.ForManager> getUnblockedCheerTalksByAdmin(final PageRequestDto pageRequest, final Member admin) {
@@ -53,7 +52,9 @@ public class CheerTalkQueryService {
 				admin.getId(), pageRequest.cursor(), pageRequest.size()
 		);
 
-		return toManagerResponses(cheerTalks);
+		return cheerTalks.stream()
+			.map(cheerTalk -> new CheerTalkResponse.ForManager(cheerTalk,
+				gameQueryRepository.findByGameTeamIdWithLeague(cheerTalk.getGameTeamId()))).toList();
 	}
 
 	public List<CheerTalkResponse.ForManager> getBlockedCheerTalksByAdmin(final PageRequestDto pageRequest, final Member admin) {
@@ -61,21 +62,8 @@ public class CheerTalkQueryService {
 				admin.getId(), pageRequest.cursor(), pageRequest.size()
 		);
 
-		return toManagerResponses(blockedCheerTalks);
-	}
-
-	private List<CheerTalkResponse.ForManager> toManagerResponses(List<CheerTalk> cheerTalks) {
-		return cheerTalks.stream()
-				.map(this::toManagerResponse)
-				.filter(Objects::nonNull)
-				.toList();
-	}
-
-	private CheerTalkResponse.ForManager toManagerResponse(CheerTalk cheerTalk) {
-		Game game = gameQueryRepository.findByGameTeamIdWithLeague(cheerTalk.getGameTeamId());
-		if (game == null) {
-			return null;
-		}
-		return new CheerTalkResponse.ForManager(cheerTalk, game);
+		return blockedCheerTalks.stream()
+			.map(cheerTalk -> new CheerTalkResponse.ForManager(cheerTalk,
+				gameQueryRepository.findByGameTeamIdWithLeague(cheerTalk.getGameTeamId()))).toList();
 	}
 }

--- a/src/main/java/com/sports/server/query/repository/CheerTalkDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/CheerTalkDynamicRepositoryImpl.java
@@ -45,7 +45,8 @@ public class CheerTalkDynamicRepositoryImpl implements CheerTalkDynamicRepositor
                         .join(member).on(league.administrator.id.eq(member.id))
                         .join(report).on(report.cheerTalk.eq(cheerTalk))
                         .where(report.state.eq(ReportState.PENDING))
-                        .where(member.id.eq(adminId)),
+                        .where(member.id.eq(adminId))
+                        .where(league.isDeleted.isFalse()),
                 cursor,
                 size
         );
@@ -60,7 +61,8 @@ public class CheerTalkDynamicRepositoryImpl implements CheerTalkDynamicRepositor
                         .join(league).on(game.league.id.eq(league.id))
                         .join(member).on(league.administrator.id.eq(member.id))
                         .where(member.id.eq(adminId))
-                        .where(cheerTalk.blockStatus.eq(CheerTalkBlockStatus.ACTIVE)),
+                        .where(cheerTalk.blockStatus.eq(CheerTalkBlockStatus.ACTIVE))
+                        .where(league.isDeleted.isFalse()),
                 cursor,
                 size
         );
@@ -75,7 +77,8 @@ public class CheerTalkDynamicRepositoryImpl implements CheerTalkDynamicRepositor
                         .join(league).on(game.league.id.eq(league.id))
                         .join(member).on(league.administrator.id.eq(member.id))
                         .where(member.id.eq(adminId))
-                        .where(cheerTalk.blockStatus.ne(CheerTalkBlockStatus.ACTIVE)),
+                        .where(cheerTalk.blockStatus.ne(CheerTalkBlockStatus.ACTIVE))
+                        .where(league.isDeleted.isFalse()),
                 cursor,
                 size
         );


### PR DESCRIPTION
Closes #453

## 이슈 배경
- 매니저 화면에서 응원톡 전체 조회(`GET /cheer-talks`) 시 500 에러 발생
- 매니저 페이지 전체가 터지는 상황

## 원인
1. 응원톡 조회 쿼리에서 league join으로 삭제된 리그의 응원톡은 제외됨 (정상)
2. `CheerTalkQueryService`에서 결과 매핑 시 `findByGameTeamIdWithLeague`로 game을 **다시 조회**
3. 재조회 쿼리의 `JOIN FETCH g.league`에 `@Where(is_deleted=0)` 필터가 적용되어 삭제된 리그의 game은 **null 반환**
4. `game.getId()` → **NPE**

## 해결 방식
- `findByGameTeamIdWithLeague` 결과가 null인 경우 해당 응원톡을 결과에서 제외
- 3개 매핑 메서드(`getReportedCheerTalksByAdmin`, `getUnblockedCheerTalksByAdmin`, `getBlockedCheerTalksByAdmin`)의 중복 코드를 `toManagerResponses`로 추출

## 영향 범위
- `CheerTalkQueryService` 매핑 로직 변경만 포함
- 삭제된 리그의 응원톡이 매니저 화면에서 노출되지 않음 (정상 동작)

## Breaking Change 여부
- 없음