### PR TITLE
[FIX] 라인업 조회 응답에 playerId 추가 (#462)

### DIFF
--- a/src/main/java/com/sports/server/query/dto/response/LineupPlayerResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LineupPlayerResponse.java
@@ -50,7 +50,7 @@ public class LineupPlayerResponse {
 	}
 
 	public record PlayerResponse(
-			Long id,
+			Long lineupPlayerId,
 			Long playerId,
 			String playerName,
 			Integer jerseyNumber,

--- a/src/main/java/com/sports/server/query/repository/LineupPlayerQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LineupPlayerQueryRepository.java
@@ -12,7 +12,9 @@ public interface LineupPlayerQueryRepository extends Repository<LineupPlayer, Lo
     @Query("select lp from LineupPlayer lp " +
             "join fetch lp.gameTeam gt " +
             "join fetch gt.team " +
+            "join fetch lp.player " +
             "left join fetch lp.replacedPlayer rp " +
+            "left join fetch rp.player " +
             "where gt.game.id = :gameId " +
             "order by lp.jerseyNumber asc")
     List<LineupPlayer> findPlayersByGameId(@Param("gameId") final Long gameId);
@@ -20,6 +22,7 @@ public interface LineupPlayerQueryRepository extends Repository<LineupPlayer, Lo
     @Query("select lp from LineupPlayer lp " +
             "join fetch lp.gameTeam gt " +
             "join fetch gt.team " +
+            "join fetch lp.player " +
             "where gt.game.id = :gameId " +
             "and lp.isPlaying = true " +
             "order by lp.jerseyNumber asc")

--- a/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
@@ -85,12 +85,12 @@ public class GameAcceptanceTest extends AcceptanceTest {
                 .toList();
 
         List<LineupPlayerResponse.PlayerResponse> actual = lineupPlayerResponses.get(0).starterPlayers().stream()
-                .filter(playerResponse -> playerResponse.id().equals(lineupPlayerId))
+                .filter(playerResponse -> playerResponse.lineupPlayerId().equals(lineupPlayerId))
                 .toList();
 
         assertAll(
                 () -> assertThat(lineupPlayerResponses.get(0).gameTeamId()).isEqualTo(gameTeamId),
-                () -> assertThat(actual.get(0).id()).isEqualTo(lineupPlayerId),
+                () -> assertThat(actual.get(0).lineupPlayerId()).isEqualTo(lineupPlayerId),
                 () -> assertThat(actual.get(0).state()).isEqualTo(LineupPlayerState.STARTER)
         );
     }
@@ -124,12 +124,12 @@ public class GameAcceptanceTest extends AcceptanceTest {
                 .toList();
 
         List<LineupPlayerResponse.PlayerResponse> actual = lineupPlayerResponses.get(0).candidatePlayers().stream()
-                .filter(playerResponse -> playerResponse.id().equals(lineupPlayerId))
+                .filter(playerResponse -> playerResponse.lineupPlayerId().equals(lineupPlayerId))
                 .toList();
 
         assertAll(
                 () -> assertThat(lineupPlayerResponses.get(0).gameTeamId()).isEqualTo(gameTeamId),
-                () -> assertThat(actual.get(0).id()).isEqualTo(lineupPlayerId),
+                () -> assertThat(actual.get(0).lineupPlayerId()).isEqualTo(lineupPlayerId),
                 () -> assertThat(actual.get(0).state()).isEqualTo(LineupPlayerState.CANDIDATE)
         );
     }
@@ -300,12 +300,12 @@ public class GameAcceptanceTest extends AcceptanceTest {
                 .toList();
 
         List<LineupPlayerResponse.PlayerResponse> actual = lineupPlayerResponses.get(0).starterPlayers().stream()
-                .filter(playerResponse -> playerResponse.id().equals(lineupPlayerId))
+                .filter(playerResponse -> playerResponse.lineupPlayerId().equals(lineupPlayerId))
                 .toList();
 
         assertAll(
                 () -> assertThat(lineupPlayerResponses.get(0).gameTeamId()).isEqualTo(gameTeamId),
-                () -> assertThat(actual.get(0).id()).isEqualTo(lineupPlayerId),
+                () -> assertThat(actual.get(0).lineupPlayerId()).isEqualTo(lineupPlayerId),
                 () -> assertThat(actual.get(0).isCaptain()).isEqualTo(true)
         );
     }
@@ -338,12 +338,12 @@ public class GameAcceptanceTest extends AcceptanceTest {
                 .toList();
 
         List<LineupPlayerResponse.PlayerResponse> actual = lineupPlayerResponses.get(0).starterPlayers().stream()
-                .filter(playerResponse -> playerResponse.id().equals(lineupPlayerId))
+                .filter(playerResponse -> playerResponse.lineupPlayerId().equals(lineupPlayerId))
                 .toList();
 
         assertAll(
                 () -> assertThat(lineupPlayerResponses.get(0).gameTeamId()).isEqualTo(gameTeamId),
-                () -> assertThat(actual.get(0).id()).isEqualTo(lineupPlayerId),
+                () -> assertThat(actual.get(0).lineupPlayerId()).isEqualTo(lineupPlayerId),
                 () -> assertThat(actual.get(0).isCaptain()).isEqualTo(false)
         );
     }

--- a/src/test/java/com/sports/server/query/application/LineupPlayerQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/LineupPlayerQueryServiceTest.java
@@ -60,7 +60,7 @@ public class LineupPlayerQueryServiceTest extends ServiceTest {
         // then
         List<LineupPlayer> lineupPlayers = responses.stream()
                 .flatMap(lpr -> lpr.gameTeamPlayers().stream()
-                        .map(pr -> entityUtils.getEntity(pr.id(), LineupPlayer.class)))
+                        .map(pr -> entityUtils.getEntity(pr.lineupPlayerId(), LineupPlayer.class)))
                 .toList();
 
         Assertions.assertThat(lineupPlayers)

--- a/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
@@ -243,7 +243,7 @@ class GameQueryControllerTest extends DocumentationTest {
                         responseFields(
                                 fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER).description("게임팀의 ID"),
                                 fieldWithPath("[].teamName").type(JsonFieldType.STRING).description("게임팀 이름"),
-                                fieldWithPath("[].starterPlayers[].id").type(JsonFieldType.NUMBER)
+                                fieldWithPath("[].starterPlayers[].lineupPlayerId").type(JsonFieldType.NUMBER)
                                         .description("선발 선수 라인업 ID"),
                                 fieldWithPath("[].starterPlayers[].playerId").type(JsonFieldType.NUMBER)
                                         .description("선발 선수 ID"),
@@ -277,7 +277,7 @@ class GameQueryControllerTest extends DocumentationTest {
                                         .type(JsonFieldType.NUMBER)
                                         .optional()
                                         .description("교체된 선수의 등번호"),
-                                fieldWithPath("[].candidatePlayers[].id").type(JsonFieldType.NUMBER)
+                                fieldWithPath("[].candidatePlayers[].lineupPlayerId").type(JsonFieldType.NUMBER)
                                         .description("후보 선수 라인업 ID"),
                                 fieldWithPath("[].candidatePlayers[].playerId").type(JsonFieldType.NUMBER)
                                         .description("후보 선수 ID"),
@@ -355,7 +355,7 @@ class GameQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER).description("게임팀의 ID"),
                                 fieldWithPath("[].teamName").type(JsonFieldType.STRING).description("게임팀 이름"),
                                 fieldWithPath("[].teamColor").type(JsonFieldType.STRING).description("게임팀 팀색깔"),
-                                fieldWithPath("[].gameTeamPlayers[].id").type(JsonFieldType.NUMBER)
+                                fieldWithPath("[].gameTeamPlayers[].lineupPlayerId").type(JsonFieldType.NUMBER)
                                         .description("선수 라인업 ID"),
                                 fieldWithPath("[].gameTeamPlayers[].playerId").type(JsonFieldType.NUMBER)
                                         .description("선수 ID"),


### PR DESCRIPTION
## 관련 이슈
closes #462

## 문제

`POST /game-teams/{id}/lineup-players`로 미등록 선수를 라인업에 추가할 때 아래 에러가 발생했습니다.

```json
{"message": "이미 라인업에 등록된 선수입니다.", "fieldErrors": null}
```

## 원인

프론트엔드는 다음 두 API를 조합해 \"미등록 선수\" 목록을 구성합니다.

| API | 반환 ID |
|-----|---------|
| 팀 선수 조회 | `playerId`, `teamPlayerId` |
| 라인업 조회 (`GET /games/{id}/lineup`) | `id` (lineupPlayerId) |

`LineupPlayerResponse.PlayerResponse`에 `playerId`가 없어 두 목록을 공통 키로 대조할 수 없었고, 이미 라인업에 등록된 선수가 미등록 선수 목록에 잘못 포함되었습니다.

결과적으로 해당 선수에 대해 상태 변경 PATCH 대신 새 등록 POST가 호출되어 400 에러가 발생했습니다.

## 해결

`LineupPlayerResponse.PlayerResponse`에 `playerId` 필드를 추가했습니다.

```java
// Before
public record PlayerResponse(Long id, String playerName, ...)

// After
public record PlayerResponse(Long id, Long playerId, String playerName, ...)
```

`LineupPlayer`는 이미 `Player`를 참조하고 있으므로 `lineupPlayer.getPlayer().getId()`로 바로 접근 가능합니다.

프론트엔드는 라인업 응답의 `playerId`를 기준으로 팀 선수 목록과 대조하여 미등록 선수를 정확히 필터링할 수 있습니다.

## 변경 파일

- `LineupPlayerResponse.java` — `PlayerResponse`에 `playerId` 추가
- `GameQueryControllerTest.java` — 테스트 픽스처 및 RestDocs 필드 설명 업데이트