### PR TITLE
[FIX] findPlayingPlayersByGameId에 replacedPlayer fetch join 추가

### DIFF
--- a/src/main/java/com/sports/server/query/repository/LineupPlayerQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LineupPlayerQueryRepository.java
@@ -23,6 +23,8 @@ public interface LineupPlayerQueryRepository extends Repository<LineupPlayer, Lo
             "join fetch lp.gameTeam gt " +
             "join fetch gt.team " +
             "join fetch lp.player " +
+            "left join fetch lp.replacedPlayer rp " +
+            "left join fetch rp.player " +
             "where gt.game.id = :gameId " +
             "and lp.isPlaying = true " +
             "order by lp.jerseyNumber asc")


### PR DESCRIPTION
## 관련 PR
#463 머지 후 누락된 fetch join 추가

## 문제

`findPlayingPlayersByGameId` 쿼리에 `replacedPlayer`와 `replacedPlayer.player` fetch join이 없어 N+1 쿼리가 발생할 수 있었음.

`findPlayersByGameId`에는 추가했으나 `findPlayingPlayersByGameId`에는 누락됨.

## 변경

```java
// 추가
"left join fetch lp.replacedPlayer rp " +
"left join fetch rp.player " +
```