### PR TITLE
fix: AuthenticationException 500 에러 처리 오류 수정

### DIFF
--- a/src/main/java/com/sports/server/auth/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/sports/server/auth/exception/DefaultExceptionHandler.java
@@ -8,10 +8,9 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.reactive.result.method.annotation.ResponseEntityExceptionHandler;
 
 @ControllerAdvice
-public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
+public class DefaultExceptionHandler {
 
     @ExceptionHandler({AuthenticationException.class})
     @ResponseBody


### PR DESCRIPTION
## 이슈
closes #475

## 문제
인증이 필요한 엔드포인트에 인증 없이 접근 시 401 대신 500 반환

## 원인
`DefaultExceptionHandler`가 WebFlux용 `ResponseEntityExceptionHandler`를 상속하고 있어 MVC 환경에서 `AuthenticationException` 핸들러가 동작하지 않음 → `ControllerExceptionAdvice`의 `Exception.class` 핸들러로 떨어져 500 처리 및 Slack 불필요한 알림 발생

## 수정
WebFlux `ResponseEntityExceptionHandler` extends 제거