### PR TITLE
fix: HttpRequestMethodNotSupportedException 405로 처리

### DIFF
--- a/src/main/java/com/sports/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/sports/server/common/advice/ControllerExceptionAdvice.java
@@ -13,6 +13,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.stream.Collectors;
@@ -56,6 +57,13 @@ public class ControllerExceptionAdvice {
         logClientError(request, HttpStatus.BAD_REQUEST, formatBindingResult(e.getBindingResult()));
         return ResponseEntity.badRequest()
                 .body(ErrorResponse.of(e.getBindingResult()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodNotSupportedException(HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
+        logClientError(request, HttpStatus.METHOD_NOT_ALLOWED, e.getMessage());
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(ErrorResponse.of("지원하지 않는 HTTP 메서드입니다."));
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)


### PR DESCRIPTION
## 이슈
closes #480

## 문제
잘못된 HTTP 메서드로 요청 시 405 대신 500 반환 및 Slack 불필요한 알림 발생

## 원인
`ControllerExceptionAdvice`에 `HttpRequestMethodNotSupportedException` 핸들러가 없어 `Exception.class` 핸들러로 떨어져 500 처리

## 수정
`HttpRequestMethodNotSupportedException` 핸들러 추가 → 405 반환