### PR TITLE
fix: AuthenticationException 500 → 401로 처리

### DIFF
--- a/src/main/java/com/sports/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/sports/server/common/advice/ControllerExceptionAdvice.java
@@ -13,6 +13,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
@@ -35,6 +36,13 @@ public class ControllerExceptionAdvice {
         }
         return ResponseEntity.status(e.getStatus())
                 .body(ErrorResponse.of(e.getMessage()));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    protected ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e, HttpServletRequest request) {
+        logClientError(request, HttpStatus.UNAUTHORIZED, e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.of("인증이 필요합니다."));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 이슈
closes #488

## 문제
인증 실패 시 `InsufficientAuthenticationException`이 `Exception.class` 핸들러로 떨어져 500 반환 + Slack 알림 폭탄

## 원인
`ControllerExceptionAdvice`에 `AuthenticationException` 핸들러 없음 → `Exception.class`로 catch → 500 + alertService 호출

## 수정
`AuthenticationException` 핸들러 추가 → 401 반환 + logClientError(WARN)로 처리