### PR TITLE
feat: Organization 조회 API 및 리그 조회 학교/종목 필터 추가

### DIFF
--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -252,9 +252,9 @@ public class LeagueQueryService {
                 .toList();
     }
 
-    public List<RecentLeagueGamesResponse> findRecentLeaguesGames() {
+    public List<RecentLeagueGamesResponse> findRecentLeaguesGames(Long organizationId, SportType sportType) {
         LocalDateTime now = LocalDateTime.now();
-        List<League> recentLeagues = getRecentLeagues(now);
+        List<League> recentLeagues = getRecentLeagues(now, organizationId, sportType);
         if (recentLeagues.isEmpty()) {
             return Collections.emptyList();
         }
@@ -276,12 +276,12 @@ public class LeagueQueryService {
                 .toList();
     }
 
-    private List<League> getRecentLeagues(LocalDateTime now) {
-        List<League> inProgressLeagues = leagueQueryRepository.findInProgressLeagues(now);
+    private List<League> getRecentLeagues(LocalDateTime now, Long organizationId, SportType sportType) {
+        List<League> inProgressLeagues = leagueQueryRepository.findInProgressLeagues(now, organizationId, sportType);
         if (!inProgressLeagues.isEmpty()) {
             return inProgressLeagues;
         }
-        return leagueQueryRepository.findLeaguesByLatestEndAt(now);
+        return leagueQueryRepository.findLeaguesByLatestEndAt(now, organizationId, sportType);
     }
 
     private Map<Long, List<GameTeam>> getTeamsByGameId(List<Game> games) {

--- a/src/main/java/com/sports/server/query/application/OrganizationQueryService.java
+++ b/src/main/java/com/sports/server/query/application/OrganizationQueryService.java
@@ -1,0 +1,22 @@
+package com.sports.server.query.application;
+
+import com.sports.server.query.dto.response.OrganizationResponse;
+import com.sports.server.query.repository.OrganizationQueryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrganizationQueryService {
+
+    private final OrganizationQueryRepository organizationQueryRepository;
+
+    public List<OrganizationResponse> findAll() {
+        return organizationQueryRepository.findAll().stream()
+                .map(OrganizationResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/sports/server/query/dto/request/LeagueQueryRequestDto.java
+++ b/src/main/java/com/sports/server/query/dto/request/LeagueQueryRequestDto.java
@@ -6,6 +6,7 @@ import com.sports.server.command.league.domain.SportType;
 public record LeagueQueryRequestDto(
         Integer year,
         LeagueProgress leagueProgress,
-        SportType sportType
+        SportType sportType,
+        Long organizationId
 ) {
 }

--- a/src/main/java/com/sports/server/query/dto/response/OrganizationResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/OrganizationResponse.java
@@ -1,0 +1,12 @@
+package com.sports.server.query.dto.response;
+
+import com.sports.server.command.organization.domain.Organization;
+
+public record OrganizationResponse(
+        Long id,
+        String name
+) {
+    public OrganizationResponse(Organization organization) {
+        this(organization.getId(), organization.getName());
+    }
+}

--- a/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/LeagueQueryController.java
@@ -1,5 +1,6 @@
 package com.sports.server.query.presentation;
 
+import com.sports.server.command.league.domain.SportType;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.query.application.LeagueQueryService;
 import com.sports.server.query.dto.request.LeagueQueryRequestDto;
@@ -89,7 +90,10 @@ public class LeagueQueryController {
     }
 
     @GetMapping("/recent/games")
-    public ResponseEntity<List<RecentLeagueGamesResponse>> findRecentLeaguesGames() {
-        return ResponseEntity.ok(leagueQueryService.findRecentLeaguesGames());
+    public ResponseEntity<List<RecentLeagueGamesResponse>> findRecentLeaguesGames(
+            @RequestParam(required = false) final Long organizationId,
+            @RequestParam(required = false) final SportType sportType
+    ) {
+        return ResponseEntity.ok(leagueQueryService.findRecentLeaguesGames(organizationId, sportType));
     }
 }

--- a/src/main/java/com/sports/server/query/presentation/OrganizationQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/OrganizationQueryController.java
@@ -1,0 +1,23 @@
+package com.sports.server.query.presentation;
+
+import com.sports.server.query.application.OrganizationQueryService;
+import com.sports.server.query.dto.response.OrganizationResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/organizations")
+@RequiredArgsConstructor
+public class OrganizationQueryController {
+
+    private final OrganizationQueryService organizationQueryService;
+
+    @GetMapping
+    public ResponseEntity<List<OrganizationResponse>> findAll() {
+        return ResponseEntity.ok(organizationQueryService.findAll());
+    }
+}

--- a/src/main/java/com/sports/server/query/repository/LeagueQueryConditionMapper.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueQueryConditionMapper.java
@@ -22,6 +22,7 @@ public class LeagueQueryConditionMapper {
         conditions.and(getYearCondition(requestDto.year()));
         conditions.and(getProgressCondition(requestDto.leagueProgress()));
         conditions.and(getSportTypeCondition(requestDto.sportType()));
+        conditions.and(getOrganizationCondition(requestDto.organizationId()));
 
         return conditions;
     }
@@ -51,6 +52,13 @@ public class LeagueQueryConditionMapper {
             return null;
         }
         return league.sportType.eq(sportType);
+    }
+
+    private BooleanExpression getOrganizationCondition(Long organizationId) {
+        if (organizationId == null) {
+            return null;
+        }
+        return league.organization.id.eq(organizationId);
     }
 
 }

--- a/src/main/java/com/sports/server/query/repository/LeagueQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueQueryRepository.java
@@ -1,6 +1,7 @@
 package com.sports.server.query.repository;
 
 import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.SportType;
 import com.sports.server.command.member.domain.Member;
 
 import java.time.LocalDateTime;
@@ -51,11 +52,22 @@ public interface LeagueQueryRepository extends Repository<League, Long>, LeagueQ
             Pageable pageable
     );
 
-    @Query("SELECT l FROM League l WHERE l.startAt <= :now AND l.endAt >= :now")
-    List<League> findInProgressLeagues(@Param("now") LocalDateTime now);
+    @Query("SELECT l FROM League l WHERE l.startAt <= :now AND l.endAt >= :now"
+            + " AND (:organizationId IS NULL OR l.organization.id = :organizationId)"
+            + " AND (:sportType IS NULL OR l.sportType = :sportType)")
+    List<League> findInProgressLeagues(@Param("now") LocalDateTime now,
+                                       @Param("organizationId") Long organizationId,
+                                       @Param("sportType") SportType sportType);
 
-    @Query("SELECT l FROM League l WHERE l.endAt = (SELECT MAX(l2.endAt) FROM League l2 WHERE l2.endAt < :now)")
-    List<League> findLeaguesByLatestEndAt(@Param("now") LocalDateTime now);
+    @Query("SELECT l FROM League l WHERE l.endAt = ("
+            + "SELECT MAX(l2.endAt) FROM League l2 WHERE l2.endAt < :now"
+            + " AND (:organizationId IS NULL OR l2.organization.id = :organizationId)"
+            + " AND (:sportType IS NULL OR l2.sportType = :sportType))"
+            + " AND (:organizationId IS NULL OR l.organization.id = :organizationId)"
+            + " AND (:sportType IS NULL OR l.sportType = :sportType)")
+    List<League> findLeaguesByLatestEndAt(@Param("now") LocalDateTime now,
+                                          @Param("organizationId") Long organizationId,
+                                          @Param("sportType") SportType sportType);
 
     @Query(
             "SELECT new com.sports.server.query.repository.LeagueRecentRecordResult(l.id, l.name, ls.firstWinnerTeam.name, CAST(l.sportType AS string)) "

--- a/src/main/java/com/sports/server/query/repository/OrganizationQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/OrganizationQueryRepository.java
@@ -1,0 +1,10 @@
+package com.sports.server.query.repository;
+
+import com.sports.server.command.organization.domain.Organization;
+import java.util.List;
+import org.springframework.data.repository.Repository;
+
+public interface OrganizationQueryRepository extends Repository<Organization, Long> {
+
+    List<Organization> findAll();
+}

--- a/src/test/java/com/sports/server/query/application/LeagueQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/LeagueQueryServiceTest.java
@@ -280,7 +280,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 연도_필터링_조건으로_리그를_조회한다() {
             // given
-            LeagueQueryRequestDto requestDto = new LeagueQueryRequestDto(2025, null, null);
+            LeagueQueryRequestDto requestDto = new LeagueQueryRequestDto(2025, null, null, null);
 
             // when
             List<LeagueResponse> leagues = leagueQueryService.findLeagues(requestDto);
@@ -298,7 +298,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 리그_진행_상태_필터링_조건으로_리그를_조회한다() {
             // given
-            LeagueQueryRequestDto requestDto = new LeagueQueryRequestDto(null, LeagueProgress.FINISHED, null);
+            LeagueQueryRequestDto requestDto = new LeagueQueryRequestDto(null, LeagueProgress.FINISHED, null, null);
 
             // when
             List<LeagueResponse> leagues = leagueQueryService.findLeagues(requestDto);
@@ -316,7 +316,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 연도와_진행_상태_모든_필터링_조건으로_리그를_조회한다() {
             // given
-            LeagueQueryRequestDto requestDto = new LeagueQueryRequestDto(2025, LeagueProgress.FINISHED, null);
+            LeagueQueryRequestDto requestDto = new LeagueQueryRequestDto(2025, LeagueProgress.FINISHED, null, null);
 
             // when
             List<LeagueResponse> leagues = leagueQueryService.findLeagues(requestDto);
@@ -334,7 +334,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 필터링_조건이_없을_경우_전체_결과를_반환한다() {
             // given
-            LeagueQueryRequestDto requestDto = new LeagueQueryRequestDto(null, null, null);
+            LeagueQueryRequestDto requestDto = new LeagueQueryRequestDto(null, null, null, null);
 
             // when
             List<LeagueResponse> leagues = leagueQueryService.findLeagues(requestDto);
@@ -508,7 +508,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 진행_중인_리그들의_게임만_반환한다() {
             // when
-            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames();
+            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames(null, null);
 
             // then
             List<Long> returnedLeagueIds = result.stream()
@@ -524,7 +524,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 진행_중인_리그의_게임이_모두_반환된다() {
             // when
-            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames();
+            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames(null, null);
 
             // then
             List<Long> gameIds = result.stream()
@@ -538,7 +538,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 반환된_게임에_올바른_팀_정보가_포함된다() {
             // when
-            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames();
+            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames(null, null);
 
             // then
             RecentLeagueGamesResponse.GameResponse firstGame = result.get(0).games().stream()
@@ -564,7 +564,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 가장_최근_종료된_리그들의_게임을_반환한다() {
             // when
-            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames();
+            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames(null, null);
 
             // then
             List<Long> returnedLeagueIds = result.stream()
@@ -580,7 +580,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 동일한_종료일자를_가진_여러_리그가_모두_반환된다() {
             // when
-            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames();
+            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames(null, null);
 
             // then
             assertThat(result).hasSize(2);
@@ -592,7 +592,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
             long olderLeagueGameId = 4L;
 
             // when
-            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames();
+            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames(null, null);
 
             // then
             List<Long> allGameIds = result.stream()
@@ -606,7 +606,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 반환된_게임_목록은_startTime_오름차순으로_정렬된다() {
             // when
-            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames();
+            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames(null, null);
 
             // then
             RecentLeagueGamesResponse leagueA = result.stream()
@@ -631,7 +631,7 @@ public class LeagueQueryServiceTest extends ServiceTest {
         @Test
         void 경기가_없어도_리그_정보는_반환된다() {
             // when
-            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames();
+            List<RecentLeagueGamesResponse> result = leagueQueryService.findRecentLeaguesGames(null, null);
 
             // then
             assertAll(

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -621,7 +621,7 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                 )
         );
 
-        given(leagueQueryService.findRecentLeaguesGames())
+        given(leagueQueryService.findRecentLeaguesGames(null, null))
                 .willReturn(responses);
 
         // when


### PR DESCRIPTION
## Summary

- `GET /organizations` 학교 드롭다운용 전체 목록 조회 API 신규 추가
- `GET /leagues` 에 `organizationId` 필터 파라미터 추가
- `GET /leagues/recent/games` 에 `organizationId`, `sportType` 필터 추가 (DB 레벨 JPQL)
- 모든 파라미터 optional, 하위 호환 유지

## 변경 파일

### 신규 (Organization 조회 API)
| 파일 | 역할 |
|------|------|
| `OrganizationQueryController` | `GET /organizations` 엔드포인트 |
| `OrganizationQueryService` | 전체 Organization 조회 |
| `OrganizationQueryRepository` | `findAll()` |
| `OrganizationResponse` | `record(id, name)` 응답 DTO |

### 수정
| 파일 | 변경 내용 |
|------|----------|
| `LeagueQueryRequestDto` | `organizationId` 필드 추가 |
| `LeagueQueryConditionMapper` | `getOrganizationCondition()` 추가 |
| `LeagueQueryController` | `findRecentLeaguesGames`에 파라미터 추가 |
| `LeagueQueryRepository` | `findInProgressLeagues`, `findLeaguesByLatestEndAt`에 optional 필터 추가 |
| `LeagueQueryService` | `findRecentLeaguesGames`에 필터 파라미터 전달 |

## 프론트 변경 필요사항

### 1. 학교 드롭다운 (GNB)
```
GET /organizations → [{ "id": 1, "name": "한국외대" }, { "id": 2, "name": "경희대" }]
```

### 2. 홈 화면 경기 목록
```
// 기존
GET /leagues/recent/games

// 변경 (학교 선택 + 종목 탭)
GET /leagues/recent/games?organizationId=1&sportType=SOCCER
```

### 3. 리그 목록 페이지
```
GET /leagues?organizationId=1&sportType=SOCCER
```

### API 호출 플로우
```
1. 앱 로드 → GET /organizations → 드롭다운 채움
2. 학교 선택 + 종목 탭 → GET /leagues/recent/games?organizationId=1&sportType=SOCCER
3. 리그 목록 → GET /leagues?organizationId=1&sportType=SOCCER
```

## 선행 조건
- #511 머지 후 리베이스 필요 (sportType 필터 기반)

## Test plan
- [x] 전체 테스트 통과 확인
- [ ] Organization 조회 API 응답 확인
- [ ] 리그 조회 organizationId 필터 동작 확인
- [ ] 홈 경기목록 organizationId + sportType 필터 동작 확인
- [ ] 파라미터 없이 호출 시 기존과 동일 응답 확인 (하위 호환)

closes #518