### PR TITLE
fix: 수동 게임 종료 시 리그 통계 미생성 버그 수정 (#520)

### DIFF
--- a/src/main/java/com/sports/server/command/game/application/GameService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameService.java
@@ -69,6 +69,12 @@ public class GameService {
     }
 
     @Transactional
+    public void determineResults(List<Long> gameIds) {
+        List<Game> games = gameRepository.findAllByIdIn(gameIds);
+        games.forEach(Game::updateResult);
+    }
+
+    @Transactional
     public void updateGame(Long leagueId, Long gameId, GameRequest.Update request, Member administrator) {
         League league = entityUtils.getEntity(leagueId, League.class);
         PermissionValidator.checkPermission(league, administrator);

--- a/src/main/java/com/sports/server/command/game/application/GameService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameService.java
@@ -69,9 +69,10 @@ public class GameService {
     }
 
     @Transactional
-    public void determineResults(List<Long> gameIds) {
+    public List<Game> determineResultsAndGet(List<Long> gameIds) {
         List<Game> games = gameRepository.findAllByIdIn(gameIds);
         games.forEach(Game::updateResult);
+        return games;
     }
 
     @Transactional

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.GameState;
 import com.sports.server.command.league.application.LeagueStatisticsService;
 import com.sports.server.command.league.application.LeagueTopScorerService;
 import com.sports.server.command.league.application.LeagueService;
@@ -38,9 +39,15 @@ public class GameStatusScheduler {
                 });
     }
 
+    public void updateLeagueStatisticsIfNeeded(Long gameId, GameState state, Round round) {
+        if (GameState.FINISHED != state || Round.FINAL != round) {
+            return;
+        }
+        manualUpdateLeagueStatisticsForFinalGames(List.of(gameId));
+    }
+
     public void manualUpdateLeagueStatisticsForFinalGames(List<Long> gameIds) {
-        gameService.determineResults(gameIds);
-        List<Game> games = gameService.findGamesByIds(gameIds);
+        List<Game> games = gameService.determineResultsAndGet(gameIds);
         updateLeagueStatisticsForFinalGames(games);
     }
 }

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -39,6 +39,7 @@ public class GameStatusScheduler {
     }
 
     public void manualUpdateLeagueStatisticsForFinalGames(List<Long> gameIds) {
+        gameService.determineResults(gameIds);
         List<Game> games = gameService.findGamesByIds(gameIds);
         updateLeagueStatisticsForFinalGames(games);
     }

--- a/src/main/java/com/sports/server/command/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/command/game/presentation/GameController.java
@@ -4,8 +4,10 @@ import com.sports.server.command.game.application.GameService;
 import com.sports.server.command.game.application.GameStatusScheduler;
 import com.sports.server.command.game.application.GameTeamService;
 import com.sports.server.command.game.application.LineupPlayerService;
+import com.sports.server.command.game.domain.GameState;
 import com.sports.server.command.game.dto.CheerCountUpdateRequest;
 import com.sports.server.command.game.dto.GameRequest;
+import com.sports.server.command.league.domain.Round;
 import com.sports.server.command.member.domain.Member;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -59,6 +61,14 @@ public class GameController {
     public void updateGame(@PathVariable final Long leagueId, @PathVariable final Long gameId,
                            @RequestBody final GameRequest.Update request, final Member member) {
         gameService.updateGame(leagueId, gameId, request, member);
+        updateLeagueStatisticsIfFinalFinished(request, gameId);
+    }
+
+    private void updateLeagueStatisticsIfFinalFinished(GameRequest.Update request, Long gameId) {
+        if (GameState.FINISHED == GameState.from(request.state())
+                && Round.FINAL == Round.from(request.round())) {
+            gameStatusScheduler.manualUpdateLeagueStatisticsForFinalGames(List.of(gameId));
+        }
     }
 
     @DeleteMapping("/leagues/{leagueId}/{gameId}")

--- a/src/main/java/com/sports/server/command/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/command/game/presentation/GameController.java
@@ -61,14 +61,8 @@ public class GameController {
     public void updateGame(@PathVariable final Long leagueId, @PathVariable final Long gameId,
                            @RequestBody final GameRequest.Update request, final Member member) {
         gameService.updateGame(leagueId, gameId, request, member);
-        updateLeagueStatisticsIfFinalFinished(request, gameId);
-    }
-
-    private void updateLeagueStatisticsIfFinalFinished(GameRequest.Update request, Long gameId) {
-        if (GameState.FINISHED == GameState.from(request.state())
-                && Round.FINAL == Round.from(request.round())) {
-            gameStatusScheduler.manualUpdateLeagueStatisticsForFinalGames(List.of(gameId));
-        }
+        gameStatusScheduler.updateLeagueStatisticsIfNeeded(
+                gameId, GameState.from(request.state()), Round.from(request.round()));
     }
 
     @DeleteMapping("/leagues/{leagueId}/{gameId}")


### PR DESCRIPTION
## Summary
- 관리자가 `updateGame` API로 결승 게임을 수동 FINISHED 처리할 때 `league_statistics`가 생성되지 않던 버그 수정
- `manualUpdateLeagueStatisticsForFinalGames`에서 `determineResults` 미호출로 WIN/LOSE 미설정되던 문제 수정

## 변경사항
- `GameController.updateGame()` — FINAL + FINISHED 변경 시 통계 자동 생성 트리거 추가
- `GameService.determineResults()` — 트랜잭션 내에서 게임 결과(WIN/LOSE) 결정 메서드 추가
- `GameStatusScheduler.manualUpdateLeagueStatisticsForFinalGames()` — `determineResults` 선행 호출 추가

## 원인 분석
- 스케줄러(`scheduleUpdateGameStatusToFinish`)는 PLAYING → FINISHED 전환 시 결승 게임 통계를 자동 생성
- `updateGame` API 경로에는 통계 생성 로직이 없어 수동 종료된 결승 게임의 통계가 누락됨
- `manualUpdateLeagueStatisticsForFinalGames`도 `determineResult()` 미호출로 GameTeam의 result가 null인 채 통계 생성 → winner 팀 null

## Test plan
- [x] `GameControllerTest` 통과
- [x] `com.sports.server.command.game.*` 전체 테스트 통과
- [ ] 수동으로 결승 게임 FINISHED 변경 후 `/leagues/{id}/statistics` 응답에 winner 팀 포함 확인

closes #520