### PR TITLE
feat: 응원톡 조회 응답에 gameName, leagueName 필드 추가

### DIFF
--- a/src/main/java/com/sports/server/query/application/CheerTalkQueryService.java
+++ b/src/main/java/com/sports/server/query/application/CheerTalkQueryService.java
@@ -34,12 +34,13 @@ public class CheerTalkQueryService {
 	private final LeagueQueryRepository leagueQueryRepository;
 
 	public List<CheerTalkResponse.ForSpectator> getCheerTalksByGameId(final Long gameId, final PageRequestDto pageRequest) {
+		Game game = getGame(gameId);
 		List<CheerTalk> cheerTalks = cheerTalkDynamicRepository.findByGameIdOrderByStartTime(
 			gameId, pageRequest.cursor(), pageRequest.size()
 		);
 
 		List<CheerTalkResponse.ForSpectator> responses = cheerTalks.stream()
-			.map(CheerTalkResponse.ForSpectator::new)
+			.map(cheerTalk -> new CheerTalkResponse.ForSpectator(cheerTalk, game))
 			.collect(Collectors.toList());
 
 		Collections.reverse(responses);

--- a/src/main/java/com/sports/server/query/dto/response/CheerTalkResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/CheerTalkResponse.java
@@ -10,7 +10,9 @@ public class CheerTalkResponse {
             String content,
             Long gameTeamId,
             LocalDateTime createdAt,
-            Boolean isBlocked
+            Boolean isBlocked,
+            String gameName,
+            String leagueName
     ) {
         public ForSpectator(CheerTalk cheerTalk) {
             this(
@@ -18,7 +20,9 @@ public class CheerTalkResponse {
                     checkCheerTalkIsBlocked(cheerTalk),
                     cheerTalk.getGameTeamId(),
                     cheerTalk.getCreatedAt(),
-                    cheerTalk.isBlocked()
+                    cheerTalk.isBlocked(),
+                    null,
+                    null
             );
         }
 
@@ -28,7 +32,21 @@ public class CheerTalkResponse {
                     maskedContent,
                     cheerTalk.getGameTeamId(),
                     cheerTalk.getCreatedAt(),
-                    cheerTalk.isBlocked()
+                    cheerTalk.isBlocked(),
+                    null,
+                    null
+            );
+        }
+
+        public ForSpectator(CheerTalk cheerTalk, Game game) {
+            this(
+                    cheerTalk.getId(),
+                    checkCheerTalkIsBlocked(cheerTalk),
+                    cheerTalk.getGameTeamId(),
+                    cheerTalk.getCreatedAt(),
+                    cheerTalk.isBlocked(),
+                    game.getName(),
+                    game.getLeague().getName()
             );
         }
 

--- a/src/test/java/com/sports/server/query/acceptance/CheerTalkQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/CheerTalkQueryAcceptanceTest.java
@@ -48,7 +48,9 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                                     null,
                                     1L,
                                     LocalDateTime.of(2023, 1, 2, 16, 0, 0),
-                                    true
+                                    true,
+                                    "축구 대전",
+                                    "삼건물 대회"
                             )),
                     () -> assertThat(actual)
                             .map(CheerTalkResponse.ForSpectator::cheerTalkId)

--- a/src/test/java/com/sports/server/query/presentation/CheerTalkQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/CheerTalkQueryControllerTest.java
@@ -42,10 +42,10 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 		LocalDateTime createdAt = LocalDateTime.of(2024, 1, 21, 11, 46, 0);
 		List<CheerTalkResponse.ForSpectator> response = List.of(
 			new CheerTalkResponse.ForSpectator(
-				2L, "응원해요", 1L, createdAt, false
+				2L, "응원해요", 1L, createdAt, false, "경기1", "리그1"
 			),
 			new CheerTalkResponse.ForSpectator(
-				3L, "파이팅", 2L, createdAt, false
+				3L, "파이팅", 2L, createdAt, false, "경기1", "리그1"
 			)
 		);
 
@@ -74,7 +74,9 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 					fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER)
 						.description("응원톡에 해당하는 게임팀의 ID"),
 					fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
-					fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부")
+					fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
+						fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("게임의 이름"),
+						fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("리그의 이름")
 				)
 			));
 	}


### PR DESCRIPTION
## Summary
- `GET /games/{gameId}/cheer-talks` 응답에 `gameName`, `leagueName` 필드 추가
- `CheerTalkResponse.ForSpectator`에 새 필드 및 `(CheerTalk, Game)` 생성자 추가
- WebSocket 응답은 기존대로 null (게임별 토픽 구독이라 불필요)

closes #522

## Test plan
- [x] `CheerTalkQueryControllerTest` 통과 (REST Docs 포함)
- [x] `CheerTalkQueryAcceptanceTest` 통과