### PR TITLE
feat: Team, Player에 Organization 기반 접근 제어 추가

### DIFF
--- a/src/main/java/com/sports/server/command/nl/application/NlService.java
+++ b/src/main/java/com/sports/server/command/nl/application/NlService.java
@@ -91,14 +91,14 @@ public class NlService {
     @Transactional
     public NlRegisterTeamResponse registerTeamWithPlayers(NlRegisterTeamRequest request, Member member) {
         Organization organization = member.getOrganization();
-        Team team = createTeam(request);
+        Team team = createTeam(request, member);
 
         List<NlExecuteRequest.PlayerData> playerDataList = toExecutePlayerData(request.players());
         ExecuteContext context = buildExecuteContext(team.getId(), playerDataList, organization);
-        processPlayersForExecution(playerDataList, context);
+        processPlayersForExecution(playerDataList, context, member);
 
         if (!context.teamPlayerRegisters.isEmpty()) {
-            teamService.addPlayersToTeam(team.getId(), context.teamPlayerRegisters);
+            teamService.addPlayersToTeam(member, team.getId(), context.teamPlayerRegisters);
         }
 
         String displayMessage = String.format("%s에 %d명의 선수가 등록되었습니다.", team.getName(), context.assigned);
@@ -117,10 +117,10 @@ public class NlService {
 
         Organization organization = member.getOrganization();
         ExecuteContext context = buildExecuteContext(request.teamId(), request.players(), organization);
-        processPlayersForExecution(request.players(), context);
+        processPlayersForExecution(request.players(), context, member);
 
         if (!context.teamPlayerRegisters.isEmpty()) {
-            teamService.addPlayersToTeam(request.teamId(), context.teamPlayerRegisters);
+            teamService.addPlayersToTeam(member, request.teamId(), context.teamPlayerRegisters);
         }
 
         String displayMessage = String.format("%s에 %d명의 선수가 등록되었습니다.", team.getName(), context.assigned);
@@ -264,12 +264,12 @@ public class NlService {
 
     // --- registerTeamWithPlayers 전용 ---
 
-    private Team createTeam(NlRegisterTeamRequest request) {
+    private Team createTeam(NlRegisterTeamRequest request, Member member) {
         NlRegisterTeamRequest.TeamInfo teamInfo = request.team();
         TeamRequest.Register teamRegister = new TeamRequest.Register(
                 teamInfo.name(), teamInfo.logoImageUrl(), teamInfo.unit(), teamInfo.teamColor(), null, null
         );
-        Long teamId = teamService.registerAndReturnId(teamRegister);
+        Long teamId = teamService.registerAndReturnId(member, teamRegister);
         return entityUtils.getEntity(teamId, Team.class);
     }
 
@@ -292,14 +292,14 @@ public class NlService {
         return new ExecuteContext(teamPlayerIdSet, existingPlayerMap, organization);
     }
 
-    private void processPlayersForExecution(List<NlExecuteRequest.PlayerData> players, ExecuteContext context) {
+    private void processPlayersForExecution(List<NlExecuteRequest.PlayerData> players, ExecuteContext context, Member member) {
         for (NlExecuteRequest.PlayerData playerData : players) {
             if (!isValidName(playerData.name()) || !context.seenStudentNumbers.add(playerData.studentNumber())) {
                 context.skipped++;
                 continue;
             }
 
-            Long playerId = getOrCreatePlayerId(playerData, context);
+            Long playerId = getOrCreatePlayerId(playerData, context, member);
             if (playerId == null) {
                 context.skipped++;
                 continue;
@@ -315,7 +315,7 @@ public class NlService {
         }
     }
 
-    private Long getOrCreatePlayerId(NlExecuteRequest.PlayerData playerData, ExecuteContext context) {
+    private Long getOrCreatePlayerId(NlExecuteRequest.PlayerData playerData, ExecuteContext context, Member member) {
         Player existingPlayer = context.existingPlayerMap.get(playerData.studentNumber());
 
         if (existingPlayer != null) {
@@ -326,8 +326,7 @@ public class NlService {
         }
 
         Long playerId = playerService.register(
-                new PlayerRequest.Register(playerData.name(), playerData.studentNumber()),
-                context.organization
+                member, new PlayerRequest.Register(playerData.name(), playerData.studentNumber())
         );
         context.created++;
         return playerId;

--- a/src/main/java/com/sports/server/command/nl/application/NlService.java
+++ b/src/main/java/com/sports/server/command/nl/application/NlService.java
@@ -322,6 +322,7 @@ public class NlService {
             if (context.teamPlayerIdSet.contains(existingPlayer.getId())) {
                 return null;
             }
+            PermissionValidator.checkPermission(existingPlayer, member);
             return existingPlayer.getId();
         }
 

--- a/src/main/java/com/sports/server/command/player/application/PlayerService.java
+++ b/src/main/java/com/sports/server/command/player/application/PlayerService.java
@@ -1,10 +1,12 @@
 package com.sports.server.command.player.application;
 
+import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.organization.domain.Organization;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.player.domain.PlayerRepository;
 import com.sports.server.command.player.dto.PlayerRequest;
 import com.sports.server.common.application.EntityUtils;
+import com.sports.server.common.application.PermissionValidator;
 import com.sports.server.common.exception.BadRequestException;
 import com.sports.server.common.exception.ExceptionMessages;
 import jakarta.transaction.Transactional;
@@ -19,26 +21,30 @@ public class PlayerService {
     private final PlayerRepository playerRepository;
     private final EntityUtils entityUtils;
 
-    public Long register(final PlayerRequest.Register request, final Organization organization) {
+    public Long register(final Member member, final PlayerRequest.Register request) {
         validateUniqueStudentNumber(request.studentNumber());
+        Organization organization = member.getOrganization();
         Player player = new Player(request.name(), request.studentNumber(), organization.getStudentNumberDigits());
+        player.setOrganization(organization);
         playerRepository.save(player);
         return player.getId();
     }
 
-    public void update(final Long playerId, final PlayerRequest.Update request, final Organization organization) {
+    public void update(final Member member, final Long playerId, final PlayerRequest.Update request) {
         Player player = entityUtils.getEntity(playerId, Player.class);
+        PermissionValidator.checkPermission(player, member);
 
         String newStudentNumber = request.studentNumber();
         if (newStudentNumber != null && !newStudentNumber.equals(player.getStudentNumber())) {
             validateUniqueStudentNumber(newStudentNumber);
         }
 
-        player.update(request.name(), request.studentNumber(), organization.getStudentNumberDigits());
+        player.update(request.name(), request.studentNumber(), member.getOrganization().getStudentNumberDigits());
     }
 
-    public void delete(final Long playerId) {
+    public void delete(final Member member, final Long playerId) {
         Player player = entityUtils.getEntity(playerId, Player.class);
+        PermissionValidator.checkPermission(player, member);
         playerRepository.delete(player);
     }
 

--- a/src/main/java/com/sports/server/command/player/domain/Player.java
+++ b/src/main/java/com/sports/server/command/player/domain/Player.java
@@ -4,7 +4,9 @@ import com.sports.server.command.league.domain.League;
 import com.sports.server.command.league.domain.LeagueTopScorer;
 import com.sports.server.command.organization.domain.Organization;
 import com.sports.server.command.team.domain.TeamPlayer;
+import com.sports.server.command.member.domain.Member;
 import com.sports.server.common.domain.BaseEntity;
+import com.sports.server.common.domain.ManagedEntity;
 import com.sports.server.common.util.StudentNumber;
 import jakarta.persistence.*;
 import lombok.*;
@@ -17,7 +19,7 @@ import java.util.Objects;
 @Getter
 @Table(name = "players")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Player extends BaseEntity<Player> {
+public class Player extends BaseEntity<Player> implements ManagedEntity {
 
     @Column(name = "name", nullable = false)
     private String name;
@@ -88,6 +90,15 @@ public class Player extends BaseEntity<Player> {
             leagueTopScorer.updateRanking(ranking);
             leagueTopScorer.updateGoalCount(goalCount);
         }
+    }
+
+    @Override
+    public boolean isManagedBy(Member manager) {
+        return manager.getId() == 1 || (this.organization != null && this.organization.equals(manager.getOrganization()));
+    }
+
+    public void setOrganization(Organization organization) {
+        this.organization = organization;
     }
 
     @Override

--- a/src/main/java/com/sports/server/command/player/domain/Player.java
+++ b/src/main/java/com/sports/server/command/player/domain/Player.java
@@ -94,7 +94,11 @@ public class Player extends BaseEntity<Player> implements ManagedEntity {
 
     @Override
     public boolean isManagedBy(Member manager) {
-        return manager.getId() == 1 || (this.organization != null && this.organization.equals(manager.getOrganization()));
+        if (manager.isAdministrator()) {
+            return true;
+        }
+        return this.organization != null && manager.getOrganization() != null
+                && this.organization.getId().equals(manager.getOrganization().getId());
     }
 
     public void setOrganization(Organization organization) {

--- a/src/main/java/com/sports/server/command/player/presentation/PlayerController.java
+++ b/src/main/java/com/sports/server/command/player/presentation/PlayerController.java
@@ -16,18 +16,18 @@ public class PlayerController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public void register(@RequestBody PlayerRequest.Register request, Member member) {
-        playerService.register(request, member.getOrganization());
+        playerService.register(member, request);
     }
 
     @PatchMapping("/{playerId}")
     @ResponseStatus(HttpStatus.OK)
     public void update(@PathVariable Long playerId, @RequestBody PlayerRequest.Update update, Member member) {
-        playerService.update(playerId, update, member.getOrganization());
+        playerService.update(member, playerId, update);
     }
 
     @DeleteMapping("/{playerId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long playerId) {
-        playerService.delete(playerId);
+    public void delete(@PathVariable Long playerId, Member member) {
+        playerService.delete(member, playerId);
     }
 }

--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -1,11 +1,13 @@
 package com.sports.server.command.team.application;
 
+import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.player.domain.PlayerRepository;
 import com.sports.server.command.player.exception.PlayerErrorMessages;
 import com.sports.server.command.team.domain.*;
 import com.sports.server.command.team.dto.TeamRequest;
 import com.sports.server.common.application.EntityUtils;
+import com.sports.server.common.application.PermissionValidator;
 import com.sports.server.common.application.S3Service;
 import com.sports.server.common.exception.CustomException;
 import com.sports.server.common.exception.NotFoundException;
@@ -36,29 +38,33 @@ public class TeamService {
     private final EntityUtils entityUtils;
     private final S3Service s3Service;
 
-    public void register(final TeamRequest.Register request) {
+    public void register(final Member member, final TeamRequest.Register request) {
         String imgUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
         s3Service.doesFileExist(imgUrl);
 
         Team team = request.toEntity(imgUrl);
+        team.setOrganization(member.getOrganization());
         teamRepository.save(team);
 
         if (request.teamPlayers() != null && !request.teamPlayers().isEmpty()) {
-            addPlayersToTeam(team.getId(), request.teamPlayers());
+            addPlayersToTeam(member, team.getId(), request.teamPlayers());
         }
     }
 
-    public Long registerAndReturnId(final TeamRequest.Register request) {
+    public Long registerAndReturnId(final Member member, final TeamRequest.Register request) {
         String imgUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
         s3Service.doesFileExist(imgUrl);
 
         Team team = request.toEntity(imgUrl);
+        team.setOrganization(member.getOrganization());
         teamRepository.save(team);
         return team.getId();
     }
 
-    public void update(final TeamRequest.Update request, final Long teamId) {
+    public void update(final Member member, final TeamRequest.Update request, final Long teamId) {
         Team team = entityUtils.getEntity(teamId, Team.class);
+        PermissionValidator.checkPermission(team, member);
+
         s3Service.doesFileExist(team.getLogoImageUrl());
         Unit unit = Optional.ofNullable(request.unit()).map(Unit::from).orElse(null);
         team.update(request.name(), request.logoImageUrl(), originPrefix, replacePrefix, unit, request.teamColor());
@@ -68,13 +74,16 @@ public class TeamService {
         }
     }
 
-    public void delete(final Long teamId) {
+    public void delete(final Member member, final Long teamId) {
         Team team = entityUtils.getEntity(teamId, Team.class);
+        PermissionValidator.checkPermission(team, member);
         teamRepository.delete(team);
     }
 
-    public void addPlayersToTeam(final Long teamId, final List<TeamRequest.TeamPlayerRegister> request) {
+    public void addPlayersToTeam(final Member member, final Long teamId, final List<TeamRequest.TeamPlayerRegister> request) {
         Team team = entityUtils.getEntity(teamId, Team.class);
+        PermissionValidator.checkPermission(team, member);
+
         List<Player> players = fetchAndValidatePlayers(request);
         Map<Long, Integer> jerseyNumbers = buildJerseyNumberMap(request);
 
@@ -85,16 +94,19 @@ public class TeamService {
         teamPlayerRepository.saveAll(newTeamPlayers);
     }
 
-    public void deleteTeamPlayer(final Long teamPlayerId) {
+    public void deleteTeamPlayer(final Member member, final Long teamPlayerId) {
         TeamPlayer teamPlayer = entityUtils.getEntity(teamPlayerId, TeamPlayer.class);
         Team team = teamPlayer.getTeam();
+        PermissionValidator.checkPermission(team, member);
+
         Player player = teamPlayer.getPlayer();
         team.removeTeamPlayer(player);
         teamPlayerRepository.delete(teamPlayer);
     }
 
-    public void deleteLogoImage(Long teamId) {
+    public void deleteLogoImage(final Member member, Long teamId) {
         Team team = entityUtils.getEntity(teamId, Team.class);
+        PermissionValidator.checkPermission(team, member);
         team.deleteLogoImageUrl();
     }
 

--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -70,7 +70,7 @@ public class TeamService {
         team.update(request.name(), request.logoImageUrl(), originPrefix, replacePrefix, unit, request.teamColor());
 
         if (request.teamPlayers() != null) {
-            upsertPlayersToTeam(team, request.teamPlayers());
+            upsertPlayersToTeam(member, team, request.teamPlayers());
         }
     }
 
@@ -85,6 +85,7 @@ public class TeamService {
         PermissionValidator.checkPermission(team, member);
 
         List<Player> players = fetchAndValidatePlayers(request);
+        validatePlayersOrganization(players, member);
         Map<Long, Integer> jerseyNumbers = buildJerseyNumberMap(request);
 
         List<TeamPlayer> newTeamPlayers = players.stream()
@@ -110,8 +111,9 @@ public class TeamService {
         team.deleteLogoImageUrl();
     }
 
-    private void upsertPlayersToTeam(Team team, List<TeamRequest.TeamPlayerRegister> request) {
+    private void upsertPlayersToTeam(Member member, Team team, List<TeamRequest.TeamPlayerRegister> request) {
         List<Player> players = fetchAndValidatePlayers(request);
+        validatePlayersOrganization(players, member);
         Map<Long, Integer> jerseyNumbers = buildJerseyNumberMap(request);
         Map<Long, TeamPlayer> existingTeamPlayersMap = buildExistingTeamPlayerMap(team.getId());
 
@@ -157,6 +159,10 @@ public class TeamService {
         if (players.size() != new HashSet<>(playerIds).size()) {
             throw new NotFoundException(PlayerErrorMessages.PLAYER_NOT_EXIST_EXCEPTION);
         }
+    }
+
+    private void validatePlayersOrganization(List<Player> players, Member member) {
+        players.forEach(player -> PermissionValidator.checkPermission(player, member));
     }
 
     private static Map<Long, Integer> buildJerseyNumberMap(List<TeamRequest.TeamPlayerRegister> request) {

--- a/src/main/java/com/sports/server/command/team/domain/Team.java
+++ b/src/main/java/com/sports/server/command/team/domain/Team.java
@@ -5,7 +5,9 @@ import com.sports.server.command.league.domain.LeagueTeam;
 import com.sports.server.command.league.domain.SportType;
 import com.sports.server.command.organization.domain.Organization;
 import com.sports.server.command.player.domain.Player;
+import com.sports.server.command.member.domain.Member;
 import com.sports.server.common.domain.BaseEntity;
+import com.sports.server.common.domain.ManagedEntity;
 import com.sports.server.common.exception.CustomException;
 import jakarta.persistence.*;
 
@@ -24,7 +26,7 @@ import org.springframework.http.HttpStatus;
 @SQLDelete(sql = "UPDATE teams SET is_deleted = 1 WHERE id = ?")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Team extends BaseEntity<Team> {
+public class Team extends BaseEntity<Team> implements ManagedEntity {
 
     @Column(name = "name", nullable = false)
     private String name;
@@ -135,6 +137,15 @@ public class Team extends BaseEntity<Team> {
 
     public void removeGameTeam(GameTeam gameTeam) {
         this.gameTeams.remove(gameTeam);
+    }
+
+    @Override
+    public boolean isManagedBy(Member manager) {
+        return manager.getId() == 1 || (this.organization != null && this.organization.equals(manager.getOrganization()));
+    }
+
+    public void setOrganization(Organization organization) {
+        this.organization = organization;
     }
 
 }

--- a/src/main/java/com/sports/server/command/team/domain/Team.java
+++ b/src/main/java/com/sports/server/command/team/domain/Team.java
@@ -141,7 +141,11 @@ public class Team extends BaseEntity<Team> implements ManagedEntity {
 
     @Override
     public boolean isManagedBy(Member manager) {
-        return manager.getId() == 1 || (this.organization != null && this.organization.equals(manager.getOrganization()));
+        if (manager.isAdministrator()) {
+            return true;
+        }
+        return this.organization != null && manager.getOrganization() != null
+                && this.organization.getId().equals(manager.getOrganization().getId());
     }
 
     public void setOrganization(Organization organization) {

--- a/src/main/java/com/sports/server/command/team/presentation/TeamController.java
+++ b/src/main/java/com/sports/server/command/team/presentation/TeamController.java
@@ -1,5 +1,6 @@
 package com.sports.server.command.team.presentation;
 
+import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.team.application.TeamService;
 import com.sports.server.command.team.dto.TeamRequest;
 import lombok.RequiredArgsConstructor;
@@ -15,39 +16,39 @@ public class TeamController {
 
     @PostMapping("/teams")
     @ResponseStatus(HttpStatus.CREATED)
-    public void register(@RequestBody TeamRequest.Register request) {
-        teamService.register(request);
+    public void register(@RequestBody TeamRequest.Register request, Member member) {
+        teamService.register(member, request);
     }
 
     @PatchMapping("/teams/{teamId}")
     @ResponseStatus(HttpStatus.OK)
-    public void update(@RequestBody TeamRequest.Update request, @PathVariable Long teamId) {
-        teamService.update(request, teamId);
+    public void update(@RequestBody TeamRequest.Update request, @PathVariable Long teamId, Member member) {
+        teamService.update(member, request, teamId);
     }
 
     @DeleteMapping("/teams/{teamId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long teamId) {
-        teamService.delete(teamId);
+    public void delete(@PathVariable Long teamId, Member member) {
+        teamService.delete(member, teamId);
     }
 
     @PostMapping("/teams/{teamId}/delete-logo")
     @ResponseStatus(HttpStatus.OK)
-    public void deleteLogo(@PathVariable Long teamId) {
-        teamService.deleteLogoImage(teamId);
+    public void deleteLogo(@PathVariable Long teamId, Member member) {
+        teamService.deleteLogoImage(member, teamId);
     }
 
     @PostMapping("/teams/{teamId}/players")
     @ResponseStatus(HttpStatus.OK)
     public void addPlayersToTeam(@PathVariable Long teamId,
-                          @RequestBody List<TeamRequest.TeamPlayerRegister> request){
-        teamService.addPlayersToTeam(teamId, request);
+                          @RequestBody List<TeamRequest.TeamPlayerRegister> request, Member member){
+        teamService.addPlayersToTeam(member, teamId, request);
     }
 
     @DeleteMapping("/team-players/{teamPlayerId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteTeamPlayer(@PathVariable Long teamPlayerId){
-        teamService.deleteTeamPlayer(teamPlayerId);
+    public void deleteTeamPlayer(@PathVariable Long teamPlayerId, Member member){
+        teamService.deleteTeamPlayer(member, teamPlayerId);
     }
 
 }

--- a/src/main/java/com/sports/server/query/application/PlayerQueryService.java
+++ b/src/main/java/com/sports/server/query/application/PlayerQueryService.java
@@ -1,5 +1,6 @@
 package com.sports.server.query.application;
 
+import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.team.domain.TeamPlayer;
 import com.sports.server.command.team.domain.TeamPlayerRepository;
@@ -29,8 +30,8 @@ public class PlayerQueryService {
     private final TeamPlayerRepository teamPlayerRepository;
     private final PlayerInfoProvider playerInfoProvider;
 
-    public List<PlayerResponse> getAllPlayers(){
-        List<Player> players = playerQueryRepository.findAll();
+    public List<PlayerResponse> getAllPlayers(Member member){
+        List<Player> players = playerQueryRepository.findAllByOrganizationId(member.getOrganization().getId());
         if (players.isEmpty()) {
             return Collections.emptyList();
         }

--- a/src/main/java/com/sports/server/query/application/PlayerQueryService.java
+++ b/src/main/java/com/sports/server/query/application/PlayerQueryService.java
@@ -5,9 +5,10 @@ import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.team.domain.TeamPlayer;
 import com.sports.server.command.team.domain.TeamPlayerRepository;
 import com.sports.server.common.application.EntityUtils;
+import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.query.dto.response.PlayerResponse;
 import com.sports.server.query.dto.response.TeamResponse;
-import com.sports.server.query.repository.PlayerQueryRepository;
+import com.sports.server.query.repository.PlayerDynamicRepository;
 import com.sports.server.query.repository.TimelineQueryRepository;
 import com.sports.server.query.support.PlayerInfoProvider;
 import lombok.RequiredArgsConstructor;
@@ -24,14 +25,16 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PlayerQueryService {
 
-    private final PlayerQueryRepository playerQueryRepository;
+    private final PlayerDynamicRepository playerDynamicRepository;
     private final EntityUtils entityUtils;
     private final TimelineQueryRepository timelineQueryRepository;
     private final TeamPlayerRepository teamPlayerRepository;
     private final PlayerInfoProvider playerInfoProvider;
 
-    public List<PlayerResponse> getAllPlayers(Member member){
-        List<Player> players = playerQueryRepository.findAllByOrganizationId(member.getOrganization().getId());
+    public List<PlayerResponse> getAllPlayers(Member member, PageRequestDto pageRequest){
+        List<Player> players = playerDynamicRepository.findAllByOrganizationId(
+                member.getOrganization().getId(), pageRequest.cursor(), pageRequest.size()
+        );
         if (players.isEmpty()) {
             return Collections.emptyList();
         }

--- a/src/main/java/com/sports/server/query/presentation/PlayerQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/PlayerQueryController.java
@@ -1,6 +1,7 @@
 package com.sports.server.query.presentation;
 
 import com.sports.server.command.member.domain.Member;
+import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.query.application.PlayerQueryService;
 import com.sports.server.query.dto.response.PlayerResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +18,9 @@ public class PlayerQueryController {
     private final PlayerQueryService playerQueryService;
 
     @GetMapping
-    public ResponseEntity<List<PlayerResponse>> getAllPlayers(Member member){
-        return ResponseEntity.ok(playerQueryService.getAllPlayers(member));
+    public ResponseEntity<List<PlayerResponse>> getAllPlayers(
+            @ModelAttribute PageRequestDto pageRequest, Member member){
+        return ResponseEntity.ok(playerQueryService.getAllPlayers(member, pageRequest));
     }
 
     @GetMapping("/{playerId}")

--- a/src/main/java/com/sports/server/query/presentation/PlayerQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/PlayerQueryController.java
@@ -1,5 +1,6 @@
 package com.sports.server.query.presentation;
 
+import com.sports.server.command.member.domain.Member;
 import com.sports.server.query.application.PlayerQueryService;
 import com.sports.server.query.dto.response.PlayerResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +17,8 @@ public class PlayerQueryController {
     private final PlayerQueryService playerQueryService;
 
     @GetMapping
-    public ResponseEntity<List<PlayerResponse>> getAllPlayers(){
-        return ResponseEntity.ok(playerQueryService.getAllPlayers());
+    public ResponseEntity<List<PlayerResponse>> getAllPlayers(Member member){
+        return ResponseEntity.ok(playerQueryService.getAllPlayers(member));
     }
 
     @GetMapping("/{playerId}")

--- a/src/main/java/com/sports/server/query/repository/PlayerDynamicRepository.java
+++ b/src/main/java/com/sports/server/query/repository/PlayerDynamicRepository.java
@@ -1,0 +1,8 @@
+package com.sports.server.query.repository;
+
+import com.sports.server.command.player.domain.Player;
+import java.util.List;
+
+public interface PlayerDynamicRepository {
+    List<Player> findAllByOrganizationId(Long organizationId, Long cursor, Integer size);
+}

--- a/src/main/java/com/sports/server/query/repository/PlayerDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/PlayerDynamicRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.sports.server.query.repository;
+
+import static com.sports.server.command.player.domain.QPlayer.player;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sports.server.command.player.domain.Player;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PlayerDynamicRepositoryImpl implements PlayerDynamicRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Player> findAllByOrganizationId(Long organizationId, Long cursor, Integer size) {
+        return queryFactory.selectFrom(player)
+                .where(
+                        player.organization.id.eq(organizationId),
+                        getCursorCondition(cursor)
+                )
+                .orderBy(player.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    private BooleanExpression getCursorCondition(Long cursor) {
+        if (cursor == null) {
+            return null;
+        }
+        return player.id.lt(cursor);
+    }
+}

--- a/src/main/java/com/sports/server/query/repository/PlayerQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/PlayerQueryRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface PlayerQueryRepository extends Repository<Player, Long> {
     List<Player> findAll();
+
+    List<Player> findAllByOrganizationId(Long organizationId);
 }

--- a/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
+++ b/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
@@ -344,6 +344,7 @@ class NlServiceTest {
             Player existingPlayer = mock(Player.class);
             given(existingPlayer.getId()).willReturn(42L);
             given(existingPlayer.getStudentNumber()).willReturn("202600002");
+            given(existingPlayer.isManagedBy(mockMember)).willReturn(true);
 
             given(teamPlayerRepository.findPlayerIdsByTeamId(99L)).willReturn(List.of());
             given(playerRepository.findByStudentNumberIn(anyList())).willReturn(List.of(existingPlayer));
@@ -396,6 +397,7 @@ class NlServiceTest {
             Player existingPlayer = mock(Player.class);
             given(existingPlayer.getId()).willReturn(42L);
             given(existingPlayer.getStudentNumber()).willReturn("202600002");
+            given(existingPlayer.isManagedBy(mockMember)).willReturn(true);
 
             given(entityUtils.getEntity(1L, Team.class)).willReturn(mockTeam);
             given(teamPlayerRepository.findPlayerIdsByTeamId(1L)).willReturn(List.of());

--- a/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
+++ b/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
@@ -303,7 +303,7 @@ class NlServiceTest {
                     List.of(new NlRegisterTeamRequest.PlayerData("홍길동", "202600001", 10))
             );
 
-            given(teamService.registerAndReturnId(any())).willReturn(99L);
+            given(teamService.registerAndReturnId(any(), any())).willReturn(99L);
 
             Team createdTeam = mock(Team.class);
             given(createdTeam.getId()).willReturn(99L);
@@ -321,8 +321,8 @@ class NlServiceTest {
             assertThat(response.teamId()).isEqualTo(99L);
             assertThat(response.result().created()).isEqualTo(1);
             assertThat(response.result().assigned()).isEqualTo(1);
-            verify(teamService).registerAndReturnId(any());
-            verify(teamService).addPlayersToTeam(eq(99L), anyList());
+            verify(teamService).registerAndReturnId(any(), any());
+            verify(teamService).addPlayersToTeam(any(), eq(99L), anyList());
         }
 
         @Test
@@ -334,7 +334,7 @@ class NlServiceTest {
                     List.of(new NlRegisterTeamRequest.PlayerData("김철수", "202600002", 7))
             );
 
-            given(teamService.registerAndReturnId(any())).willReturn(99L);
+            given(teamService.registerAndReturnId(any(), any())).willReturn(99L);
 
             Team createdTeam = mock(Team.class);
             given(createdTeam.getId()).willReturn(99L);
@@ -382,7 +382,7 @@ class NlServiceTest {
             assertThat(response.result().created()).isEqualTo(1);
             assertThat(response.result().assigned()).isEqualTo(1);
             verify(playerService).register(any(), any());
-            verify(teamService).addPlayersToTeam(eq(1L), anyList());
+            verify(teamService).addPlayersToTeam(any(), eq(1L), anyList());
         }
 
         @Test
@@ -408,7 +408,7 @@ class NlServiceTest {
             assertThat(response.result().created()).isEqualTo(0);
             assertThat(response.result().assigned()).isEqualTo(1);
             verify(playerService, never()).register(any(), any());
-            verify(teamService).addPlayersToTeam(eq(1L), anyList());
+            verify(teamService).addPlayersToTeam(any(), eq(1L), anyList());
         }
 
         @Test
@@ -434,7 +434,7 @@ class NlServiceTest {
             assertThat(response.result().created()).isEqualTo(0);
             assertThat(response.result().assigned()).isEqualTo(0);
             assertThat(response.result().skipped()).isEqualTo(1);
-            verify(teamService, never()).addPlayersToTeam(anyLong(), anyList());
+            verify(teamService, never()).addPlayersToTeam(any(), anyLong(), anyList());
         }
     }
 

--- a/src/test/java/com/sports/server/command/nl/presentation/NlControllerTest.java
+++ b/src/test/java/com/sports/server/command/nl/presentation/NlControllerTest.java
@@ -169,6 +169,7 @@ public class NlControllerTest extends DocumentationTest {
         ResultActions result = mockMvc.perform(post("/nl/register-team")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
+                .cookie(new Cookie(COOKIE_NAME, "temp-cookie"))
         );
 
         // then

--- a/src/test/java/com/sports/server/command/player/application/PlayerServiceTest.java
+++ b/src/test/java/com/sports/server/command/player/application/PlayerServiceTest.java
@@ -1,6 +1,7 @@
 package com.sports.server.command.player.application;
 
-import com.sports.server.command.organization.domain.Organization;
+import com.sports.server.command.member.domain.Member;
+import com.sports.server.command.member.domain.MemberRepository;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.player.domain.PlayerRepository;
 import com.sports.server.command.player.dto.PlayerRequest;
@@ -10,6 +11,7 @@ import com.sports.server.common.exception.ExceptionMessages;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.support.ServiceTest;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
@@ -31,18 +33,28 @@ public class PlayerServiceTest extends ServiceTest {
     @Autowired
     private EntityUtils entityUtils;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member manager;
+
+    @BeforeEach
+    void setUp() {
+        manager = memberRepository.findMemberByEmailWithOrganization("john@example.com")
+                .orElseThrow();
+    }
+
     @Nested
     @DisplayName("Organization별 학번 자릿수 검증")
     class StudentNumberDigitsValidation {
 
         @Test
         void 학번_9자리_organization에서_9자리_학번으로_등록_성공() {
-            // given
-            Organization org = entityUtils.getEntity(1L, Organization.class); // student_number_digits = 9
+            // given — manager의 organization은 student_number_digits = 9
             PlayerRequest.Register request = new PlayerRequest.Register("손흥민", "202500001");
 
             // when
-            Long playerId = playerService.register(request, org);
+            Long playerId = playerService.register(manager, request);
 
             // then
             assertThat(playerId).isNotNull();
@@ -51,23 +63,23 @@ public class PlayerServiceTest extends ServiceTest {
         @Test
         void 학번_9자리_organization에서_10자리_학번으로_등록_시_예외가_발생한다() {
             // given
-            Organization org = entityUtils.getEntity(1L, Organization.class); // student_number_digits = 9
             PlayerRequest.Register request = new PlayerRequest.Register("손흥민", "2025000001");
 
             // when & then
-            assertThatThrownBy(() -> playerService.register(request, org))
+            assertThatThrownBy(() -> playerService.register(manager, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(String.format(ExceptionMessages.PLAYER_STUDENT_NUMBER_INVALID, 9));
         }
 
         @Test
         void 학번_10자리_organization에서_10자리_학번으로_등록_성공() {
-            // given
-            Organization org = entityUtils.getEntity(4L, Organization.class); // student_number_digits = 10
+            // given — organization id=4는 student_number_digits = 10
+            Member manager10 = memberRepository.findMemberByEmailWithOrganization("user4@example.com")
+                    .orElseThrow();
             PlayerRequest.Register request = new PlayerRequest.Register("손흥민", "2025000001");
 
             // when
-            Long playerId = playerService.register(request, org);
+            Long playerId = playerService.register(manager10, request);
 
             // then
             assertThat(playerId).isNotNull();
@@ -76,11 +88,12 @@ public class PlayerServiceTest extends ServiceTest {
         @Test
         void 학번_10자리_organization에서_9자리_학번으로_등록_시_예외가_발생한다() {
             // given
-            Organization org = entityUtils.getEntity(4L, Organization.class); // student_number_digits = 10
+            Member manager10 = memberRepository.findMemberByEmailWithOrganization("user4@example.com")
+                    .orElseThrow();
             PlayerRequest.Register request = new PlayerRequest.Register("손흥민", "202500001");
 
             // when & then
-            assertThatThrownBy(() -> playerService.register(request, org))
+            assertThatThrownBy(() -> playerService.register(manager10, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(String.format(ExceptionMessages.PLAYER_STUDENT_NUMBER_INVALID, 10));
         }
@@ -90,13 +103,12 @@ public class PlayerServiceTest extends ServiceTest {
     void 선수_등록_시_학번이_중복되면_예외가_발생한다() {
         // given
         String duplicatedStudentNumber = "202500001";
-        Organization organization = entityUtils.getEntity(1L, Organization.class);
-        playerRepository.save(new Player("손흥민", duplicatedStudentNumber, organization.getStudentNumberDigits()));
+        playerService.register(manager, new PlayerRequest.Register("손흥민", duplicatedStudentNumber));
 
         // when & then
         PlayerRequest.Register request = new PlayerRequest.Register("박지성", duplicatedStudentNumber);
 
-        assertThatThrownBy(() -> playerService.register(request, organization))
+        assertThatThrownBy(() -> playerService.register(manager, request))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("이미 존재하는 학번입니다.");
     }
@@ -104,16 +116,14 @@ public class PlayerServiceTest extends ServiceTest {
     @Test
     void 삭제한_이후에는_해당_객체를_찾을_수_없다() {
         // given
-        Organization organization = entityUtils.getEntity(1L, Organization.class);
-        Player player = new Player("손흥민", "202500001", organization.getStudentNumberDigits());
-        playerRepository.save(player);
+        Long playerId = playerService.register(manager, new PlayerRequest.Register("손흥민", "202500001"));
 
         // when
-        playerService.delete(player.getId());
+        playerService.delete(manager, playerId);
 
         // then
         Assertions.assertThatThrownBy(
-                        () -> entityUtils.getEntity(player.getId(), Player.class))
+                        () -> entityUtils.getEntity(playerId, Player.class))
                 .isInstanceOf(NotFoundException.class);
     }
 }

--- a/src/test/java/com/sports/server/command/team/application/TeamServiceTest.java
+++ b/src/test/java/com/sports/server/command/team/application/TeamServiceTest.java
@@ -1,5 +1,7 @@
 package com.sports.server.command.team.application;
 
+import com.sports.server.command.member.domain.Member;
+import com.sports.server.command.member.domain.MemberRepository;
 import com.sports.server.command.player.exception.PlayerErrorMessages;
 import com.sports.server.command.team.domain.*;
 import com.sports.server.command.team.dto.TeamRequest;
@@ -45,11 +47,17 @@ public class TeamServiceTest extends ServiceTest {
     @Autowired
     private TeamPlayerRepository teamPlayerRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     private String imageUrl;
+    private Member manager;
 
     @BeforeEach
     void setUp() {
         imageUrl = originPrefix + "image_url.png";
+        manager = memberRepository.findMemberByEmailWithOrganization("john@example.com")
+                .orElseThrow();
     }
 
     @Nested
@@ -66,7 +74,7 @@ public class TeamServiceTest extends ServiceTest {
                     "사회과학대학","color code", playerRegisterRequests, null);
 
             // when & then
-            assertThatThrownBy(() -> teamService.register(request))
+            assertThatThrownBy(() -> teamService.register(manager, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessage("잘못된 이미지 url 입니다.");
         }
@@ -82,7 +90,7 @@ public class TeamServiceTest extends ServiceTest {
                     "invalid unit","color code", playerRegisterRequests, null);
 
             // when & then
-            assertThatThrownBy(() -> teamService.register(request))
+            assertThatThrownBy(() -> teamService.register(manager, request))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage(TeamErrorMessages.UNIT_NOT_FOUND_EXCEPTION);
         }
@@ -102,7 +110,7 @@ public class TeamServiceTest extends ServiceTest {
             doNothing().when(s3Service).doesFileExist(anyString());
 
             // when
-            teamService.update(request, teamId);
+            teamService.update(manager, request, teamId);
             Team team = entityUtils.getEntity(1L, Team.class);
 
             // then
@@ -119,7 +127,7 @@ public class TeamServiceTest extends ServiceTest {
             doNothing().when(s3Service).doesFileExist(anyString());
 
             // when & then
-            assertThatThrownBy(() -> teamService.update(request, teamId))
+            assertThatThrownBy(() -> teamService.update(manager, request, teamId))
                     .isInstanceOf(CustomException.class)
                     .hasMessage("잘못된 이미지 url 입니다.");
         }
@@ -131,7 +139,7 @@ public class TeamServiceTest extends ServiceTest {
             TeamRequest.Update request = new TeamRequest.Update("newName", null, null, null, null);
 
             // when & then
-            assertThatThrownBy(() -> teamService.update(request, teamId))
+            assertThatThrownBy(() -> teamService.update(manager, request, teamId))
                     .isInstanceOf(NotFoundException.class);
         }
 
@@ -142,7 +150,7 @@ public class TeamServiceTest extends ServiceTest {
             TeamRequest.Update request = new TeamRequest.Update(null, null, "invalid unit", null, null);
 
             // when & then
-            assertThatThrownBy(() -> teamService.update(request, teamId))
+            assertThatThrownBy(() -> teamService.update(manager, request, teamId))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage(TeamErrorMessages.UNIT_NOT_FOUND_EXCEPTION);
         }
@@ -156,7 +164,7 @@ public class TeamServiceTest extends ServiceTest {
             doNothing().when(s3Service).doesFileExist(anyString());
 
             // when
-            teamService.update(request, teamId);
+            teamService.update(manager, request, teamId);
             List<TeamPlayer> teamPlayers = teamPlayerRepository.findTeamPlayersWithPlayerByTeamId(teamId);
 
             // then
@@ -176,7 +184,7 @@ public class TeamServiceTest extends ServiceTest {
             doNothing().when(s3Service).doesFileExist(anyString());
 
             // when
-            teamService.update(request, teamId);
+            teamService.update(manager, request, teamId);
             List<TeamPlayer> teamPlayers = teamPlayerRepository.findTeamPlayersWithPlayerByTeamId(teamId);
 
             // then
@@ -195,7 +203,7 @@ public class TeamServiceTest extends ServiceTest {
             doNothing().when(s3Service).doesFileExist(anyString());
 
             // when
-            teamService.update(request, teamId);
+            teamService.update(manager, request, teamId);
             List<TeamPlayer> teamPlayers = teamPlayerRepository.findTeamPlayersWithPlayerByTeamId(teamId);
 
             // then
@@ -219,7 +227,7 @@ public class TeamServiceTest extends ServiceTest {
             doNothing().when(s3Service).doesFileExist(anyString());
 
             // when & then
-            assertThatThrownBy(() -> teamService.update(request, teamId))
+            assertThatThrownBy(() -> teamService.update(manager, request, teamId))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage(PlayerErrorMessages.PLAYER_NOT_EXIST_EXCEPTION);
         }
@@ -239,7 +247,7 @@ public class TeamServiceTest extends ServiceTest {
             );
 
             // when
-            teamService.addPlayersToTeam(teamId, playerToAdd);
+            teamService.addPlayersToTeam(manager, teamId, playerToAdd);
             List<TeamPlayer> teamPlayers = teamPlayerRepository.findTeamPlayersWithPlayerByTeamId(teamId);
 
             //then
@@ -256,7 +264,7 @@ public class TeamServiceTest extends ServiceTest {
             );
 
             // when & then
-            assertThatThrownBy(() -> teamService.addPlayersToTeam(teamId, playerToAdd))
+            assertThatThrownBy(() -> teamService.addPlayersToTeam(manager, teamId, playerToAdd))
                     .isInstanceOf(CustomException.class)
                     .hasMessage("이미 팀에 소속된 선수입니다.");
         }
@@ -268,7 +276,7 @@ public class TeamServiceTest extends ServiceTest {
             List<TeamRequest.TeamPlayerRegister> playerToAdd = List.of();
 
             // when
-            teamService.addPlayersToTeam(teamId, playerToAdd);
+            teamService.addPlayersToTeam(manager, teamId, playerToAdd);
             List<TeamPlayer> teamPlayers = teamPlayerRepository.findTeamPlayersWithPlayerByTeamId(teamId);
 
             //then
@@ -284,7 +292,7 @@ public class TeamServiceTest extends ServiceTest {
             );
 
             // when & then
-            assertThatThrownBy(() -> teamService.addPlayersToTeam(teamId, playerToAdd))
+            assertThatThrownBy(() -> teamService.addPlayersToTeam(manager, teamId, playerToAdd))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage(PlayerErrorMessages.PLAYER_NOT_EXIST_EXCEPTION);
         }
@@ -300,7 +308,7 @@ public class TeamServiceTest extends ServiceTest {
             Long teamPlayerIdToDelete = 1L;
 
             // when
-            teamService.deleteTeamPlayer(teamPlayerIdToDelete);
+            teamService.deleteTeamPlayer(manager, teamPlayerIdToDelete);
 
             //then
             Optional<TeamPlayer> result = teamPlayerRepository.findById(teamPlayerIdToDelete);
@@ -313,7 +321,7 @@ public class TeamServiceTest extends ServiceTest {
             Long nonExistentTeamPlayerId = 999L;
 
             // when & then
-            assertThatThrownBy(() -> teamService.deleteTeamPlayer(nonExistentTeamPlayerId))
+            assertThatThrownBy(() -> teamService.deleteTeamPlayer(manager, nonExistentTeamPlayerId))
                     .isInstanceOf(NotFoundException.class);
         }
     }
@@ -324,7 +332,7 @@ public class TeamServiceTest extends ServiceTest {
         Long teamId = 1L;
 
         // when
-        teamService.deleteLogoImage(teamId);
+        teamService.deleteLogoImage(manager, teamId);
 
         // then
         Team team = entityUtils.getEntity(teamId, Team.class);

--- a/src/test/java/com/sports/server/command/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/sports/server/command/team/presentation/TeamControllerTest.java
@@ -44,7 +44,7 @@ public class TeamControllerTest extends DocumentationTest {
                 null
         );
 
-        Mockito.doNothing().when(teamService).register(Mockito.any(TeamRequest.Register.class));
+        Mockito.doNothing().when(teamService).register(any(), Mockito.any(TeamRequest.Register.class));
 
         // when
         ResultActions result = mockMvc.perform(post("/teams", request)
@@ -79,7 +79,7 @@ public class TeamControllerTest extends DocumentationTest {
         Long teamId = 1L;
         Cookie cookie = new Cookie(COOKIE_NAME, "temp-cookie");
 
-        doNothing().when(teamService).delete(anyLong());
+        doNothing().when(teamService).delete(any(), anyLong());
 
         // when
         ResultActions result = mockMvc.perform(delete("/teams/{teamId}", teamId)
@@ -114,7 +114,7 @@ public class TeamControllerTest extends DocumentationTest {
                 )
         );
 
-        doNothing().when(teamService).update(any(TeamRequest.Update.class), anyLong());
+        doNothing().when(teamService).update(any(), any(TeamRequest.Update.class), anyLong());
 
         // when
         ResultActions result = mockMvc.perform(patch("/teams/{teamId}", teamId)
@@ -153,7 +153,7 @@ public class TeamControllerTest extends DocumentationTest {
                 new TeamRequest.TeamPlayerRegister(2L, 7)
         );
 
-        doNothing().when(teamService).addPlayersToTeam(anyLong(), any());
+        doNothing().when(teamService).addPlayersToTeam(any(), anyLong(), any());
 
         // when
         ResultActions result = mockMvc.perform(post("/teams/{teamId}/players", teamId)
@@ -183,7 +183,7 @@ public class TeamControllerTest extends DocumentationTest {
         // given
         Long teamPlayerId = 1L;
 
-        doNothing().when(teamService).deleteTeamPlayer(anyLong());
+        doNothing().when(teamService).deleteTeamPlayer(any(), anyLong());
 
         // when
         ResultActions result = mockMvc.perform(delete("/team-players/{teamPlayerId}", teamPlayerId)

--- a/src/test/java/com/sports/server/query/acceptance/PlayerQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/PlayerQueryAcceptanceTest.java
@@ -1,5 +1,8 @@
 package com.sports.server.query.acceptance;
 
+import com.sports.server.command.member.domain.Member;
+import com.sports.server.command.member.domain.MemberRepository;
+import com.sports.server.command.organization.domain.Organization;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.player.domain.PlayerRepository;
 import com.sports.server.query.dto.response.PlayerResponse;
@@ -12,16 +15,21 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+@Sql("/member-fixture.sql")
 public class PlayerQueryAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private PlayerRepository playerRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     private Player player1;
     private Player player2;
@@ -30,16 +38,24 @@ public class PlayerQueryAcceptanceTest extends AcceptanceTest {
     @BeforeEach
     protected void setUp() {
         super.setUp();
+        Member member = memberRepository.findMemberByEmailWithOrganization("john@example.com").orElseThrow();
+        Organization organization = member.getOrganization();
+
         player1 = new Player("손흥민", "202500111", 9);
+        player1.setOrganization(organization);
         player2 = new Player("박지성", "202500112", 9);
+        player2.setOrganization(organization);
         playerRepository.save(player1);
         playerRepository.save(player2);
     }
 
     @Test
     void 모든_선수를_조회한다() {
+        configureMockJwtForEmail("john@example.com");
+
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
+                .cookie(COOKIE_NAME, mockToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .get("/players")
                 .then().log().all()

--- a/src/test/java/com/sports/server/query/acceptance/PlayerQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/PlayerQueryAcceptanceTest.java
@@ -63,7 +63,7 @@ public class PlayerQueryAcceptanceTest extends AcceptanceTest {
 
         // then
         List<PlayerResponse> actual = toResponses(response, PlayerResponse.class);
-        List<PlayerResponse> expected = List.of(new PlayerResponse(player1, null), new PlayerResponse(player2, null));
+        List<PlayerResponse> expected = List.of(new PlayerResponse(player2, null), new PlayerResponse(player1, null));
 
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),

--- a/src/test/java/com/sports/server/query/presentation/PlayerQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/PlayerQueryControllerTest.java
@@ -39,7 +39,7 @@ public class PlayerQueryControllerTest extends DocumentationTest {
                 new PlayerResponse(3L, null, "선수3", "202500003", null, 10, Collections.emptyList())
         );
 
-        given(playerQueryService.getAllPlayers(any()))
+        given(playerQueryService.getAllPlayers(any(), any()))
                 .willReturn(responses);
 
         // when

--- a/src/test/java/com/sports/server/query/presentation/PlayerQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/PlayerQueryControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.util.Collections;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -38,7 +39,7 @@ public class PlayerQueryControllerTest extends DocumentationTest {
                 new PlayerResponse(3L, null, "선수3", "202500003", null, 10, Collections.emptyList())
         );
 
-        given(playerQueryService.getAllPlayers())
+        given(playerQueryService.getAllPlayers(any()))
                 .willReturn(responses);
 
         // when

--- a/src/test/resources/member-fixture.sql
+++ b/src/test/resources/member-fixture.sql
@@ -21,5 +21,8 @@ VALUES (2, 1, 'jane@example.com', '$2a$10$yviVCR3GmaU6cPJT.8vaMOwph9WzbX6wtn9iER
 INSERT INTO members (id, organization_id, email, password, is_administrator, last_login)
 VALUES (3, 2, 'smith@example.com', '$2a$10$yviVCR3GmaU6cPJT.8vaMOwph9WzbX6wtn9iERu3148ZP8XlKbakO', false,
         '2024-06-14 17:45:00');
+INSERT INTO members (id, organization_id, email, password, is_administrator, last_login)
+VALUES (4, 4, 'user4@example.com', '$2a$10$yviVCR3GmaU6cPJT.8vaMOwph9WzbX6wtn9iERu3148ZP8XlKbakO', false,
+        '2024-06-14 17:45:00');
 
 SET foreign_key_checks = 1;

--- a/src/test/resources/team-fixture.sql
+++ b/src/test/resources/team-fixture.sql
@@ -16,12 +16,12 @@ VALUES (1, 'BUSINESS', '경영 야생마', 'https://example.com/logos/wildhorse.
        (5, 'BUSINESS', '컴공 독수리', 'https://example.com/logos/eagle.png', '#4B0082');
 
 -- 선수
-INSERT INTO players (id, name, student_number)
-VALUES (1, '진승희', '202101001'),
-       (2, '이동규', '202101002'),
-       (3, '이현제', '202202001'),
-       (4, '고병룡', '202202002'),
-       (5, '박주장', '202003001');
+INSERT INTO players (id, name, student_number, organization_id)
+VALUES (1, '진승희', '202101001', 1),
+       (2, '이동규', '202101002', 1),
+       (3, '이현제', '202202001', 1),
+       (4, '고병룡', '202202002', 1),
+       (5, '박주장', '202003001', 1);
 
 -- 팀-선수 연결
 INSERT INTO team_players (id, team_id, player_id, jersey_number)


### PR DESCRIPTION
## 이슈
closes #542

## 변경 내용
- Team, Player에 `ManagedEntity` 구현 → Organization 기반 `isManagedBy()` 권한 검증
- 팀/선수 생성 시 매니저의 Organization 자동 귀속 (`setOrganization`)
- 팀/선수 수정/삭제 시 `PermissionValidator.checkPermission()` 호출
- TeamController, PlayerController 모든 엔드포인트에 `Member` 파라미터 필수화
- NlService/NlController에서 Member 파라미터 전달 경로 업데이트
- **선수 전체 조회 API 커서 기반 페이지네이션 추가**

## 테스트
- TeamServiceTest, PlayerServiceTest: Member 주입 후 전체 통과
- NlServiceTest: mock stub 시그니처 업데이트 후 통과
- TeamControllerTest, NlControllerTest: mock stub 업데이트 후 통과
- PlayerAcceptanceTest: 인증 이메일을 fixture 존재하는 이메일로 변경
- 전체 테스트 통과 확인

## 영향받는 API

| API | 변경 |
|-----|------|
| `POST /teams` | 인증 필수 (기존에도 쿠키 전달하나 Member 미사용 → 이제 Member 필수) |
| `PATCH /teams/{teamId}` | 동일 팀 Organization 소속 매니저만 수정 가능 |
| `DELETE /teams/{teamId}` | 동일 팀 Organization 소속 매니저만 삭제 가능 |
| `POST /teams/{teamId}/players` | 동일 팀 Organization 소속 매니저만 선수 추가 가능 |
| `DELETE /team-players/{teamPlayerId}` | 동일 팀 Organization 소속 매니저만 선수 제거 가능 |
| `POST /teams/{teamId}/delete-logo` | 동일 팀 Organization 소속 매니저만 로고 삭제 가능 |
| `POST /players` | 인증 필수, 생성 시 매니저 Organization 자동 귀속 |
| `PATCH /players/{playerId}` | 동일 Player Organization 소속 매니저만 수정 가능 |
| `DELETE /players/{playerId}` | 동일 Player Organization 소속 매니저만 삭제 가능 |
| `GET /players` | **커서 기반 페이지네이션 추가 (⚠️ 프론트 변경 필요)** |
| `POST /nl/register-team` | 인증 필수 추가 |

## 프론트 참고

### `GET /players` 페이지네이션 변경

기존에는 전체 선수를 한번에 반환했으나, 커서 기반 페이지네이션이 추가되었습니다.

**요청**
```
GET /players?cursor={lastPlayerId}&size={pageSize}
```

| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
|----------|------|------|--------|------|
| `cursor` | Long | X | null | 마지막으로 받은 선수의 `playerId` (첫 페이지는 생략) |
| `size` | Integer | X | 10 | 한 페이지에 가져올 선수 수 |

**동작**
- `cursor` 없이 호출 → 최신 선수부터 `size`건 반환 (id 내림차순)
- `cursor` 포함 호출 → 해당 id보다 작은 선수부터 `size`건 반환
- 응답이 빈 배열 `[]` → 마지막 페이지

**응답 형식**: 기존과 동일 (`PlayerResponse[]`)

## 참고
- #527에서 추가한 Organization FK를 활용한 접근 제어 구현
- superadmin(id=1)은 모든 팀/선수 접근 가능