### PR TITLE
[FIX] 타임라인 반환 시 점수 누적하도록 수정

### DIFF
--- a/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
@@ -23,10 +23,10 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
     @Query("SELECT st FROM ScoreTimeline st JOIN FETCH st.scorer sc JOIN FETCH sc.gameTeam WHERE st.game.id = :gameId")
     List<ScoreTimeline> findScoreTimelinesByGameId(@Param("gameId") Long gameId);
 
-    @Query("SELECT count(st) FROM ScoreTimeline st WHERE st.scorer.id = :playerId")
+    @Query("SELECT COALESCE(SUM(st.score), 0) FROM ScoreTimeline st WHERE st.scorer.id = :playerId")
     int countTotalGoalsByPlayerId(@Param("playerId") Long playerId);
 
-    @Query("SELECT new com.sports.server.command.team.domain.PlayerGoalCount(st.scorer.player.id, COUNT(st.id)) " +
+    @Query("SELECT new com.sports.server.command.team.domain.PlayerGoalCount(st.scorer.player.id, SUM(st.score)) " +
             "FROM ScoreTimeline st " +
             "WHERE st.scorer.player.id IN :playerIds " +
             "GROUP BY st.scorer.player.id")
@@ -36,8 +36,8 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             SELECT new com.sports.server.query.dto.TeamTopScorerResult(
                 tp.team.id,
                 new com.sports.server.command.team.domain.PlayerGoalCountWithRank(
-                    p.id, p.studentNumber, p.name, COUNT(st.id),
-                    RANK() OVER (PARTITION BY tp.team.id ORDER BY COUNT(st.id) DESC)
+                    p.id, p.studentNumber, p.name, SUM(st.score),
+                    RANK() OVER (PARTITION BY tp.team.id ORDER BY SUM(st.score) DESC)
                 )
             )
             FROM ScoreTimeline st
@@ -46,8 +46,8 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             JOIN p.teamPlayers tp
             WHERE tp.team.id IN :teamIds
             GROUP BY tp.team.id, p.id, p.studentNumber, p.name
-            HAVING COUNT(st.id) > 0
-            ORDER BY tp.team.id, COUNT(st.id) DESC, p.name ASC
+            HAVING SUM(st.score) > 0
+            ORDER BY tp.team.id, SUM(st.score) DESC, p.name ASC
             """)
     List<TeamTopScorerResult> findTopScorersByTeamIds(@Param("teamIds") List<Long> teamIds);
 
@@ -55,16 +55,16 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             "       p.id, " +
             "       p.studentNumber, " +
             "       p.name, " +
-            "       COUNT(st.id), " +
-            "       RANK() OVER (ORDER BY COUNT(st.id) DESC)) " +
+            "       SUM(st.score), " +
+            "       RANK() OVER (ORDER BY SUM(st.score) DESC)) " +
             "FROM ScoreTimeline st " +
             "JOIN st.scorer sc " +
             "JOIN sc.player p " +
             "JOIN st.game g " +
             "WHERE g.league.id = :leagueId " +
             "GROUP BY p.id, p.studentNumber, p.name " +
-            "HAVING COUNT(st.id) > 0 " +
-            "ORDER BY COUNT(st.id) DESC, p.name ASC")
+            "HAVING SUM(st.score) > 0 " +
+            "ORDER BY SUM(st.score) DESC, p.name ASC")
     List<PlayerGoalCountWithRank> findTopScorersByLeagueId(@Param("leagueId") Long leagueId, Pageable pageable);
 
 }


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #538 

## 📝 구현 내용
- 기존의 점수 관련 쿼리가 모두 count > score 가 더 이상 1로 고정이 아니기에 sum 으로 변경
