### PR TITLE
[FEAT] 32강 > 예선으로 변경

### DIFF
--- a/src/main/java/com/sports/server/command/league/domain/Round.java
+++ b/src/main/java/com/sports/server/command/league/domain/Round.java
@@ -17,7 +17,7 @@ public enum Round {
     SEMI_FINAL("4강", 4),
     QUARTER_FINAL("8강", 8),
     ROUND_16("16강", 16),
-    ROUND_32("32강", 32);
+    PRELIMINARY("예선", 100);
 
     private final String description;
     private final int number;

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -35,7 +35,7 @@ public class LeagueQueryControllerTest extends DocumentationTest {
         // given
         List<LeagueResponse> responses = List.of(
                 new LeagueResponse(1L, "2025 외대 월드컵", 16, 2, "종료", "정치외교학과 DPS", "SOCCER"),
-                new LeagueResponse(2L, "2025 트로이카", 32, 32, "진행 중", null, "SOCCER"),
+                new LeagueResponse(2L, "2025 트로이카", 100, 100, "진행 중", null, "SOCCER"),
                 new LeagueResponse(3L, "2025 삼건물대회", 16, 2, "종료", "경영대학 야생마", "SOCCER"),
                 new LeagueResponse(4L, "2100 화성 월드컵", 8, 8, "시작전", null, "BASKETBALL")
         );


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #546 

## 📝 구현 내용
- 32강 > 예선으로 변경