### PR TITLE
[FIX] 팀 수정 시 새 이미지 URL에 대해서만 S3 검증하도록 수정

### DIFF
--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -65,9 +65,14 @@ public class TeamService {
         Team team = entityUtils.getEntity(teamId, Team.class);
         PermissionValidator.checkPermission(team, member);
 
-        s3Service.doesFileExist(team.getLogoImageUrl());
+        String logoImageUrl = null;
+        if (request.logoImageUrl() != null) {
+            logoImageUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
+            s3Service.doesFileExist(logoImageUrl);
+        }
+
         Unit unit = Optional.ofNullable(request.unit()).map(Unit::from).orElse(null);
-        team.update(request.name(), request.logoImageUrl(), originPrefix, replacePrefix, unit, request.teamColor());
+        team.update(request.name(), logoImageUrl, unit, request.teamColor());
 
         if (request.teamPlayers() != null) {
             upsertPlayersToTeam(member, team, request.teamPlayers());

--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -65,14 +65,8 @@ public class TeamService {
         Team team = entityUtils.getEntity(teamId, Team.class);
         PermissionValidator.checkPermission(team, member);
 
-        String logoImageUrl = null;
-        if (request.logoImageUrl() != null) {
-            logoImageUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
-            s3Service.doesFileExist(logoImageUrl);
-        }
-
         Unit unit = Optional.ofNullable(request.unit()).map(Unit::from).orElse(null);
-        team.update(request.name(), logoImageUrl, unit, request.teamColor());
+        team.update(request.name(), resolveLogoImageUrl(request.logoImageUrl(), team), unit, request.teamColor());
 
         if (request.teamPlayers() != null) {
             upsertPlayersToTeam(member, team, request.teamPlayers());
@@ -176,6 +170,17 @@ public class TeamService {
                         TeamRequest.TeamPlayerRegister::playerId,
                         TeamRequest.TeamPlayerRegister::jerseyNumber
                 ));
+    }
+
+    private String resolveLogoImageUrl(String requestLogoImageUrl, Team team) {
+        if (requestLogoImageUrl == null) {
+            return null;
+        }
+        String convertedUrl = changeLogoImageUrlToBeSaved(requestLogoImageUrl);
+        if (convertedUrl.equals(team.getLogoImageUrl())) {
+            return null;
+        }
+        return convertedUrl;
     }
 
     private String changeLogoImageUrlToBeSaved(String logoImageUrl) {

--- a/src/main/java/com/sports/server/command/team/domain/Team.java
+++ b/src/main/java/com/sports/server/command/team/domain/Team.java
@@ -70,7 +70,7 @@ public class Team extends BaseEntity<Team> implements ManagedEntity {
         this.sportType = sportType != null ? sportType : SportType.SOCCER;
     }
 
-    public void update(String name, String logoImageUrl, String originPrefix, String replacePrefix, Unit unit, String teamColor) {
+    public void update(String name, String logoImageUrl, Unit unit, String teamColor) {
         if (name != null) {
             this.name = name;
         }
@@ -80,8 +80,8 @@ public class Team extends BaseEntity<Team> implements ManagedEntity {
         if (teamColor != null) {
             this.teamColor = teamColor;
         }
-        if (logoImageUrl != null && !logoImageUrl.equals(this.logoImageUrl)) {
-            this.logoImageUrl = changeLogoImageUrlToBeSaved(logoImageUrl, originPrefix, replacePrefix);
+        if (logoImageUrl != null) {
+            this.logoImageUrl = logoImageUrl;
         }
     }
 
@@ -107,13 +107,6 @@ public class Team extends BaseEntity<Team> implements ManagedEntity {
                     this.teamPlayers.remove(tp);
                     player.removeTeamPlayer(tp);
                 });
-    }
-
-    private String changeLogoImageUrlToBeSaved(String logoImageUrl, String originPrefix, String replacePrefix) {
-        if (!logoImageUrl.contains(originPrefix)) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, "잘못된 이미지 url 입니다.");
-        }
-        return logoImageUrl.replace(originPrefix, replacePrefix);
     }
 
     public void deleteLogoImageUrl() {


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #549 

## 📝 구현 내용
### 문제                                                                                                                                                                      
- 팀 수정 시 기존에 저장된 logoImageUrl로 S3 검증을 수행하여, 기존 이미지가 S3에 없는 경우 팀 정보 수정 자체가 불가능한 버그                                                
                                                                                                                                                                          
### 변경 사항                                                                                                                                                                                                                                                                                                                                        
  - TeamService.update(): 기존 이미지 URL 검증 제거 → 새 이미지가 있을 때만 변환 후 S3 검증                                                                                 
  - Team.update(): URL 변환 로직을 서비스 레이어로 이동, originPrefix/replacePrefix 파라미터 제거

