### PR TITLE
quarter-scores 응답에 gameTeams 순서 보장 및 무득점 팀 포함

### DIFF
--- a/src/main/java/com/sports/server/query/application/TimelineQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TimelineQueryService.java
@@ -1,11 +1,13 @@
 package com.sports.server.query.application;
 
 import static java.util.Comparator.comparingInt;
+import static java.util.Comparator.comparingLong;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.summingInt;
 
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.GameState;
+import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.league.domain.Quarter;
 import com.sports.server.command.league.domain.SportType;
 import com.sports.server.command.timeline.domain.GameProgressTimeline;
@@ -100,6 +102,14 @@ public class TimelineQueryService {
     }
 
     public List<QuarterScoreResponse> getQuarterScores(Long gameId) {
+        Game game = entityUtils.getEntity(gameId, Game.class);
+
+        List<Long> gameTeamIds = gameTeamQueryRepository.findAllByGame(game)
+                .stream()
+                .sorted(comparingLong(GameTeam::getId))
+                .map(GameTeam::getId)
+                .toList();
+
         List<Quarter> completedQuarters = gameProgressTimelineRepository
                 .findByGameIdAndType(gameId, GameProgressType.QUARTER_END)
                 .stream()
@@ -121,6 +131,7 @@ public class TimelineQueryService {
         return completedQuarters.stream()
                 .map(quarter -> QuarterScoreResponse.of(
                         quarter,
+                        gameTeamIds,
                         scoreByQuarterAndTeam.getOrDefault(quarter, Map.of())
                 ))
                 .toList();

--- a/src/main/java/com/sports/server/query/dto/response/QuarterScoreResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/QuarterScoreResponse.java
@@ -12,10 +12,9 @@ public record QuarterScoreResponse(
 ) {
     public record TeamScore(Long gameTeamId, int score) {}
 
-    public static QuarterScoreResponse of(Quarter quarter, Map<Long, Integer> teamScoreMap) {
-        List<TeamScore> scores = teamScoreMap.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .map(e -> new TeamScore(e.getKey(), e.getValue()))
+    public static QuarterScoreResponse of(Quarter quarter, List<Long> gameTeamIds, Map<Long, Integer> teamScoreMap) {
+        List<TeamScore> scores = gameTeamIds.stream()
+                .map(id -> new TeamScore(id, teamScoreMap.getOrDefault(id, 0)))
                 .toList();
         return new QuarterScoreResponse(quarter.name(), quarter.getDisplayName(), scores);
     }

--- a/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
@@ -185,7 +185,15 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                 BasketballQuarter.FIRST_QUARTER.getDisplayName(),
                                 List.of(
                                         new QuarterScoreResponse.TeamScore(7L, 3),
-                                        new QuarterScoreResponse.TeamScore(8L, 2)
+                                        new QuarterScoreResponse.TeamScore(8L, 0)
+                                )
+                        ),
+                        new QuarterScoreResponse(
+                                BasketballQuarter.SECOND_QUARTER.name(),
+                                BasketballQuarter.SECOND_QUARTER.getDisplayName(),
+                                List.of(
+                                        new QuarterScoreResponse.TeamScore(7L, 2),
+                                        new QuarterScoreResponse.TeamScore(8L, 5)
                                 )
                         )
                 ));


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #551 

## 📝 구현 내용
- GET /games/{gameId}/quarter-scores 응답의 scores 배열을 games/{gameId}의 gameTeams와 동일한 순서(gameTeamId 오름차순)로 반환                                                                                                         
- 해당 쿼터에 득점이 없는 팀도 score: 0으로 항상 포함하여 반환                                                                                                                                           