### PR TITLE
경기 종료 요청 시 이전 쿼터 종료가 필요한 경우 종료하도록 수정

### DIFF
--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -41,11 +41,31 @@ public class TimelineService {
 
         if (request instanceof TimelineRequest.RegisterProgress progressRequest) {
             validateProgressTransition(game, progressRequest);
+
+            if (progressRequest.getGameProgressType() == GameProgressType.GAME_END) {
+                insertQuarterEndIfNeeded(game, progressRequest.getRecordedAt());
+            }
         }
 
         Timeline timeline = timelineMapper.toEntity(game, request);
         timeline.apply();
         timelineRepository.save(timeline);
+    }
+
+    private void insertQuarterEndIfNeeded(Game game, Integer recordedAt) {
+        gameProgressTimelineRepository.findFirstByGameOrderByIdDesc(game)
+                .filter(last -> last.getGameProgressType() == GameProgressType.QUARTER_START
+                        && last.getRecordedQuarter().canHaveQuarterEnd())
+                .ifPresent(last -> {
+                    GameProgressTimeline quarterEnd = new GameProgressTimeline(
+                            game,
+                            last.getRecordedQuarter(),
+                            recordedAt,
+                            GameProgressType.QUARTER_END
+                    );
+                    quarterEnd.apply();
+                    timelineRepository.save(quarterEnd);
+                });
     }
 
     private void validateProgressTransition(Game game, TimelineRequest.RegisterProgress request) {

--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -40,10 +40,12 @@ public class TimelineService {
         PermissionValidator.checkPermission(game, manager);
 
         if (request instanceof TimelineRequest.RegisterProgress progressRequest) {
-            validateProgressTransition(game, progressRequest);
+            Optional<GameProgressTimeline> lastProgressOpt =
+                    gameProgressTimelineRepository.findFirstByGameOrderByIdDesc(game);
+            validateProgressTransition(game, progressRequest, lastProgressOpt);
 
             if (progressRequest.getGameProgressType() == GameProgressType.GAME_END) {
-                insertQuarterEndIfNeeded(game, progressRequest.getRecordedAt());
+                insertQuarterEndIfNeeded(game, progressRequest.getRecordedAt(), lastProgressOpt);
             }
         }
 
@@ -52,8 +54,8 @@ public class TimelineService {
         timelineRepository.save(timeline);
     }
 
-    private void insertQuarterEndIfNeeded(Game game, Integer recordedAt) {
-        gameProgressTimelineRepository.findFirstByGameOrderByIdDesc(game)
+    private void insertQuarterEndIfNeeded(Game game, Integer recordedAt, Optional<GameProgressTimeline> lastProgressOpt) {
+        lastProgressOpt
                 .filter(last -> last.getGameProgressType() == GameProgressType.QUARTER_START
                         && last.getRecordedQuarter().canHaveQuarterEnd())
                 .ifPresent(last -> {
@@ -68,10 +70,10 @@ public class TimelineService {
                 });
     }
 
-    private void validateProgressTransition(Game game, TimelineRequest.RegisterProgress request) {
+    private void validateProgressTransition(Game game, TimelineRequest.RegisterProgress request,
+                                            Optional<GameProgressTimeline> lastOpt) {
         Quarter requestQuarter = request.resolveQuarter();
         GameProgressType requestType = request.getGameProgressType();
-        Optional<GameProgressTimeline> lastOpt = gameProgressTimelineRepository.findFirstByGameOrderByIdDesc(game);
 
         boolean isValid = lastOpt
                 .map(last -> isValidTransitionFrom(last.getRecordedQuarter(), last.getGameProgressType(), requestQuarter, requestType))

--- a/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
@@ -252,6 +252,32 @@ class TimelineServiceTest extends ServiceTest {
             Timeline actual = timelineFixtureRepository.findAllLatest(freshGameId).get(0);
             assertThat(actual).isInstanceOf(GameProgressTimeline.class);
         }
+
+        @Test
+        void 쿼터가_진행_중일_때_경기종료를_등록하면_쿼터종료가_자동으로_삽입된다() {
+            // given - game 6: SECOND_HALF QUARTER_START 상태 (쿼터 진행 중)
+            Long testGameId = 6L;
+            TimelineRequest.RegisterProgress request = new TimelineRequest.RegisterProgress(
+                    90, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), GameProgressType.GAME_END);
+
+            int beforeCount = timelineFixtureRepository.findAllLatest(testGameId).size();
+
+            // when
+            timelineService.register(manager, testGameId, request);
+
+            // then: QUARTER_END + GAME_END 2개가 추가되어야 함
+            List<Timeline> timelines = timelineFixtureRepository.findAllLatest(testGameId);
+            assertThat(timelines).hasSize(beforeCount + 2);
+
+            GameProgressTimeline gameEnd = (GameProgressTimeline) timelines.get(0);
+            GameProgressTimeline quarterEnd = (GameProgressTimeline) timelines.get(1);
+
+            assertAll(
+                    () -> assertThat(gameEnd.getGameProgressType()).isEqualTo(GameProgressType.GAME_END),
+                    () -> assertThat(quarterEnd.getGameProgressType()).isEqualTo(GameProgressType.QUARTER_END),
+                    () -> assertThat(quarterEnd.getRecordedQuarter()).isEqualTo(SoccerQuarter.SECOND_HALF)
+            );
+        }
     }
 
     @DisplayName("승부차기 타임라인을")

--- a/src/test/resources/timeline-fixture.sql
+++ b/src/test/resources/timeline-fixture.sql
@@ -222,6 +222,17 @@ VALUES ('SCORE', 5, 'FIRST_QUARTER', 8, 19, 2, 7, 3, 8, 0);
 INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, game_progress_type, game_team1_id, game_team2_id, snapshot_score1, snapshot_score2, previous_quarter, previous_quarter_changed_at)
 VALUES ('GAME_PROGRESS', 5, 'FIRST_QUARTER', 10, 'QUARTER_END', 7, 8, 3, 2, 'FIRST_QUARTER', null);
 
+-- game 6: 경기종료 시 자동 쿼터종료 테스트용 (soccer, SECOND_HALF QUARTER_START 상태)
+INSERT INTO games (id, administrator_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter, state, round, is_pk_taken)
+VALUES (6, 1, 1, '자동_쿼터종료_테스트용', '2023-11-12 10:00:00', null, '2023-11-12 10:15:00', 'SECOND_HALF', 'PLAYING', '4강', FALSE);
+
+INSERT INTO game_teams (id, game_id, team_id, cheer_count, score, pk_score, result)
+VALUES (9, 6, 1, 0, 0, 0, null),
+       (10, 6, 2, 0, 0, 0, null);
+
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, game_progress_type, previous_quarter, previous_quarter_changed_at)
+VALUES ('GAME_PROGRESS', 6, 'SECOND_HALF', 0, 'QUARTER_START', 'FIRST_HALF', null);
+
 -- 응원톡 생성
 INSERT INTO cheer_talks (id, game_team_id, content, created_at, block_status)
 VALUES (1, 1, '화이팅!', '2023-11-12 10:05:00', 'ACTIVE'),


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #553 

## 📝 구현 내용

 ## Summary                                                                                                                                                                                                                           
                                                                                                                                                                                                                                         
  - `GAME_END` 등록 시 쿼터가 진행 중인 상태(`QUARTER_START` 이후 `QUARTER_END` 없음)이면, 해당 쿼터의 `QUARTER_END` 타임라인을 자동으로 먼저 삽입하도록 수정                                                                            
  - 단, `canHaveQuarterEnd() = false`인 쿼터(축구 승부차기 등)는 자동 삽입 제외                                                                                                                                                          
                                                                                                                                                                                                                                         
  ## Problem                                                                                                                                                                                                                           
                                                                                                                                                                                                                                         
  4쿼터가 시작된 상태에서 `경기 종료`를 누르면:                                                                                                                                                                                          
  - `QUARTER_END` 없이 `GAME_END`만 저장됨
  - `quarter-scores` 등에서 해당 쿼터가 종료되지 않은 것처럼 보이는 버그 발생                                                                                                                                                            
                                                                                                                                                                                                                                         
  ## Solution                                                                                                                                                                                                                            
                                                                                                                                                                                                                                         
  `TimelineService.register()`에서 `GAME_END` 등록 전, 마지막 progress 이벤트가 `QUARTER_START`이면 동일 쿼터에 대한 `QUARTER_END`를 자동 삽입                                                                                           
   
  **before**                                                                                                                                                                                                                             
  4쿼터 QUARTER_START → GAME_END                                                                                                                                                                                                       
                                                                                                                                                                                                                                         
  **after**                                                                                                                                                                                                                            
  4쿼터 QUARTER_START → (자동) 4쿼터 QUARTER_END → GAME_END
                                                                                                                                                                                                                                         
  ## Changes
                                                                                                                                                                                                                                         
  - `TimelineService`: `insertQuarterEndIfNeeded()` 메서드 추가                                                                                                                                                                          
  - `timeline-fixture.sql`: 테스트용 게임(game 6) 추가
  - `TimelineServiceTest`: 자동 쿼터 종료 삽입 검증 테스트 추가   