### PR TITLE
[FEAT] 팀 조회 시 Organization 에 해당하는 팀들만 조회하도록 수정

### DIFF
--- a/src/main/java/com/sports/server/query/application/TeamQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TeamQueryService.java
@@ -7,6 +7,7 @@ import com.sports.server.command.game.domain.GameTeamRepository;
 import com.sports.server.command.league.domain.League;
 import com.sports.server.command.league.domain.LeagueStatistics;
 import com.sports.server.command.league.domain.SportType;
+import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.team.domain.*;
 import com.sports.server.common.application.EntityUtils;
@@ -53,8 +54,10 @@ public class TeamQueryService {
                 .toList();
     }
 
-    public List<TeamResponse> getAllTeamsByUnits(final List<String> units, final SportType sportType) {
-        List<Team> teams = findTeamsByUnits(units, sportType);
+    public List<TeamResponse> getAllTeamsByUnits(final List<String> units, final SportType sportType,
+                                                    final Member member) {
+        Long organizationId = member.getOrganization().getId();
+        List<Team> teams = findTeamsByUnits(units, sportType, organizationId);
         return teams.stream()
                 .map(TeamResponse::new)
                 .toList();
@@ -111,8 +114,13 @@ public class TeamQueryService {
     }
 
     private List<Team> findTeamsByUnits(final List<String> units, final SportType sportType) {
+        return findTeamsByUnits(units, sportType, null);
+    }
+
+    private List<Team> findTeamsByUnits(final List<String> units, final SportType sportType,
+                                         final Long organizationId) {
         List<Unit> targetUnits = (units == null || units.isEmpty()) ? null : Unit.fromNames(units);
-        return teamQueryDynamicRepository.findAllByUnitsAndSportType(targetUnits, sportType);
+        return teamQueryDynamicRepository.findAllByUnitsAndSportType(targetUnits, sportType, organizationId);
     }
 
     private Map<Long, TeamDetailResponse.TeamGameResult> getTeamGameResults(List<Long> teamIds) {

--- a/src/main/java/com/sports/server/query/presentation/TeamQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/TeamQueryController.java
@@ -1,6 +1,7 @@
 package com.sports.server.query.presentation;
 
 import com.sports.server.command.league.domain.SportType;
+import com.sports.server.command.member.domain.Member;
 import com.sports.server.query.application.GameQueryService;
 import com.sports.server.query.application.TeamQueryService;
 import com.sports.server.query.dto.response.*;
@@ -27,8 +28,9 @@ public class TeamQueryController {
     @GetMapping
     public ResponseEntity<List<TeamResponse>> getAllTeams(
             @RequestParam(required = false) final List<String> units,
-            @RequestParam(required = false) final SportType sportType) {
-        return ResponseEntity.ok(teamQueryService.getAllTeamsByUnits(units, sportType));
+            @RequestParam(required = false) final SportType sportType,
+            final Member member) {
+        return ResponseEntity.ok(teamQueryService.getAllTeamsByUnits(units, sportType, member));
     }
 
     @GetMapping("/{teamId}")

--- a/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepository.java
@@ -12,7 +12,7 @@ public interface TeamQueryDynamicRepository {
 
     List<LeagueTeam> findByLeagueAndRound(League league, Integer roundNumber);
 
-    List<Team> findAllByUnitsAndSportType(List<Unit> units, SportType sportType);
+    List<Team> findAllByUnitsAndSportType(List<Unit> units, SportType sportType, Long organizationId);
 
     List<Unit> findDistinctUnitsBySportType(SportType sportType);
 }

--- a/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
@@ -39,12 +39,14 @@ public class TeamQueryDynamicRepositoryImpl implements TeamQueryDynamicRepositor
     }
 
     @Override
-    public List<Team> findAllByUnitsAndSportType(final List<Unit> units, final SportType sportType) {
+    public List<Team> findAllByUnitsAndSportType(final List<Unit> units, final SportType sportType,
+                                                  final Long organizationId) {
         return jpaQueryFactory
                 .selectFrom(team)
                 .where(
                         teamsInUnits(units),
-                        teamsWithSportType(sportType)
+                        teamsWithSportType(sportType),
+                        teamsInOrganization(organizationId)
                 )
                 .orderBy(team.name.asc())
                 .fetch();
@@ -88,5 +90,12 @@ public class TeamQueryDynamicRepositoryImpl implements TeamQueryDynamicRepositor
             return null;
         }
         return team.sportType.eq(sportType);
+    }
+
+    private BooleanExpression teamsInOrganization(final Long organizationId) {
+        if (organizationId == null) {
+            return null;
+        }
+        return team.organization.id.eq(organizationId);
     }
 }

--- a/src/test/java/com/sports/server/query/acceptance/TeamQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/TeamQueryAcceptanceTest.java
@@ -1,0 +1,67 @@
+package com.sports.server.query.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.sports.server.query.dto.response.TeamResponse;
+import com.sports.server.support.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql(scripts = "/team-query-fixture.sql")
+public class TeamQueryAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 자신의_조직에_속한_팀만_조회된다() {
+        // given
+        configureMockJwtForEmail("john.doe@example.com");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .cookie(COOKIE_NAME, mockToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/teams")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<TeamResponse> actual = toResponses(response, TeamResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual).hasSize(7),
+                () -> assertThat(actual)
+                        .extracting(TeamResponse::name)
+                        .doesNotContain("다른조직팀")
+        );
+    }
+
+    @Test
+    void 다른_조직의_멤버는_자신의_조직_팀만_조회된다() {
+        // given
+        configureMockJwtForEmail("non.manager@example.com");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .cookie(COOKIE_NAME, mockToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/teams")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<TeamResponse> actual = toResponses(response, TeamResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual).hasSize(1),
+                () -> assertThat(actual.get(0).name()).isEqualTo("다른조직팀")
+        );
+    }
+}

--- a/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
@@ -1,7 +1,9 @@
 package com.sports.server.query.application;
 
 import com.sports.server.command.league.application.LeagueStatisticsService;
+import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.team.exception.TeamErrorMessages;
+import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.query.dto.response.*;
 import com.sports.server.support.ServiceTest;
@@ -30,6 +32,9 @@ public class TeamQueryServiceTest extends ServiceTest {
 
     @Autowired
     private LeagueStatisticsService leagueStatisticsService;
+
+    @Autowired
+    private EntityUtils entityUtils;
 
     @Nested
     @DisplayName("단과대별 팀 유무 조회 시")
@@ -67,10 +72,19 @@ public class TeamQueryServiceTest extends ServiceTest {
     @DisplayName("단위별 팀 목록 조회 시")
     class GetAllTeamsByUnitsTest {
 
+        private Member org1Member;
+        private Member org2Member;
+
+        @BeforeEach
+        void setUp() {
+            org1Member = entityUtils.getEntity(1L, Member.class);
+            org2Member = entityUtils.getEntity(2L, Member.class);
+        }
+
         @Test
-        void 필터링할_단위가_없으면_모든_팀을_조회한다() {
+        void 필터링할_단위가_없으면_해당_조직의_모든_팀을_조회한다() {
             // when
-            List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(null, null);
+            List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(null, null, org1Member);
 
             // then
             assertThat(responses).hasSize(7);
@@ -82,7 +96,7 @@ public class TeamQueryServiceTest extends ServiceTest {
             List<String> units = List.of("사회과학대학");
 
             // when
-            List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(units, null);
+            List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(units, null, org1Member);
 
             // then
             assertAll(
@@ -98,7 +112,7 @@ public class TeamQueryServiceTest extends ServiceTest {
             List<String> units = List.of("사회과학대학", "기타");
 
             // when
-            List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(units, null);
+            List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(units, null, org1Member);
 
             // then
             assertAll(
@@ -112,9 +126,21 @@ public class TeamQueryServiceTest extends ServiceTest {
             List<String> units = List.of("INVALID UNIT");
 
             // when & then
-            assertThatThrownBy(() -> teamQueryService.getAllTeamsByUnits(units, null))
+            assertThatThrownBy(() -> teamQueryService.getAllTeamsByUnits(units, null, org1Member))
                     .isInstanceOf(NotFoundException.class)
                     .hasMessage(TeamErrorMessages.UNIT_NOT_FOUND_EXCEPTION);
+        }
+
+        @Test
+        void 다른_조직의_멤버는_해당_조직의_팀만_조회한다() {
+            // when
+            List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(null, null, org2Member);
+
+            // then
+            assertAll(
+                    () -> assertThat(responses).hasSize(1),
+                    () -> assertThat(responses.get(0).name()).isEqualTo("다른조직팀")
+            );
         }
     }
 

--- a/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
@@ -1,5 +1,6 @@
 package com.sports.server.query.presentation;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 
 import com.sports.server.command.league.domain.SportType;
@@ -77,7 +78,7 @@ public class TeamQueryControllerTest extends DocumentationTest {
                 new TeamResponse(3L, "영어영문학과", "s3:logoImageUrl2", "영어대학", "#92A8D1", "SOCCER")
         );
 
-        given(teamQueryService.getAllTeamsByUnits(units, null)).willReturn(response);
+        given(teamQueryService.getAllTeamsByUnits(any(), any(), any())).willReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(get("/teams")

--- a/src/test/resources/team-query-fixture.sql
+++ b/src/test/resources/team-query-fixture.sql
@@ -11,11 +11,12 @@ VALUES (1, 1, 'john.doe@example.com', 'password123', TRUE, '2024-07-01 10:00:00'
        (2, 2, 'non.manager@example.com', 'password123', FALSE, '2024-07-01 10:00:00');
 
 
-INSERT INTO teams (id, unit, name, logo_image_url, team_color)
-VALUES (1, 'SOCIAL_SCIENCES', '팀A', 'http://example.com/logo_a.png', '#FF0000'),
-       (2, 'ETC', '팀B', 'http://example.com/logo_b.png', '#0000FF'),
-       (3, 'ENGLISH', '팀C', 'http://example.com/logo_c.png', '#0000FF'),
-       (4, 'SOCIAL_SCIENCES', '팀D', 'http://example.com/logo_d.png', '#0000FF');
+INSERT INTO teams (id, unit, name, logo_image_url, team_color, organization_id)
+VALUES (1, 'SOCIAL_SCIENCES', '팀A', 'http://example.com/logo_a.png', '#FF0000', 1),
+       (2, 'ETC', '팀B', 'http://example.com/logo_b.png', '#0000FF', 1),
+       (3, 'ENGLISH', '팀C', 'http://example.com/logo_c.png', '#0000FF', 1),
+       (4, 'SOCIAL_SCIENCES', '팀D', 'http://example.com/logo_d.png', '#0000FF', 1),
+       (20, 'BUSINESS', '다른조직팀', 'http://example.com/logo_other.png', '#00FF00', 2);
 
 
 INSERT INTO players (id, name, student_number)
@@ -159,10 +160,10 @@ VALUES ('GAME_PROGRESS', 1, 'POST_GAME', 20, 'GAME_END', 1, 2, 2, 3, 'PENALTY_SH
 
 -- === 최근 경기 조회 위한 데이터 ===
 
-INSERT INTO teams (id, unit, name, logo_image_url, team_color)
-VALUES (10, 'ETC', '게임없는팀', 'image', '#000000'),
-       (11, 'ETC', '게임2개팀', 'image', '#00FF00'),
-       (12, 'ETC', '게임많은팀', 'image', '#FF00FF');
+INSERT INTO teams (id, unit, name, logo_image_url, team_color, organization_id)
+VALUES (10, 'ETC', '게임없는팀', 'image', '#000000', 1),
+       (11, 'ETC', '게임2개팀', 'image', '#00FF00', 1),
+       (12, 'ETC', '게임많은팀', 'image', '#FF00FF', 1);
 
 INSERT INTO players (id, name, student_number)
 VALUES (20, '선수20', '202400001'),


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #555 

## 📝 구현 내용
- `/teams` 경로에서 멤버가 속한 Organization 토대로 조회하도록 수정