### PR TITLE
[FIX] 라인업 조회 API에서 교체된 선수 반영 수정

### DIFF
--- a/src/main/java/com/sports/server/query/dto/response/LineupPlayerResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LineupPlayerResponse.java
@@ -38,11 +38,11 @@ public class LineupPlayerResponse {
 					gameTeam.getId(),
 					gameTeam.getTeam().getName(),
 					lineupPlayers.stream()
-							.filter(lineupPlayer -> lineupPlayer.getState().equals(LineupPlayerState.STARTER))
+							.filter(LineupPlayer::isPlaying)
 							.map(LineupPlayerResponse.PlayerResponse::new)
 							.toList(),
 					lineupPlayers.stream()
-							.filter(lineupPlayer -> lineupPlayer.getState().equals(LineupPlayerState.CANDIDATE))
+							.filter(lineupPlayer -> !lineupPlayer.isPlaying())
 							.map(LineupPlayerResponse.PlayerResponse::new)
 							.toList()
 			);

--- a/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
@@ -222,17 +222,17 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(teamA.teamName()).isEqualTo("팀 A"),
                 () -> assertThat(teamA.gameTeamPlayers())
                         .map(LineupPlayerResponse.PlayerResponse::playerName)
-                        .containsExactly("선수15"),
+                        .containsExactly("선수12", "선수13", "선수14", "선수15"),
                 () -> assertThat(teamA.gameTeamPlayers())
                         .map(LineupPlayerResponse.PlayerResponse::jerseyNumber)
-                        .containsExactly(5),
+                        .containsExactly(2, 3, 4, 5),
                 () -> assertThat(teamB.teamName()).isEqualTo("팀 B"),
                 () -> assertThat(teamB.gameTeamPlayers())
                         .map(LineupPlayerResponse.PlayerResponse::playerName)
-                        .containsExactly("선수20"),
+                        .containsExactly("선수16", "선수17", "선수18", "선수19", "선수20"),
                 () -> assertThat(teamB.gameTeamPlayers())
                         .map(LineupPlayerResponse.PlayerResponse::jerseyNumber)
-                        .containsExactly(5)
+                        .containsExactly(1, 2, 3, 4, 5)
         );
     }
 

--- a/src/test/java/com/sports/server/query/application/LineupPlayerQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/LineupPlayerQueryServiceTest.java
@@ -3,7 +3,6 @@ package com.sports.server.query.application;
 import static org.junit.Assert.assertEquals;
 
 import com.sports.server.command.game.domain.LineupPlayer;
-import com.sports.server.command.timeline.application.TimelineService;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.query.dto.response.LineupPlayerResponse;
 import com.sports.server.support.ServiceTest;
@@ -20,9 +19,6 @@ public class LineupPlayerQueryServiceTest extends ServiceTest {
 
     @Autowired
     private LineupPlayerQueryService lineupPlayerQueryService;
-
-    @Autowired
-    private TimelineService timelineService;
 
     @Autowired
     private EntityUtils entityUtils;
@@ -68,28 +64,35 @@ public class LineupPlayerQueryServiceTest extends ServiceTest {
                 .containsOnly(true);
     }
 
-//    @Test
-//    void 교체_타임라인이_등록되면_교체선수_정보가_등록된다() {
-//
-//        // given
-//        Long gameId = 1L;
-//        Long originLineupPlayerId = 2L;
-//        Long replaceLineupPlayerId = 1L;
-//        Member manager = entityUtils.getEntity(1L, Member.class);
-//        TimelineRequest timelineRequest = new TimelineRequest.RegisterReplacement(1L, 1L,
-//                originLineupPlayerId, replaceLineupPlayerId, 2);
-//        timelineService.register(manager, gameId, timelineRequest);
-//
-//        // when
-//        List<LineupPlayerResponse.All> responses = lineupPlayerQueryService.getLineup(gameId);
-//
-//        // then
-//        Long replacedPlayerId = responses.get(0).candidatePlayers().stream()
-//                .filter(playerResponse -> playerResponse.id().equals(replaceLineupPlayerId))
-//                .map(player -> player.replacedPlayer().id())
-//                .findFirst()
-//                .orElse(null); // 값이 없으면 null 반환
-//        Assertions.assertThat(originLineupPlayerId).isEqualTo(replacedPlayerId);
-//
-//    }
+    @Test
+    void 교체된_선수는_isPlaying_기준으로_starterPlayers와_candidatePlayers에_반영된다() {
+
+        // given
+        Long gameId = 1L;
+        Long gameTeamId = 1L;
+        Long originLineupPlayerId = 5L;       // STARTER, isPlaying=true
+        Long replacementLineupPlayerId = 1L;  // CANDIDATE, isPlaying=false
+        LineupPlayer origin = entityUtils.getEntity(originLineupPlayerId, LineupPlayer.class);
+        LineupPlayer replacement = entityUtils.getEntity(replacementLineupPlayerId, LineupPlayer.class);
+
+        origin.deactivatePlayerInGame();
+        replacement.activatePlayerInGame();
+
+        // when
+        List<LineupPlayerResponse.All> responses = lineupPlayerQueryService.getLineup(gameId);
+        LineupPlayerResponse.All teamLineup = responses.stream()
+                .filter(r -> r.gameTeamId().equals(gameTeamId))
+                .findFirst()
+                .orElseThrow();
+
+        // then
+        Assertions.assertThat(teamLineup.starterPlayers())
+                .map(LineupPlayerResponse.PlayerResponse::lineupPlayerId)
+                .contains(replacementLineupPlayerId)
+                .doesNotContain(originLineupPlayerId);
+        Assertions.assertThat(teamLineup.candidatePlayers())
+                .map(LineupPlayerResponse.PlayerResponse::lineupPlayerId)
+                .contains(originLineupPlayerId)
+                .doesNotContain(replacementLineupPlayerId);
+    }
 }

--- a/src/test/java/com/sports/server/query/application/LineupPlayerQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/LineupPlayerQueryServiceTest.java
@@ -13,6 +13,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
 
 @Sql(scripts = "/game-fixture.sql")
 public class LineupPlayerQueryServiceTest extends ServiceTest {
@@ -65,6 +66,7 @@ public class LineupPlayerQueryServiceTest extends ServiceTest {
     }
 
     @Test
+    @Transactional
     void 교체된_선수는_isPlaying_기준으로_starterPlayers와_candidatePlayers에_반영된다() {
 
         // given

--- a/src/test/resources/game-fixture.sql
+++ b/src/test/resources/game-fixture.sql
@@ -145,16 +145,16 @@ VALUES (1, 1, 1, 1, 1, 0),
 INSERT INTO lineup_players (id, game_team_id, player_id, jersey_number, is_captain, state, is_playing)
 VALUES -- 축구 대전(game_id = 1), A팀(game_team_id = 1) 라인업 선수
        (1, 1, 11, 1, false, 'CANDIDATE', false),
-       (2, 1, 12, 2, false, 'STARTER', false),
-       (3, 1, 13, 3, false, 'STARTER', false),
-       (4, 1, 14, 4, false, 'STARTER', false),
+       (2, 1, 12, 2, false, 'STARTER', true),
+       (3, 1, 13, 3, false, 'STARTER', true),
+       (4, 1, 14, 4, false, 'STARTER', true),
        (5, 1, 15, 5, false, 'STARTER', true),
 
        -- 축구 대전(game_id = 1), B팀(game_team_id = 2) 라인업 선수
-       (6, 2, 16, 1, true, 'STARTER', false),
-       (7, 2, 17, 2, false, 'STARTER', false),
-       (8, 2, 18, 3, false, 'STARTER', false),
-       (9, 2, 19, 4, false, 'STARTER', false),
+       (6, 2, 16, 1, true, 'STARTER', true),
+       (7, 2, 17, 2, false, 'STARTER', true),
+       (8, 2, 18, 3, false, 'STARTER', true),
+       (9, 2, 19, 4, false, 'STARTER', true),
        (10, 2, 20, 5, false, 'STARTER', true);
 
 


### PR DESCRIPTION
## 이슈
- close #559
- QA: 교체된 선수 정보가 라인업 조회에서 반영되지 않음

## 변경 내용
- `LineupPlayerResponse.All` 필터 기준을 `state` → `isPlaying`으로 변경
  - `ReplacementTimeline.apply()`는 `isPlaying`만 토글하므로 `state` 기준 필터는 교체를 반영하지 못함
- `game-fixture.sql`의 STARTER 라인업 선수들 `is_playing=true`로 정상화
  - `LineupPlayer` 생성자 불변식(STARTER ↔ isPlaying=true) 과 일치
- 교체 반영 회귀 테스트 추가

## 테스트
- `교체된_선수는_isPlaying_기준으로_starterPlayers와_candidatePlayers에_반영된다` 추가
- 기존 `출전_선수를_조회한다` 픽스처 정상화에 맞춰 기대값 갱신

## 영향 API
- `GET /games/{id}/lineup`

## 프론트 참고
- 응답 스키마 변경 없음. 분류 기준만 `state` → `isPlaying`으로 바뀌어 교체 이후 실제 경기 중인 선수가 starter로 표시됨