### PR TITLE
[FIX] 농구 연장전 진행 중 상태 변경 목록에서 '연장전 종료' 제거

### DIFF
--- a/src/main/java/com/sports/server/command/league/domain/BasketballQuarter.java
+++ b/src/main/java/com/sports/server/command/league/domain/BasketballQuarter.java
@@ -34,7 +34,7 @@ public enum BasketballQuarter implements Quarter {
 
     @Override
     public boolean canHaveQuarterEnd() {
-        return true;
+        return this != OVERTIME;
     }
 
     public static Optional<BasketballQuarter> tryResolve(String value) {

--- a/src/test/java/com/sports/server/query/application/AvailableProgressQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/AvailableProgressQueryServiceTest.java
@@ -61,7 +61,6 @@ class AvailableProgressQueryServiceTest extends ServiceTest {
     private static final long BASKETBALL_GAME_4Q_STARTED = 17L;
     private static final long BASKETBALL_GAME_4Q_ENDED = 18L;
     private static final long BASKETBALL_GAME_OT_STARTED = 19L;
-    private static final long BASKETBALL_GAME_OT_ENDED = 20L;
     private static final long BASKETBALL_GAME_FINISHED = 21L;
 
     @Nested
@@ -307,25 +306,11 @@ class AvailableProgressQueryServiceTest extends ServiceTest {
     class 농구_OT_진행_중 {
 
         @Test
-        void OT_종료와_경기_종료_액션을_반환한다() {
+        void 경기_종료_액션_하나만_반환한다() {
             List<ProgressAction> actions = timelineQueryService.getAvailableProgress(BASKETBALL_GAME_OT_STARTED).availableActions();
 
-            assertThat(actions).hasSize(2);
-            assertAction(actions.get(0), BasketballQuarter.OVERTIME, GameProgressType.QUARTER_END, "연장전 종료");
-            assertAction(actions.get(1), BasketballQuarter.OVERTIME, GameProgressType.GAME_END, "경기 종료");
-        }
-    }
-
-    @Nested
-    @DisplayName("[농구] OT 종료 후에는")
-    class 농구_OT_종료_후 {
-
-        @Test
-        void OT_시작_액션_하나만_반환한다() {
-            List<ProgressAction> actions = timelineQueryService.getAvailableProgress(BASKETBALL_GAME_OT_ENDED).availableActions();
-
             assertThat(actions).hasSize(1);
-            assertAction(actions.get(0), BasketballQuarter.OVERTIME, GameProgressType.QUARTER_START, "연장전 시작");
+            assertAction(actions.get(0), BasketballQuarter.OVERTIME, GameProgressType.GAME_END, "경기 종료");
         }
     }
 

--- a/src/test/resources/progress-transition-fixture.sql
+++ b/src/test/resources/progress-transition-fixture.sql
@@ -87,7 +87,6 @@ VALUES
     (17, 1, 2, '농구_4Q_진행_중',      '2024-01-01 10:00:00', null, '2024-01-01 11:15:00', 'FOURTH_QUARTER', 'PLAYING',   '4강', FALSE),
     (18, 1, 2, '농구_4Q_종료_후',      '2024-01-01 10:00:00', null, '2024-01-01 11:30:00', 'FOURTH_QUARTER', 'PLAYING',   '4강', FALSE),
     (19, 1, 2, '농구_OT_진행_중',      '2024-01-01 10:00:00', null, '2024-01-01 11:35:00', 'OVERTIME',       'PLAYING',   '4강', FALSE),
-    (20, 1, 2, '농구_OT_종료_후',      '2024-01-01 10:00:00', null, '2024-01-01 11:45:00', 'OVERTIME',       'PLAYING',   '4강', FALSE),
     (21, 1, 2, '농구_경기_종료',       '2024-01-01 10:00:00', null, '2024-01-01 12:00:00', 'POST_GAME',      'FINISHED',  '4강', FALSE);
 
 -- Game 10: 타임라인 없음 (농구 경기 시작 전)
@@ -163,18 +162,5 @@ VALUES ('GAME_PROGRESS', 19, 'FIRST_QUARTER',  0,  'QUARTER_START', 'PRE_GAME', 
        ('GAME_PROGRESS', 19, 'FOURTH_QUARTER', 45, 'QUARTER_START', 'THIRD_QUARTER',  '2024-01-01 11:15:00'),
        ('GAME_PROGRESS', 19, 'FOURTH_QUARTER', 55, 'QUARTER_END',   'FOURTH_QUARTER', '2024-01-01 11:30:00'),
        ('GAME_PROGRESS', 19, 'OVERTIME',       60, 'QUARTER_START', 'FOURTH_QUARTER', '2024-01-01 11:35:00');
-
--- Game 20: ... → OT 종료
-INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, game_progress_type, previous_quarter, previous_quarter_changed_at)
-VALUES ('GAME_PROGRESS', 20, 'FIRST_QUARTER',  0,  'QUARTER_START', 'PRE_GAME',       null),
-       ('GAME_PROGRESS', 20, 'FIRST_QUARTER',  10, 'QUARTER_END',   'FIRST_QUARTER',  '2024-01-01 10:00:00'),
-       ('GAME_PROGRESS', 20, 'SECOND_QUARTER', 15, 'QUARTER_START', 'FIRST_QUARTER',  '2024-01-01 10:15:00'),
-       ('GAME_PROGRESS', 20, 'SECOND_QUARTER', 25, 'QUARTER_END',   'SECOND_QUARTER', '2024-01-01 10:30:00'),
-       ('GAME_PROGRESS', 20, 'THIRD_QUARTER',  30, 'QUARTER_START', 'SECOND_QUARTER', '2024-01-01 10:45:00'),
-       ('GAME_PROGRESS', 20, 'THIRD_QUARTER',  40, 'QUARTER_END',   'THIRD_QUARTER',  '2024-01-01 11:00:00'),
-       ('GAME_PROGRESS', 20, 'FOURTH_QUARTER', 45, 'QUARTER_START', 'THIRD_QUARTER',  '2024-01-01 11:15:00'),
-       ('GAME_PROGRESS', 20, 'FOURTH_QUARTER', 55, 'QUARTER_END',   'FOURTH_QUARTER', '2024-01-01 11:30:00'),
-       ('GAME_PROGRESS', 20, 'OVERTIME',       60, 'QUARTER_START', 'FOURTH_QUARTER', '2024-01-01 11:35:00'),
-       ('GAME_PROGRESS', 20, 'OVERTIME',       65, 'QUARTER_END',   'OVERTIME',       '2024-01-01 11:45:00');
 
 SET foreign_key_checks = 1;


### PR DESCRIPTION
## 관련 이슈
- closes #562

## 변경 내용
- `BasketballQuarter.OVERTIME`의 `canHaveQuarterEnd()`가 `false`를 반환하도록 수정 (기존 스타일 `canEndGame()`과 일관되게 `this != OVERTIME` 조건식으로 구현)
- `TimelineQueryService.actionsFromQuarterStart` / `TimelineService.isValidFromQuarterStart` 모두 해당 플래그를 참조하므로 UI 노출과 API 검증 양쪽에서 일관되게 막힘

## 테스트
- [x] `AvailableProgressQueryServiceTest#농구_OT_진행_중`: 액션 1개(`경기 종료`)만 반환하도록 기댓값 수정
- [x] 도달 불가능해진 `농구_OT_종료_후` 테스트 및 `progress-transition-fixture.sql`의 Game 20 더미 데이터 제거
- [ ] 로컬 Lombok/JDK 이슈로 풀빌드 미수행 → CI에서 확인 필요

## 영향 API
- `GET /games/{gameId}/timeline/available-progress` 응답에서 농구 OT 진행 중일 때 `QUARTER_END` 액션이 제거됨
- `POST /games/{gameId}/timeline` (RegisterProgress): 농구 OT에서 `QUARTER_END` 요청 시 `INVALID_PROGRESS_TRANSITION` 반환

## 프론트 참고
- 상태 변경 모달(`/leagues/{id}/basketball/{gameId}/timeline`)에서 연장전 진행 중에는 `경기 종료`만 표시됨
- 프론트에서 옵션 리스트를 하드코딩하고 있다면 해당 부분도 확인 필요