### PR TITLE
[FEAT] 단과대 > 열거형에서 테이블로 확장

### DIFF
--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -6,6 +6,7 @@ import com.sports.server.command.player.domain.PlayerRepository;
 import com.sports.server.command.player.exception.PlayerErrorMessages;
 import com.sports.server.command.team.domain.*;
 import com.sports.server.command.team.dto.TeamRequest;
+import com.sports.server.command.team.exception.TeamErrorMessages;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.application.PermissionValidator;
 import com.sports.server.common.application.S3Service;
@@ -35,6 +36,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final TeamPlayerRepository teamPlayerRepository;
     private final PlayerRepository playerRepository;
+    private final UnitRepository unitRepository;
     private final EntityUtils entityUtils;
     private final S3Service s3Service;
 
@@ -42,7 +44,8 @@ public class TeamService {
         String imgUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
         s3Service.doesFileExist(imgUrl);
 
-        Team team = request.toEntity(imgUrl);
+        Unit unit = findUnit(request.unit(), member.getOrganization().getId());
+        Team team = request.toEntity(imgUrl, unit);
         team.setOrganization(member.getOrganization());
         teamRepository.save(team);
 
@@ -55,7 +58,8 @@ public class TeamService {
         String imgUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
         s3Service.doesFileExist(imgUrl);
 
-        Team team = request.toEntity(imgUrl);
+        Unit unit = findUnit(request.unit(), member.getOrganization().getId());
+        Team team = request.toEntity(imgUrl, unit);
         team.setOrganization(member.getOrganization());
         teamRepository.save(team);
         return team.getId();
@@ -65,7 +69,9 @@ public class TeamService {
         Team team = entityUtils.getEntity(teamId, Team.class);
         PermissionValidator.checkPermission(team, member);
 
-        Unit unit = Optional.ofNullable(request.unit()).map(Unit::from).orElse(null);
+        Unit unit = Optional.ofNullable(request.unit())
+                .map(unitName -> findUnit(unitName, member.getOrganization().getId()))
+                .orElse(null);
         team.update(request.name(), resolveLogoImageUrl(request.logoImageUrl(), team), unit, request.teamColor());
 
         if (request.teamPlayers() != null) {
@@ -181,6 +187,11 @@ public class TeamService {
             return null;
         }
         return convertedUrl;
+    }
+
+    private Unit findUnit(String unitName, Long organizationId) {
+        return unitRepository.findByNameAndOrganizationId(unitName, organizationId)
+                .orElseThrow(() -> new NotFoundException(TeamErrorMessages.UNIT_NOT_FOUND_EXCEPTION));
     }
 
     private String changeLogoImageUrlToBeSaved(String logoImageUrl) {

--- a/src/main/java/com/sports/server/command/team/domain/Team.java
+++ b/src/main/java/com/sports/server/command/team/domain/Team.java
@@ -35,7 +35,7 @@ public class Team extends BaseEntity<Team> implements ManagedEntity {
     private String logoImageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "unit_id")
+    @JoinColumn(name = "unit_id", nullable = false)
     private Unit unit;
 
     @Column(name = "team_color", nullable = false)
@@ -62,7 +62,8 @@ public class Team extends BaseEntity<Team> implements ManagedEntity {
     private List<GameTeam> gameTeams = new ArrayList<>();
 
     @Builder
-    public Team(@NonNull String name, String logoImageUrl, @NonNull Unit unit, @NonNull String teamColor, SportType sportType) {
+    public Team(@NonNull String name, String logoImageUrl, @NonNull Unit unit, @NonNull String teamColor,
+                SportType sportType) {
         this.name = name;
         this.logoImageUrl = logoImageUrl;
         this.unit = unit;
@@ -96,7 +97,7 @@ public class Team extends BaseEntity<Team> implements ManagedEntity {
     }
 
     void addTeamPlayer(TeamPlayer teamPlayer) {
-            this.teamPlayers.add(teamPlayer);
+        this.teamPlayers.add(teamPlayer);
     }
 
     public void removeTeamPlayer(Player player) {

--- a/src/main/java/com/sports/server/command/team/domain/Team.java
+++ b/src/main/java/com/sports/server/command/team/domain/Team.java
@@ -34,8 +34,8 @@ public class Team extends BaseEntity<Team> implements ManagedEntity {
     @Column(name = "logo_image_url")
     private String logoImageUrl;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "unit", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "unit_id")
     private Unit unit;
 
     @Column(name = "team_color", nullable = false)

--- a/src/main/java/com/sports/server/command/team/domain/TeamPlayerRepository.java
+++ b/src/main/java/com/sports/server/command/team/domain/TeamPlayerRepository.java
@@ -16,9 +16,9 @@ public interface TeamPlayerRepository extends JpaRepository<TeamPlayer, Long> {
     @Query("SELECT tp FROM TeamPlayer tp JOIN FETCH tp.player WHERE tp.id IN :ids")
     List<TeamPlayer> findAllByTeamPlayerIds(@Param("ids") List<Long> teamPlayerIds);
 
-    @Query("SELECT tp FROM TeamPlayer tp JOIN FETCH tp.team WHERE tp.player.id = :playerId")
+    @Query("SELECT tp FROM TeamPlayer tp JOIN FETCH tp.team t JOIN FETCH t.unit WHERE tp.player.id = :playerId")
     List<TeamPlayer> findAllByPlayerId(@Param("playerId") Long playerId);
 
-    @Query("SELECT tp FROM TeamPlayer tp JOIN FETCH tp.player JOIN FETCH tp.team WHERE tp.player.id IN :playerIds")
+    @Query("SELECT tp FROM TeamPlayer tp JOIN FETCH tp.player JOIN FETCH tp.team t JOIN FETCH t.unit WHERE tp.player.id IN :playerIds")
     List<TeamPlayer> findAllByPlayerIds(@Param("playerIds") List<Long> playerIds);
 }

--- a/src/main/java/com/sports/server/command/team/domain/Unit.java
+++ b/src/main/java/com/sports/server/command/team/domain/Unit.java
@@ -1,48 +1,27 @@
 package com.sports.server.command.team.domain;
 
-import com.sports.server.command.team.exception.TeamErrorMessages;
-import com.sports.server.common.exception.NotFoundException;
+import com.sports.server.command.organization.domain.Organization;
+import com.sports.server.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Stream;
-
+@Entity
 @Getter
-@RequiredArgsConstructor
-public enum Unit {
-    ENGLISH("영어대학"),
-    OCCIDENTAL_LANGUAGES("서양어대학"),
-    ASIAN_LANGUAGES_AND_CULTURE("아시아언어문화대학"),
-    CHINESE_STUDIES("중국학대학"),
-    JAPANESE_STUDIES("일본어대학"),
-    SOCIAL_SCIENCES("사회과학대학"),
-    BUSINESS_AND_ECONOMICS("상경대학"),
-    BUSINESS("경영대학"),
-    EDUCATION("사범대학"),
-    AI_CONVERGENCE("AI융합대학"),
-    INTERNATIONAL_STUDIES("국제학부"),
-    LD_AND_LT("LD/LT학부"),
-    KOREAN_AS_A_FOREIGN_LANGUAGE("KFL학부"),
-    LIBERAL_ARTS("자유전공학부"),
-    ETC("기타");
+@Table(name = "units")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Unit extends BaseEntity<Unit> {
 
-    private final String name;
+    @Column(name = "name", nullable = false)
+    private String name;
 
-    public static Unit from(String name) {
-        return Stream.of(values())
-                .filter(u -> u.getName().equals(name))
-                .findFirst()
-                .orElseThrow(() -> new NotFoundException(TeamErrorMessages.UNIT_NOT_FOUND_EXCEPTION));
-    }
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", nullable = false)
+    private Organization organization;
 
-    public static List<Unit> fromNames(List<String> names) {
-        if (names == null || names.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return names.stream()
-                .map(Unit::from)
-                .toList();
+    public Unit(String name, Organization organization) {
+        this.name = name;
+        this.organization = organization;
     }
 }

--- a/src/main/java/com/sports/server/command/team/domain/UnitRepository.java
+++ b/src/main/java/com/sports/server/command/team/domain/UnitRepository.java
@@ -10,4 +10,6 @@ public interface UnitRepository extends JpaRepository<Unit, Long> {
     List<Unit> findAllByOrganizationId(Long organizationId);
 
     Optional<Unit> findByNameAndOrganizationId(String name, Long organizationId);
+
+    List<Unit> findAllByName(String name);
 }

--- a/src/main/java/com/sports/server/command/team/domain/UnitRepository.java
+++ b/src/main/java/com/sports/server/command/team/domain/UnitRepository.java
@@ -1,0 +1,13 @@
+package com.sports.server.command.team.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UnitRepository extends JpaRepository<Unit, Long> {
+
+    List<Unit> findAllByOrganizationId(Long organizationId);
+
+    Optional<Unit> findByNameAndOrganizationId(String name, Long organizationId);
+}

--- a/src/main/java/com/sports/server/command/team/domain/UnitRepository.java
+++ b/src/main/java/com/sports/server/command/team/domain/UnitRepository.java
@@ -11,5 +11,7 @@ public interface UnitRepository extends JpaRepository<Unit, Long> {
 
     Optional<Unit> findByNameAndOrganizationId(String name, Long organizationId);
 
-    List<Unit> findAllByName(String name);
+    List<Unit> findAllByNameInAndOrganizationId(List<String> names, Long organizationId);
+
+    List<Unit> findAllByNameIn(List<String> names);
 }

--- a/src/main/java/com/sports/server/command/team/dto/TeamRequest.java
+++ b/src/main/java/com/sports/server/command/team/dto/TeamRequest.java
@@ -15,11 +15,11 @@ public class TeamRequest {
             List<TeamPlayerRegister> teamPlayers,
             SportType sportType
     ) {
-        public Team toEntity(String logoImageUrl) {
+        public Team toEntity(String logoImageUrl, Unit unit) {
             return Team.builder()
                     .name(this.name)
                     .logoImageUrl(logoImageUrl)
-                    .unit(Unit.from(this.unit))
+                    .unit(unit)
                     .teamColor(this.teamColor)
                     .sportType(this.sportType)
                     .build();

--- a/src/main/java/com/sports/server/query/application/TeamQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TeamQueryService.java
@@ -47,7 +47,8 @@ public class TeamQueryService {
     private final LeagueStatisticsQueryRepository leagueStatisticsQueryRepository;
     private final GameQueryRepository gameQueryRepository;
 
-    public List<UnitResponse> getUnitsWithTeams(final SportType sportType, final Long organizationId) {
+    public List<UnitResponse> getUnitsWithTeams(final SportType sportType, final Member member) {
+        Long organizationId = member.getOrganization().getId();
         List<Unit> allUnits = unitRepository.findAllByOrganizationId(organizationId);
         Set<Unit> unitsWithTeam = new HashSet<>(
                 teamQueryDynamicRepository.findDistinctUnitsBySportTypeAndOrganizationId(sportType, organizationId)
@@ -123,6 +124,9 @@ public class TeamQueryService {
     private List<Team> findTeamsByUnits(final List<String> units, final SportType sportType,
                                          final Long organizationId) {
         List<Unit> targetUnits = resolveUnits(units, organizationId);
+        if (targetUnits != null && targetUnits.isEmpty()) {
+            return Collections.emptyList();
+        }
         return teamQueryDynamicRepository.findAllByUnitsAndSportType(targetUnits, sportType, organizationId);
     }
 

--- a/src/main/java/com/sports/server/query/application/TeamQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TeamQueryService.java
@@ -135,15 +135,9 @@ public class TeamQueryService {
             return null;
         }
         if (organizationId != null) {
-            return unitNames.stream()
-                    .map(name -> unitRepository.findByNameAndOrganizationId(name, organizationId))
-                    .flatMap(Optional::stream)
-                    .toList();
+            return unitRepository.findAllByNameInAndOrganizationId(unitNames, organizationId);
         }
-        return unitNames.stream()
-                .map(unitRepository::findAllByName)
-                .flatMap(List::stream)
-                .toList();
+        return unitRepository.findAllByNameIn(unitNames);
     }
 
     private Map<Long, TeamDetailResponse.TeamGameResult> getTeamGameResults(List<Long> teamIds) {

--- a/src/main/java/com/sports/server/query/application/TeamQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TeamQueryService.java
@@ -42,14 +42,17 @@ public class TeamQueryService {
     private final TeamQueryRepository teamQueryRepository;
     private final TeamQueryDynamicRepository teamQueryDynamicRepository;
     private final TeamPlayerRepository teamPlayerRepository;
+    private final UnitRepository unitRepository;
     private final GameTeamRepository gameTeamRepository;
     private final LeagueStatisticsQueryRepository leagueStatisticsQueryRepository;
     private final GameQueryRepository gameQueryRepository;
 
-    public List<UnitResponse> getUnitsWithTeams(final SportType sportType) {
-        List<Unit> distinctUnits = teamQueryDynamicRepository.findDistinctUnitsBySportType(sportType);
-        Set<Unit> unitsWithTeam = distinctUnits.isEmpty() ? EnumSet.noneOf(Unit.class) : EnumSet.copyOf(distinctUnits);
-        return Arrays.stream(Unit.values())
+    public List<UnitResponse> getUnitsWithTeams(final SportType sportType, final Long organizationId) {
+        List<Unit> allUnits = unitRepository.findAllByOrganizationId(organizationId);
+        Set<Unit> unitsWithTeam = new HashSet<>(
+                teamQueryDynamicRepository.findDistinctUnitsBySportTypeAndOrganizationId(sportType, organizationId)
+        );
+        return allUnits.stream()
                 .map(unit -> UnitResponse.of(unit, unitsWithTeam.contains(unit)))
                 .toList();
     }
@@ -119,8 +122,24 @@ public class TeamQueryService {
 
     private List<Team> findTeamsByUnits(final List<String> units, final SportType sportType,
                                          final Long organizationId) {
-        List<Unit> targetUnits = (units == null || units.isEmpty()) ? null : Unit.fromNames(units);
+        List<Unit> targetUnits = resolveUnits(units, organizationId);
         return teamQueryDynamicRepository.findAllByUnitsAndSportType(targetUnits, sportType, organizationId);
+    }
+
+    private List<Unit> resolveUnits(final List<String> unitNames, final Long organizationId) {
+        if (unitNames == null || unitNames.isEmpty()) {
+            return null;
+        }
+        if (organizationId != null) {
+            return unitNames.stream()
+                    .map(name -> unitRepository.findByNameAndOrganizationId(name, organizationId))
+                    .flatMap(Optional::stream)
+                    .toList();
+        }
+        return unitNames.stream()
+                .map(unitRepository::findAllByName)
+                .flatMap(List::stream)
+                .toList();
     }
 
     private Map<Long, TeamDetailResponse.TeamGameResult> getTeamGameResults(List<Long> teamIds) {

--- a/src/main/java/com/sports/server/query/dto/response/UnitResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/UnitResponse.java
@@ -3,11 +3,11 @@ package com.sports.server.query.dto.response;
 import com.sports.server.command.team.domain.Unit;
 
 public record UnitResponse(
-        String unit,
+        Long id,
         String unitName,
         boolean hasTeam
 ) {
     public static UnitResponse of(Unit unit, boolean hasTeam) {
-        return new UnitResponse(unit.name(), unit.getName(), hasTeam);
+        return new UnitResponse(unit.getId(), unit.getName(), hasTeam);
     }
 }

--- a/src/main/java/com/sports/server/query/presentation/TeamQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/TeamQueryController.java
@@ -23,8 +23,7 @@ public class TeamQueryController {
     public ResponseEntity<List<UnitResponse>> getUnitsWithTeams(
             @RequestParam(required = false) final SportType sportType,
             final Member member) {
-        Long organizationId = member.getOrganization().getId();
-        return ResponseEntity.ok(teamQueryService.getUnitsWithTeams(sportType, organizationId));
+        return ResponseEntity.ok(teamQueryService.getUnitsWithTeams(sportType, member));
     }
 
     @GetMapping

--- a/src/main/java/com/sports/server/query/presentation/TeamQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/TeamQueryController.java
@@ -21,8 +21,10 @@ public class TeamQueryController {
 
     @GetMapping("/units")
     public ResponseEntity<List<UnitResponse>> getUnitsWithTeams(
-            @RequestParam(required = false) final SportType sportType) {
-        return ResponseEntity.ok(teamQueryService.getUnitsWithTeams(sportType));
+            @RequestParam(required = false) final SportType sportType,
+            final Member member) {
+        Long organizationId = member.getOrganization().getId();
+        return ResponseEntity.ok(teamQueryService.getUnitsWithTeams(sportType, organizationId));
     }
 
     @GetMapping

--- a/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepository.java
@@ -14,5 +14,5 @@ public interface TeamQueryDynamicRepository {
 
     List<Team> findAllByUnitsAndSportType(List<Unit> units, SportType sportType, Long organizationId);
 
-    List<Unit> findDistinctUnitsBySportType(SportType sportType);
+    List<Unit> findDistinctUnitsBySportTypeAndOrganizationId(SportType sportType, Long organizationId);
 }

--- a/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
@@ -30,6 +30,7 @@ public class TeamQueryDynamicRepositoryImpl implements TeamQueryDynamicRepositor
         return jpaQueryFactory
                 .selectFrom(leagueTeam)
                 .join(leagueTeam.team, team).fetchJoin()
+                .join(team.unit).fetchJoin()
                 .where(
                         leagueTeam.league.eq(league),
                         teamsPlayedInRound(league, roundNumber)
@@ -43,6 +44,7 @@ public class TeamQueryDynamicRepositoryImpl implements TeamQueryDynamicRepositor
                                                   final Long organizationId) {
         return jpaQueryFactory
                 .selectFrom(team)
+                .join(team.unit).fetchJoin()
                 .where(
                         teamsInUnits(units),
                         teamsWithSportType(sportType),

--- a/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
@@ -70,11 +70,14 @@ public class TeamQueryDynamicRepositoryImpl implements TeamQueryDynamicRepositor
     }
 
     @Override
-    public List<Unit> findDistinctUnitsBySportType(final SportType sportType) {
+    public List<Unit> findDistinctUnitsBySportTypeAndOrganizationId(final SportType sportType, final Long organizationId) {
         return jpaQueryFactory
                 .select(team.unit).distinct()
                 .from(team)
-                .where(teamsWithSportType(sportType))
+                .where(
+                        teamsWithSportType(sportType),
+                        teamsInOrganization(organizationId)
+                )
                 .fetch();
     }
 

--- a/src/main/resources/db/migration/prod/V14__convert_unit_to_entity.sql
+++ b/src/main/resources/db/migration/prod/V14__convert_unit_to_entity.sql
@@ -1,0 +1,65 @@
+-- 1. units 테이블 생성
+CREATE TABLE units
+(
+    id              BIGINT AUTO_INCREMENT NOT NULL,
+    name            VARCHAR(255)          NOT NULL,
+    organization_id BIGINT                NOT NULL,
+
+    CONSTRAINT pk_units PRIMARY KEY (id),
+    CONSTRAINT fk_units_on_organization FOREIGN KEY (organization_id) REFERENCES organizations (id)
+);
+
+-- 2. 기존 enum name → 한글 이름 매핑하여 units 테이블에 INSERT
+INSERT INTO units (name, organization_id)
+SELECT DISTINCT
+    CASE t.unit
+        WHEN 'ENGLISH' THEN '영어대학'
+        WHEN 'OCCIDENTAL_LANGUAGES' THEN '서양어대학'
+        WHEN 'ASIAN_LANGUAGES_AND_CULTURE' THEN '아시아언어문화대학'
+        WHEN 'CHINESE_STUDIES' THEN '중국학대학'
+        WHEN 'JAPANESE_STUDIES' THEN '일본어대학'
+        WHEN 'SOCIAL_SCIENCES' THEN '사회과학대학'
+        WHEN 'BUSINESS_AND_ECONOMICS' THEN '상경대학'
+        WHEN 'BUSINESS' THEN '경영대학'
+        WHEN 'EDUCATION' THEN '사범대학'
+        WHEN 'AI_CONVERGENCE' THEN 'AI융합대학'
+        WHEN 'INTERNATIONAL_STUDIES' THEN '국제학부'
+        WHEN 'LD_AND_LT' THEN 'LD/LT학부'
+        WHEN 'KOREAN_AS_A_FOREIGN_LANGUAGE' THEN 'KFL학부'
+        WHEN 'LIBERAL_ARTS' THEN '자유전공학부'
+        WHEN 'ETC' THEN '기타'
+        ELSE t.unit
+    END,
+    t.organization_id
+FROM teams t
+WHERE t.organization_id IS NOT NULL;
+
+-- 3. teams 테이블에 unit_id 컬럼 추가
+ALTER TABLE teams ADD COLUMN unit_id BIGINT;
+
+-- 4. 기존 데이터 마이그레이션: teams.unit → units.id 매핑
+UPDATE teams t
+    JOIN units u ON u.organization_id = t.organization_id
+        AND u.name = CASE t.unit
+            WHEN 'ENGLISH' THEN '영어대학'
+            WHEN 'OCCIDENTAL_LANGUAGES' THEN '서양어대학'
+            WHEN 'ASIAN_LANGUAGES_AND_CULTURE' THEN '아시아언어문화대학'
+            WHEN 'CHINESE_STUDIES' THEN '중국학대학'
+            WHEN 'JAPANESE_STUDIES' THEN '일본어대학'
+            WHEN 'SOCIAL_SCIENCES' THEN '사회과학대학'
+            WHEN 'BUSINESS_AND_ECONOMICS' THEN '상경대학'
+            WHEN 'BUSINESS' THEN '경영대학'
+            WHEN 'EDUCATION' THEN '사범대학'
+            WHEN 'AI_CONVERGENCE' THEN 'AI융합대학'
+            WHEN 'INTERNATIONAL_STUDIES' THEN '국제학부'
+            WHEN 'LD_AND_LT' THEN 'LD/LT학부'
+            WHEN 'KOREAN_AS_A_FOREIGN_LANGUAGE' THEN 'KFL학부'
+            WHEN 'LIBERAL_ARTS' THEN '자유전공학부'
+            WHEN 'ETC' THEN '기타'
+            ELSE t.unit
+        END
+SET t.unit_id = u.id;
+
+-- 5. unit_id FK 설정 및 기존 unit 컬럼 DROP
+ALTER TABLE teams ADD CONSTRAINT fk_teams_on_unit FOREIGN KEY (unit_id) REFERENCES units (id);
+ALTER TABLE teams DROP COLUMN unit;

--- a/src/main/resources/db/migration/prod/V14__convert_unit_to_entity.sql
+++ b/src/main/resources/db/migration/prod/V14__convert_unit_to_entity.sql
@@ -38,27 +38,28 @@ WHERE t.organization_id IS NOT NULL;
 ALTER TABLE teams ADD COLUMN unit_id BIGINT;
 
 -- 4. 기존 데이터 마이그레이션: teams.unit → units.id 매핑
-UPDATE teams t
-    JOIN units u ON u.organization_id = t.organization_id
-        AND u.name = CASE t.unit
-            WHEN 'ENGLISH' THEN '영어대학'
-            WHEN 'OCCIDENTAL_LANGUAGES' THEN '서양어대학'
-            WHEN 'ASIAN_LANGUAGES_AND_CULTURE' THEN '아시아언어문화대학'
-            WHEN 'CHINESE_STUDIES' THEN '중국학대학'
-            WHEN 'JAPANESE_STUDIES' THEN '일본어대학'
-            WHEN 'SOCIAL_SCIENCES' THEN '사회과학대학'
-            WHEN 'BUSINESS_AND_ECONOMICS' THEN '상경대학'
-            WHEN 'BUSINESS' THEN '경영대학'
-            WHEN 'EDUCATION' THEN '사범대학'
-            WHEN 'AI_CONVERGENCE' THEN 'AI융합대학'
-            WHEN 'INTERNATIONAL_STUDIES' THEN '국제학부'
-            WHEN 'LD_AND_LT' THEN 'LD/LT학부'
-            WHEN 'KOREAN_AS_A_FOREIGN_LANGUAGE' THEN 'KFL학부'
-            WHEN 'LIBERAL_ARTS' THEN '자유전공학부'
-            WHEN 'ETC' THEN '기타'
-            ELSE t.unit
-        END
-SET t.unit_id = u.id;
+UPDATE teams SET unit_id = (
+    SELECT u.id FROM units u
+    WHERE u.organization_id = teams.organization_id
+      AND u.name = CASE teams.unit
+          WHEN 'ENGLISH' THEN '영어대학'
+          WHEN 'OCCIDENTAL_LANGUAGES' THEN '서양어대학'
+          WHEN 'ASIAN_LANGUAGES_AND_CULTURE' THEN '아시아언어문화대학'
+          WHEN 'CHINESE_STUDIES' THEN '중국학대학'
+          WHEN 'JAPANESE_STUDIES' THEN '일본어대학'
+          WHEN 'SOCIAL_SCIENCES' THEN '사회과학대학'
+          WHEN 'BUSINESS_AND_ECONOMICS' THEN '상경대학'
+          WHEN 'BUSINESS' THEN '경영대학'
+          WHEN 'EDUCATION' THEN '사범대학'
+          WHEN 'AI_CONVERGENCE' THEN 'AI융합대학'
+          WHEN 'INTERNATIONAL_STUDIES' THEN '국제학부'
+          WHEN 'LD_AND_LT' THEN 'LD/LT학부'
+          WHEN 'KOREAN_AS_A_FOREIGN_LANGUAGE' THEN 'KFL학부'
+          WHEN 'LIBERAL_ARTS' THEN '자유전공학부'
+          WHEN 'ETC' THEN '기타'
+          ELSE teams.unit
+      END
+) WHERE teams.organization_id IS NOT NULL;
 
 -- 5. unit_id FK 설정 및 기존 unit 컬럼 DROP
 ALTER TABLE teams ADD CONSTRAINT fk_teams_on_unit FOREIGN KEY (unit_id) REFERENCES units (id);

--- a/src/test/java/com/sports/server/command/team/acceptance/TeamAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/team/acceptance/TeamAcceptanceTest.java
@@ -5,6 +5,7 @@ import com.sports.server.command.team.domain.TeamPlayer;
 import com.sports.server.command.team.domain.TeamPlayerRepository;
 import com.sports.server.command.team.domain.TeamRepository;
 import com.sports.server.command.team.domain.Unit;
+import com.sports.server.command.team.domain.UnitRepository;
 import com.sports.server.command.team.dto.TeamRequest;
 import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
@@ -30,6 +31,9 @@ public class TeamAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private TeamPlayerRepository teamPlayerRepository;
+
+    @Autowired
+    private UnitRepository unitRepository;
 
     @Value("${image.origin-prefix}")
     private String originPrefix;
@@ -69,10 +73,11 @@ public class TeamAcceptanceTest extends AcceptanceTest {
     @Test
     void 팀_정보를_수정한다() {
         // given
+        Unit unit = unitRepository.findByNameAndOrganizationId("사회과학대학", 1L).orElseThrow();
         Team savedTeam = teamRepository.save(Team.builder()
                 .name("정치외교학과 PSD")
                 .teamColor("team color")
-                .unit(Unit.SOCIAL_SCIENCES)
+                .unit(unit)
                 .logoImageUrl(originPrefix + "logo-url").build());
 
         TeamRequest.Update request = new TeamRequest.Update(
@@ -145,10 +150,11 @@ public class TeamAcceptanceTest extends AcceptanceTest {
     @Test
     void 팀을_삭제한다() {
         // given
+        Unit unit = unitRepository.findByNameAndOrganizationId("사회과학대학", 1L).orElseThrow();
         Team savedTeam = teamRepository.save(Team.builder()
                 .name("정치외교학과 PSD")
                 .teamColor("team color")
-                .unit(Unit.SOCIAL_SCIENCES)
+                .unit(unit)
                 .logoImageUrl(originPrefix + "logo-url").build());
 
         configureMockJwtForEmail("john@example.com");

--- a/src/test/java/com/sports/server/command/team/domain/TeamTest.java
+++ b/src/test/java/com/sports/server/command/team/domain/TeamTest.java
@@ -1,5 +1,6 @@
 package com.sports.server.command.team.domain;
 
+import com.sports.server.command.organization.domain.Organization;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.common.exception.CustomException;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,9 +22,10 @@ public class TeamTest {
 
         @BeforeEach
         void setUp() {
+            Unit unit = new Unit("사회과학대학", null);
             team = Team.builder()
                     .name("팀1")
-                    .unit(Unit.SOCIAL_SCIENCES)
+                    .unit(unit)
                     .logoImageUrl("image-url")
                     .teamColor("color")
                     .build();

--- a/src/test/java/com/sports/server/command/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/sports/server/command/team/presentation/TeamControllerTest.java
@@ -1,6 +1,5 @@
 package com.sports.server.command.team.presentation;
 
-import com.sports.server.command.team.domain.Unit;
 import com.sports.server.command.team.dto.TeamRequest;
 import com.sports.server.support.DocumentationTest;
 import jakarta.servlet.http.Cookie;

--- a/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.sports.server.command.team.domain.Unit;
 import java.time.LocalDateTime;
 
 @Sql(scripts = "/team-query-fixture.sql")
@@ -41,30 +40,31 @@ public class TeamQueryServiceTest extends ServiceTest {
     class GetUnitsWithTeamsTest {
 
         @Test
-        void 모든_단과대가_반환되고_팀이_있는_단과대는_hasTeam이_true이다() {
-            // when
-            List<UnitResponse> responses = teamQueryService.getUnitsWithTeams(null);
+        void 해당_조직의_모든_단과대가_반환되고_팀이_있는_단과대는_hasTeam이_true이다() {
+            // when (organizationId = 1, fixture에 units 3개: 사회과학대학, 기타, 영어대학)
+            List<UnitResponse> responses = teamQueryService.getUnitsWithTeams(null, 1L);
 
             // then
             assertAll(
-                    () -> assertThat(responses).hasSize(Unit.values().length),
+                    () -> assertThat(responses).hasSize(3),
                     () -> assertThat(responses)
                             .filteredOn(UnitResponse::hasTeam)
-                            .extracting(UnitResponse::unit)
-                            .contains("SOCIAL_SCIENCES", "ETC", "ENGLISH")
+                            .extracting(UnitResponse::unitName)
+                            .contains("사회과학대학", "기타", "영어대학")
             );
         }
 
         @Test
         void 팀이_없는_단과대는_hasTeam이_false이다() {
-            // when
-            List<UnitResponse> responses = teamQueryService.getUnitsWithTeams(null);
+            // when (organizationId = 1)
+            List<UnitResponse> responses = teamQueryService.getUnitsWithTeams(null, 1L);
 
-            // then
-            assertThat(responses)
-                    .filteredOn(r -> !r.hasTeam())
+            // then - fixture에서 org1의 모든 unit에 팀이 있으므로 hasTeam false인 것은 없음
+            // 대신 org2 조회 시 확인
+            List<UnitResponse> org2Responses = teamQueryService.getUnitsWithTeams(null, 2L);
+            assertThat(org2Responses)
                     .isNotEmpty()
-                    .allSatisfy(r -> assertThat(r.hasTeam()).isFalse());
+                    .allSatisfy(r -> assertThat(r.hasTeam()).isTrue());
         }
     }
 
@@ -121,14 +121,15 @@ public class TeamQueryServiceTest extends ServiceTest {
         }
 
         @Test
-        void 존재하지_않는_단위로_필터링하면_예외가_발생한다() {
+        void 존재하지_않는_단위로_필터링하면_빈_결과를_반환한다() {
             // given
             List<String> units = List.of("INVALID UNIT");
 
-            // when & then
-            assertThatThrownBy(() -> teamQueryService.getAllTeamsByUnits(units, null, org1Member))
-                    .isInstanceOf(NotFoundException.class)
-                    .hasMessage(TeamErrorMessages.UNIT_NOT_FOUND_EXCEPTION);
+            // when
+            List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(units, null, org1Member);
+
+            // then
+            assertThat(responses).isEmpty();
         }
 
         @Test

--- a/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
@@ -39,10 +39,19 @@ public class TeamQueryServiceTest extends ServiceTest {
     @DisplayName("단과대별 팀 유무 조회 시")
     class GetUnitsWithTeamsTest {
 
+        private Member org1Member;
+        private Member org2Member;
+
+        @BeforeEach
+        void setUp() {
+            org1Member = entityUtils.getEntity(1L, Member.class);
+            org2Member = entityUtils.getEntity(2L, Member.class);
+        }
+
         @Test
         void 해당_조직의_모든_단과대가_반환되고_팀이_있는_단과대는_hasTeam이_true이다() {
-            // when (organizationId = 1, fixture에 units 3개: 사회과학대학, 기타, 영어대학)
-            List<UnitResponse> responses = teamQueryService.getUnitsWithTeams(null, 1L);
+            // when (fixture에 org1 units 3개: 사회과학대학, 기타, 영어대학)
+            List<UnitResponse> responses = teamQueryService.getUnitsWithTeams(null, org1Member);
 
             // then
             assertAll(
@@ -56,12 +65,10 @@ public class TeamQueryServiceTest extends ServiceTest {
 
         @Test
         void 팀이_없는_단과대는_hasTeam이_false이다() {
-            // when (organizationId = 1)
-            List<UnitResponse> responses = teamQueryService.getUnitsWithTeams(null, 1L);
+            // when
+            List<UnitResponse> org2Responses = teamQueryService.getUnitsWithTeams(null, org2Member);
 
-            // then - fixture에서 org1의 모든 unit에 팀이 있으므로 hasTeam false인 것은 없음
-            // 대신 org2 조회 시 확인
-            List<UnitResponse> org2Responses = teamQueryService.getUnitsWithTeams(null, 2L);
+            // then
             assertThat(org2Responses)
                     .isNotEmpty()
                     .allSatisfy(r -> assertThat(r.hasTeam()).isTrue());

--- a/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
@@ -30,24 +30,14 @@ public class TeamQueryControllerTest extends DocumentationTest {
     void 단과대별_팀_유무를_조회한다() throws Exception {
         // given
         List<UnitResponse> response = List.of(
-                new UnitResponse("ENGLISH", "영어대학", true),
-                new UnitResponse("OCCIDENTAL_LANGUAGES", "서양어대학", false),
-                new UnitResponse("ASIAN_LANGUAGES_AND_CULTURE", "아시아언어문화대학", false),
-                new UnitResponse("CHINESE_STUDIES", "중국학대학", false),
-                new UnitResponse("JAPANESE_STUDIES", "일본어대학", false),
-                new UnitResponse("SOCIAL_SCIENCES", "사회과학대학", true),
-                new UnitResponse("BUSINESS_AND_ECONOMICS", "상경대학", false),
-                new UnitResponse("BUSINESS", "경영대학", true),
-                new UnitResponse("EDUCATION", "사범대학", false),
-                new UnitResponse("AI_CONVERGENCE", "AI융합대학", false),
-                new UnitResponse("INTERNATIONAL_STUDIES", "국제학부", false),
-                new UnitResponse("LD_AND_LT", "LD/LT학부", false),
-                new UnitResponse("KOREAN_AS_A_FOREIGN_LANGUAGE", "KFL학부", false),
-                new UnitResponse("LIBERAL_ARTS", "자유전공학부", false),
-                new UnitResponse("ETC", "기타", false)
+                new UnitResponse(1L, "영어대학", true),
+                new UnitResponse(2L, "서양어대학", false),
+                new UnitResponse(3L, "사회과학대학", true),
+                new UnitResponse(4L, "경영대학", true),
+                new UnitResponse(5L, "기타", false)
         );
 
-        given(teamQueryService.getUnitsWithTeams(SportType.SOCCER)).willReturn(response);
+        given(teamQueryService.getUnitsWithTeams(any(), any())).willReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(get("/teams/units")
@@ -61,7 +51,7 @@ public class TeamQueryControllerTest extends DocumentationTest {
                                 parameterWithName("sportType").description("종목 필터 (SOCCER, BASKETBALL)").optional()
                         ),
                         responseFields(
-                                fieldWithPath("[].unit").type(JsonFieldType.STRING).description("단과대 코드"),
+                                fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("단과대 ID"),
                                 fieldWithPath("[].unitName").type(JsonFieldType.STRING).description("단과대 이름"),
                                 fieldWithPath("[].hasTeam").type(JsonFieldType.BOOLEAN).description("해당 단과대에 팀 존재 여부")
                         )

--- a/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
@@ -37,7 +37,7 @@ public class TeamQueryControllerTest extends DocumentationTest {
                 new UnitResponse(5L, "기타", false)
         );
 
-        given(teamQueryService.getUnitsWithTeams(any(), any())).willReturn(response);
+        given(teamQueryService.getUnitsWithTeams(any(SportType.class), any())).willReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(get("/teams/units")

--- a/src/test/resources/game-fixture.sql
+++ b/src/test/resources/game-fixture.sql
@@ -14,14 +14,24 @@ VALUES (1, 1, 'john.doe@example.com', '$2a$10$yviVCR3GmaU6cPJT.8vaMOwph9WzbX6wtn
        (5, 1, 'carol.white@example.com', '$2a$10$yviVCR3GmaU6cPJT.8vaMOwph9WzbX6wtn9iERu3148ZP8XlKbakO', TRUE, '2024-07-05 16:10:00');
 
 
-INSERT INTO teams (id, unit, name, logo_image_url, team_color)
-VALUES (1, 'OCCIDENTAL_LANGUAGES', '팀 A', 'http://example.com/logo_a.png', '#FF0000'),
-       (2, 'ENGLISH', '팀 B', 'http://example.com/logo_b.png', '#0000FF'),
-       (3, 'JAPANESE_STUDIES', '팀 C', 'http://example.com/logo_c.png', '#00FF00'),
-       (4, 'BUSINESS_AND_ECONOMICS', '팀 D', 'http://example.com/logo_d.png', '#FFFF00'),
-       (5, 'AI_CONVERGENCE', '팀 E', 'http://example.com/logo_e.png', '#800080'),
-       (6, 'LD_AND_LT', '팀 F', 'http://example.com/logo_e.png', '#FF0000'),
-       (7, 'ETC', '팀 G', 'http://example.com/logo_e.png', '#00FF00');
+INSERT INTO units (id, name, organization_id)
+VALUES (1, '서양어대학', 1),
+       (2, '영어대학', 1),
+       (3, '일본어대학', 1),
+       (4, '상경대학', 1),
+       (5, 'AI융합대학', 1),
+       (6, 'LD/LT학부', 1),
+       (7, '기타', 1);
+
+
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color)
+VALUES (1, 1, '팀 A', 'http://example.com/logo_a.png', '#FF0000'),
+       (2, 2, '팀 B', 'http://example.com/logo_b.png', '#0000FF'),
+       (3, 3, '팀 C', 'http://example.com/logo_c.png', '#00FF00'),
+       (4, 4, '팀 D', 'http://example.com/logo_d.png', '#FFFF00'),
+       (5, 5, '팀 E', 'http://example.com/logo_e.png', '#800080'),
+       (6, 6, '팀 F', 'http://example.com/logo_e.png', '#FF0000'),
+       (7, 7, '팀 G', 'http://example.com/logo_e.png', '#00FF00');
 
 
 INSERT INTO players (id, name, student_number)

--- a/src/test/resources/league-fixture.sql
+++ b/src/test/resources/league-fixture.sql
@@ -11,13 +11,17 @@ VALUES (1, 1, 'john.doe@example.com', 'password123', TRUE, '2025-07-01 10:00:00'
        (2, 1, 'user@example.com', 'password456', FALSE, '2025-07-02 12:30:00');
 
 
-INSERT INTO teams (id, unit, name, logo_image_url, team_color, sport_type)
-VALUES (1, 'BUSINESS', '경영 야생마', 'https://example.com/logos/wildhorse.png', '#8B0000', 'SOCCER'),
-       (2, 'BUSINESS', '서어 뻬데뻬', 'https://example.com/logos/pedro.png', '#FF4500', 'SOCCER'),
-       (3, 'BUSINESS', '미컴 축구생각', 'https://example.com/logos/micom.png', '#1E90FF', 'SOCCER'),
-       (4, 'BUSINESS', '체교 불사조', 'https://example.com/logos/phoenix.png', '#FFD700', 'SOCCER'),
-       (5, 'BUSINESS', '컴공 독수리', 'https://example.com/logos/eagle.png', '#4B0082', 'SOCCER'),
-       (6, 'BUSINESS', '경영 슬램덩크', 'https://example.com/logos/slamdunk.png', '#FF6347', 'BASKETBALL');
+INSERT INTO units (id, name, organization_id)
+VALUES (1, '경영대학', 1);
+
+
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color, sport_type)
+VALUES (1, 1, '경영 야생마', 'https://example.com/logos/wildhorse.png', '#8B0000', 'SOCCER'),
+       (2, 1, '서어 뻬데뻬', 'https://example.com/logos/pedro.png', '#FF4500', 'SOCCER'),
+       (3, 1, '미컴 축구생각', 'https://example.com/logos/micom.png', '#1E90FF', 'SOCCER'),
+       (4, 1, '체교 불사조', 'https://example.com/logos/phoenix.png', '#FFD700', 'SOCCER'),
+       (5, 1, '컴공 독수리', 'https://example.com/logos/eagle.png', '#4B0082', 'SOCCER'),
+       (6, 1, '경영 슬램덩크', 'https://example.com/logos/slamdunk.png', '#FF6347', 'BASKETBALL');
 
 
 INSERT INTO players (id, name, student_number)

--- a/src/test/resources/recent-league-games-ended-fixture.sql
+++ b/src/test/resources/recent-league-games-ended-fixture.sql
@@ -6,9 +6,12 @@ VALUES (1, '테스트 조직', 9);
 INSERT INTO members (id, organization_id, email, password, is_administrator, last_login)
 VALUES (1, 1, 'test@test.com', 'password', TRUE, '2025-01-01 00:00:00');
 
-INSERT INTO teams (id, unit, name, logo_image_url, team_color)
-VALUES (1, 'BUSINESS', '팀 A', 'http://logo.com/a.png', '#FF0000'),
-       (2, 'BUSINESS', '팀 B', 'http://logo.com/b.png', '#0000FF');
+INSERT INTO units (id, name, organization_id)
+VALUES (1, '경영대학', 1);
+
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color)
+VALUES (1, 1, '팀 A', 'http://logo.com/a.png', '#FF0000'),
+       (2, 1, '팀 B', 'http://logo.com/b.png', '#0000FF');
 
 -- 진행 중인 리그는 없음
 -- 리그 1, 2는 동일한 종료일(2025-12-31)로 가장 최근 종료

--- a/src/test/resources/recent-league-games-in-progress-fixture.sql
+++ b/src/test/resources/recent-league-games-in-progress-fixture.sql
@@ -6,9 +6,12 @@ VALUES (1, '테스트 조직', 9);
 INSERT INTO members (id, organization_id, email, password, is_administrator, last_login)
 VALUES (1, 1, 'test@test.com', 'password', TRUE, '2025-01-01 00:00:00');
 
-INSERT INTO teams (id, unit, name, logo_image_url, team_color)
-VALUES (1, 'BUSINESS', '팀 A', 'http://logo.com/a.png', '#FF0000'),
-       (2, 'BUSINESS', '팀 B', 'http://logo.com/b.png', '#0000FF');
+INSERT INTO units (id, name, organization_id)
+VALUES (1, '경영대학', 1);
+
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color)
+VALUES (1, 1, '팀 A', 'http://logo.com/a.png', '#FF0000'),
+       (2, 1, '팀 B', 'http://logo.com/b.png', '#0000FF');
 
 INSERT INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)
 VALUES (1, 1, 1, '진행중인 대회', '2000-01-01 00:00:00', '2100-01-01 00:00:00', false, '4강', '4강'),

--- a/src/test/resources/recent-league-games-no-games-fixture.sql
+++ b/src/test/resources/recent-league-games-no-games-fixture.sql
@@ -6,9 +6,12 @@ VALUES (1, '테스트 조직', 9);
 INSERT INTO members (id, organization_id, email, password, is_administrator, last_login)
 VALUES (1, 1, 'test@test.com', 'password', TRUE, '2025-01-01 00:00:00');
 
-INSERT INTO teams (id, unit, name, logo_image_url, team_color)
-VALUES (1, 'BUSINESS', '팀 A', 'http://logo.com/a.png', '#FF0000'),
-       (2, 'BUSINESS', '팀 B', 'http://logo.com/b.png', '#0000FF');
+INSERT INTO units (id, name, organization_id)
+VALUES (1, '경영대학', 1);
+
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color)
+VALUES (1, 1, '팀 A', 'http://logo.com/a.png', '#FF0000'),
+       (2, 1, '팀 B', 'http://logo.com/b.png', '#0000FF');
 
 -- 진행 중인 리그이지만 경기가 없음
 INSERT INTO leagues (id, administrator_id, organization_id, name, start_at, end_at, is_deleted, max_round, in_progress_round)

--- a/src/test/resources/team-fixture.sql
+++ b/src/test/resources/team-fixture.sql
@@ -7,13 +7,18 @@ INSERT INTO members (id, organization_id, email, password, is_administrator, las
 VALUES (1, 1, 'john@example.com', '$2a$10$yviVCR3GmaU6cPJT.8vaMOwph9WzbX6wtn9iERu3148ZP8XlKbakO', true,
         '2024-06-15 10:00:00');
 
+-- 단과대
+INSERT INTO units (id, name, organization_id)
+VALUES (1, '경영대학', 1),
+       (2, '사회과학대학', 1);
+
 -- 팀
-INSERT INTO teams (id, unit, name, logo_image_url, team_color)
-VALUES (1, 'BUSINESS', '경영 야생마', 'https://example.com/logos/wildhorse.png', '#8B0000'),
-       (2, 'BUSINESS', '서어 뻬데뻬', 'https://example.com/logos/pedro.png', '#FF4500'),
-       (3, 'BUSINESS', '미컴 축구생각', 'https://example.com/logos/micom.png', '#1E90FF'),
-       (4, 'BUSINESS', '체교 불사조', 'https://example.com/logos/phoenix.png', '#FFD700'),
-       (5, 'BUSINESS', '컴공 독수리', 'https://example.com/logos/eagle.png', '#4B0082');
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color)
+VALUES (1, 1, '경영 야생마', 'https://example.com/logos/wildhorse.png', '#8B0000'),
+       (2, 1, '서어 뻬데뻬', 'https://example.com/logos/pedro.png', '#FF4500'),
+       (3, 1, '미컴 축구생각', 'https://example.com/logos/micom.png', '#1E90FF'),
+       (4, 1, '체교 불사조', 'https://example.com/logos/phoenix.png', '#FFD700'),
+       (5, 1, '컴공 독수리', 'https://example.com/logos/eagle.png', '#4B0082');
 
 -- 선수
 INSERT INTO players (id, name, student_number, organization_id)

--- a/src/test/resources/team-query-fixture.sql
+++ b/src/test/resources/team-query-fixture.sql
@@ -11,12 +11,19 @@ VALUES (1, 1, 'john.doe@example.com', 'password123', TRUE, '2024-07-01 10:00:00'
        (2, 2, 'non.manager@example.com', 'password123', FALSE, '2024-07-01 10:00:00');
 
 
-INSERT INTO teams (id, unit, name, logo_image_url, team_color, organization_id)
-VALUES (1, 'SOCIAL_SCIENCES', '팀A', 'http://example.com/logo_a.png', '#FF0000', 1),
-       (2, 'ETC', '팀B', 'http://example.com/logo_b.png', '#0000FF', 1),
-       (3, 'ENGLISH', '팀C', 'http://example.com/logo_c.png', '#0000FF', 1),
-       (4, 'SOCIAL_SCIENCES', '팀D', 'http://example.com/logo_d.png', '#0000FF', 1),
-       (20, 'BUSINESS', '다른조직팀', 'http://example.com/logo_other.png', '#00FF00', 2);
+INSERT INTO units (id, name, organization_id)
+VALUES (1, '사회과학대학', 1),
+       (2, '기타', 1),
+       (3, '영어대학', 1),
+       (4, '경영대학', 2);
+
+
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color, organization_id)
+VALUES (1, 1, '팀A', 'http://example.com/logo_a.png', '#FF0000', 1),
+       (2, 2, '팀B', 'http://example.com/logo_b.png', '#0000FF', 1),
+       (3, 3, '팀C', 'http://example.com/logo_c.png', '#0000FF', 1),
+       (4, 1, '팀D', 'http://example.com/logo_d.png', '#0000FF', 1),
+       (20, 4, '다른조직팀', 'http://example.com/logo_other.png', '#00FF00', 2);
 
 
 INSERT INTO players (id, name, student_number)
@@ -160,10 +167,10 @@ VALUES ('GAME_PROGRESS', 1, 'POST_GAME', 20, 'GAME_END', 1, 2, 2, 3, 'PENALTY_SH
 
 -- === 최근 경기 조회 위한 데이터 ===
 
-INSERT INTO teams (id, unit, name, logo_image_url, team_color, organization_id)
-VALUES (10, 'ETC', '게임없는팀', 'image', '#000000', 1),
-       (11, 'ETC', '게임2개팀', 'image', '#00FF00', 1),
-       (12, 'ETC', '게임많은팀', 'image', '#FF00FF', 1);
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color, organization_id)
+VALUES (10, 2, '게임없는팀', 'image', '#000000', 1),
+       (11, 2, '게임2개팀', 'image', '#00FF00', 1),
+       (12, 2, '게임많은팀', 'image', '#FF00FF', 1);
 
 INSERT INTO players (id, name, student_number)
 VALUES (20, '선수20', '202400001'),

--- a/src/test/resources/timeline-fixture.sql
+++ b/src/test/resources/timeline-fixture.sql
@@ -10,12 +10,18 @@ INSERT INTO members (id, organization_id, email, password, is_administrator, las
 VALUES (1, 1, 'john.doe@example.com', 'password123', TRUE, '2024-07-01 10:00:00'),
        (2, 2, 'non.manager@example.com', 'password123', FALSE, '2024-07-01 10:00:00');
 
+-- 단과대 생성
+INSERT INTO units (id, name, organization_id)
+VALUES (1, '사회과학대학', 1),
+       (2, '기타', 1),
+       (3, '영어대학', 1);
+
 -- 팀 생성
-INSERT INTO teams (id, unit, name, logo_image_url, team_color)
-VALUES (1, 'SOCIAL_SCIENCES', '팀A', 'http://example.com/logo_a.png', '#FF0000'),
-       (2, 'ETC', '팀B', 'http://example.com/logo_b.png', '#0000FF'),
-       (3, 'ENGLISH', '팀C', 'http://example.com/logo_c.png', '#0000FF'),
-       (4, 'SOCIAL_SCIENCES', '팀D', 'http://example.com/logo_d.png', '#0000FF');
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color)
+VALUES (1, 1, '팀A', 'http://example.com/logo_a.png', '#FF0000'),
+       (2, 2, '팀B', 'http://example.com/logo_b.png', '#0000FF'),
+       (3, 3, '팀C', 'http://example.com/logo_c.png', '#0000FF'),
+       (4, 1, '팀D', 'http://example.com/logo_d.png', '#0000FF');
 
 -- 선수 생성
 INSERT INTO players (id, name, student_number)


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #557 

## 📝 구현 내용
- Unit을 enum에서 DB 엔티티로 전환 (Organization별 단과대 관리)                                                                                                         
- `units` 테이블 신설, `teams.unit` VARCHAR → `teams.unit_id` FK 변경                                                                                                     
- N+1 방지를 위한 fetch join 추가 