### PR TITLE
fix: NL 선수 파서에서 Organization별 학번 자릿수 검증

### DIFF
--- a/src/main/java/com/sports/server/command/nl/application/NlClient.java
+++ b/src/main/java/com/sports/server/command/nl/application/NlClient.java
@@ -6,5 +6,5 @@ import java.util.List;
 import java.util.Map;
 
 public interface NlClient {
-    NlParseResult parsePlayers(String message, List<Map<String, String>> history);
+    NlParseResult parsePlayers(String message, List<Map<String, String>> history, int studentNumberDigits);
 }

--- a/src/main/java/com/sports/server/command/nl/application/NlService.java
+++ b/src/main/java/com/sports/server/command/nl/application/NlService.java
@@ -71,7 +71,8 @@ public class NlService {
         return buildProcessPreview(request, team, parseResult.players(), member.getOrganization());
     }
 
-    public NlParseResponse parse(NlParseRequest request) {
+    public NlParseResponse parse(NlParseRequest request, Member member) {
+        int studentNumberDigits = member.getOrganization().getStudentNumberDigits();
         NlParseResult parseResult = nlClient.parsePlayers(request.message(), request.history());
 
         if (!parseResult.parsed()) {
@@ -85,7 +86,7 @@ public class NlService {
             return new NlParseResponse(NlErrorMessages.NO_PLAYER_INFO, null);
         }
 
-        return buildParsePreview(request.message(), parseResult.players());
+        return buildParsePreview(request.message(), parseResult.players(), studentNumberDigits);
     }
 
     @Transactional
@@ -206,27 +207,27 @@ public class NlService {
 
     // --- parse 전용 (팀 컨텍스트 없음) ---
 
-    private NlParseResponse buildParsePreview(String message, List<ParsedPlayer> parsedPlayers) {
-        Set<String> originalNineDigits = extractStudentNumbers(message);
+    private NlParseResponse buildParsePreview(String message, List<ParsedPlayer> parsedPlayers, int studentNumberDigits) {
+        Set<String> originalStudentNumbers = extractStudentNumbers(message);
 
         List<NlParseResponse.ParsedPlayerPreview> playerPreviews = new ArrayList<>();
         List<NlFailedLine> failedLines = new ArrayList<>();
-        classifyWithoutTeamContext(parsedPlayers, originalNineDigits, playerPreviews, failedLines);
+        classifyWithoutTeamContext(parsedPlayers, originalStudentNumbers, playerPreviews, failedLines, studentNumberDigits);
 
         String displayMessage = String.format("%d명의 선수가 인식되었습니다.", playerPreviews.size());
         NlParseResponse.Preview preview = new NlParseResponse.Preview(playerPreviews, playerPreviews.size(), failedLines);
         return new NlParseResponse(displayMessage, preview);
     }
 
-    private void classifyWithoutTeamContext(List<ParsedPlayer> parsedPlayers, Set<String> originalNineDigits,
+    private void classifyWithoutTeamContext(List<ParsedPlayer> parsedPlayers, Set<String> originalStudentNumbers,
                                              List<NlParseResponse.ParsedPlayerPreview> playerPreviews,
-                                             List<NlFailedLine> failedLines) {
+                                             List<NlFailedLine> failedLines, int studentNumberDigits) {
         Set<String> seenStudentNumbers = new HashSet<>();
 
         for (int i = 0; i < parsedPlayers.size(); i++) {
             ParsedPlayer parsed = parsedPlayers.get(i);
 
-            NlFailedLine failedLine = validateParsedPlayer(i, parsed, originalNineDigits);
+            NlFailedLine failedLine = validateParsedPlayer(i, parsed, originalStudentNumbers, studentNumberDigits);
             if (failedLine != null) {
                 failedLines.add(failedLine);
                 continue;
@@ -357,19 +358,6 @@ public class NlService {
         if (StudentNumber.isInvalid(parsed.studentNumber(), digits)) {
             return new NlFailedLine(index + 1, parsed.studentNumber(),
                     String.format(ExceptionMessages.PLAYER_STUDENT_NUMBER_INVALID, digits));
-        }
-        if (!originalStudentNumbers.contains(parsed.studentNumber())) {
-            return new NlFailedLine(index + 1, parsed.studentNumber(), NlErrorMessages.STUDENT_NUMBER_NOT_IN_ORIGINAL);
-        }
-        if (!isValidName(parsed.name())) {
-            return new NlFailedLine(index + 1, parsed.studentNumber(), NlErrorMessages.INVALID_PLAYER_NAME);
-        }
-        return null;
-    }
-
-    private NlFailedLine validateParsedPlayer(int index, ParsedPlayer parsed, Set<String> originalStudentNumbers) {
-        if (StudentNumber.isInvalid(parsed.studentNumber())) {
-            return new NlFailedLine(index + 1, parsed.studentNumber(), NlErrorMessages.STUDENT_NUMBER_INVALID);
         }
         if (!originalStudentNumbers.contains(parsed.studentNumber())) {
             return new NlFailedLine(index + 1, parsed.studentNumber(), NlErrorMessages.STUDENT_NUMBER_NOT_IN_ORIGINAL);

--- a/src/main/java/com/sports/server/command/nl/application/NlService.java
+++ b/src/main/java/com/sports/server/command/nl/application/NlService.java
@@ -55,7 +55,8 @@ public class NlService {
         Team team = entityUtils.getEntity(request.teamId(), Team.class);
         validateTeamBelongsToLeague(league, team);
 
-        NlParseResult parseResult = nlClient.parsePlayers(request.message(), request.history());
+        int studentNumberDigits = member.getOrganization().getStudentNumberDigits();
+        NlParseResult parseResult = nlClient.parsePlayers(request.message(), request.history(), studentNumberDigits);
 
         if (!parseResult.parsed()) {
             return new NlProcessResponse(
@@ -71,9 +72,10 @@ public class NlService {
         return buildProcessPreview(request, team, parseResult.players(), member.getOrganization());
     }
 
+    @Transactional(readOnly = true)
     public NlParseResponse parse(NlParseRequest request, Member member) {
         int studentNumberDigits = member.getOrganization().getStudentNumberDigits();
-        NlParseResult parseResult = nlClient.parsePlayers(request.message(), request.history());
+        NlParseResult parseResult = nlClient.parsePlayers(request.message(), request.history(), studentNumberDigits);
 
         if (!parseResult.parsed()) {
             return new NlParseResponse(

--- a/src/main/java/com/sports/server/command/nl/infra/NlGeminiClient.java
+++ b/src/main/java/com/sports/server/command/nl/infra/NlGeminiClient.java
@@ -86,14 +86,14 @@ public class NlGeminiClient implements NlClient {
     );
 
     @Override
-    public NlParseResult parsePlayers(String message, List<Map<String, String>> history) {
-        GeminiFunctionCallResponse response = callGeminiApiWithRetry(message, history);
+    public NlParseResult parsePlayers(String message, List<Map<String, String>> history, int studentNumberDigits) {
+        GeminiFunctionCallResponse response = callGeminiApiWithRetry(message, history, studentNumberDigits);
         return toParseResult(response);
     }
 
-    private GeminiFunctionCallResponse callGeminiApiWithRetry(String message, List<Map<String, String>> history) {
+    private GeminiFunctionCallResponse callGeminiApiWithRetry(String message, List<Map<String, String>> history, int studentNumberDigits) {
         List<Map<String, Object>> contents = buildContents(message, history);
-        Map<String, Object> body = buildRequestBody(contents);
+        Map<String, Object> body = buildRequestBody(contents, studentNumberDigits);
 
         for (int attempt = 0; attempt <= MAX_RETRY; attempt++) {
             int currentKeyIndex = keyIndex.getAndUpdate(i -> (i + 1) % apiKeys.size());
@@ -120,10 +120,17 @@ public class NlGeminiClient implements NlClient {
         throw new CustomException(HttpStatus.TOO_MANY_REQUESTS, "AI 서비스가 일시적으로 사용량이 많습니다. 잠시 후 다시 시도해주세요.");
     }
 
-    private Map<String, Object> buildRequestBody(List<Map<String, Object>> contents) {
+    private Map<String, Object> buildRequestBody(List<Map<String, Object>> contents, int studentNumberDigits) {
+        String perCallInstruction = String.format(
+                "이 요청의 학번 자릿수는 정확히 %d자리다. %d자리가 아닌 숫자는 학번으로 추출하지 마.",
+                studentNumberDigits, studentNumberDigits
+        );
         return Map.of(
                 "systemInstruction", Map.of(
-                        "parts", List.of(Map.of("text", systemPrompt))
+                        "parts", List.of(
+                                Map.of("text", systemPrompt),
+                                Map.of("text", perCallInstruction)
+                        )
                 ),
                 "contents", contents,
                 "tools", List.of(Map.of(

--- a/src/main/java/com/sports/server/command/nl/infra/NlGeminiClient.java
+++ b/src/main/java/com/sports/server/command/nl/infra/NlGeminiClient.java
@@ -74,7 +74,7 @@ public class NlGeminiClient implements NlClient {
                                             "type", "OBJECT",
                                             "properties", Map.of(
                                                     "name", Map.of("type", "STRING", "description", "선수 이름"),
-                                                    "studentNumber", Map.of("type", "STRING", "description", "9자리 학번"),
+                                                    "studentNumber", Map.of("type", "STRING", "description", "9자리 또는 10자리 학번"),
                                                     "jerseyNumber", Map.of("type", "INTEGER", "description", "등번호 (1~99)")
                                             ),
                                             "required", List.of("name", "studentNumber")

--- a/src/main/java/com/sports/server/command/nl/presentation/NlController.java
+++ b/src/main/java/com/sports/server/command/nl/presentation/NlController.java
@@ -33,8 +33,8 @@ public class NlController {
     }
 
     @PostMapping("/parse")
-    public ResponseEntity<NlParseResponse> parse(@Valid @RequestBody NlParseRequest request) {
-        return ResponseEntity.ok(nlService.parse(request));
+    public ResponseEntity<NlParseResponse> parse(@Valid @RequestBody NlParseRequest request, Member member) {
+        return ResponseEntity.ok(nlService.parse(request, member));
     }
 
     @PostMapping("/register-team")

--- a/src/test/java/com/sports/server/command/nl/acceptance/NlAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/nl/acceptance/NlAcceptanceTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.jdbc.Sql;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -37,7 +38,7 @@ public class NlAcceptanceTest extends AcceptanceTest {
     @Test
     void 선수_정보를_파싱하여_프리뷰를_반환한다() {
         // given
-        given(nlClient.parsePlayers(anyString(), anyList()))
+        given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                 .willReturn(NlParseResult.ofPlayers(List.of(
                         new ParsedPlayer("홍길동", "202600001", 10),
                         new ParsedPlayer("김철수", "202600002", 7)
@@ -70,7 +71,7 @@ public class NlAcceptanceTest extends AcceptanceTest {
     @Test
     void 팀_컨텍스트_없이_선수_정보를_파싱한다() {
         // given
-        given(nlClient.parsePlayers(anyString(), anyList()))
+        given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                 .willReturn(NlParseResult.ofPlayers(List.of(
                         new ParsedPlayer("홍길동", "202600001", 10),
                         new ParsedPlayer("김철수", "202600002", 7)
@@ -177,7 +178,7 @@ public class NlAcceptanceTest extends AcceptanceTest {
     @Test
     void 기존_선수를_다른_팀에_배정한다() {
         // given: player 1(진승희, 202101001)은 team 3에 소속, team 1에는 미소속
-        given(nlClient.parsePlayers(anyString(), anyList()))
+        given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                 .willReturn(NlParseResult.ofPlayers(List.of(
                         new ParsedPlayer("진승희", "202101001", 5)
                 )));

--- a/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
+++ b/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
@@ -218,7 +218,7 @@ class NlServiceTest {
                     )));
 
             // when
-            NlParseResponse response = nlService.parse(request);
+            NlParseResponse response = nlService.parse(request, mockMember);
 
             // then
             assertThat(response.preview()).isNotNull();
@@ -242,7 +242,7 @@ class NlServiceTest {
                     )));
 
             // when
-            NlParseResponse response = nlService.parse(request);
+            NlParseResponse response = nlService.parse(request, mockMember);
 
             // then
             assertThat(response.preview().players()).hasSize(1);
@@ -263,7 +263,7 @@ class NlServiceTest {
                     )));
 
             // when
-            NlParseResponse response = nlService.parse(request);
+            NlParseResponse response = nlService.parse(request, mockMember);
 
             // then
             assertThat(response.preview().players()).isEmpty();
@@ -282,7 +282,7 @@ class NlServiceTest {
                     .willReturn(NlParseResult.ofText("선수 정보를 입력해주세요."));
 
             // when
-            NlParseResponse response = nlService.parse(request);
+            NlParseResponse response = nlService.parse(request, mockMember);
 
             // then
             assertThat(response.preview()).isNull();

--- a/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
+++ b/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
@@ -96,7 +96,7 @@ class NlServiceTest {
             );
 
             given(entityUtils.getEntity(1L, Team.class)).willReturn(mockTeam);
-            given(nlClient.parsePlayers(anyString(), anyList()))
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                     .willReturn(NlParseResult.ofPlayers(List.of(
                             new ParsedPlayer("홍길동", "202600001", 10),
                             new ParsedPlayer("김철수", "202600002", 7)
@@ -128,7 +128,7 @@ class NlServiceTest {
             given(existingPlayer.getId()).willReturn(42L);
 
             given(entityUtils.getEntity(1L, Team.class)).willReturn(mockTeam);
-            given(nlClient.parsePlayers(anyString(), anyList()))
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                     .willReturn(NlParseResult.ofPlayers(List.of(
                             new ParsedPlayer("홍길동", "202600001", 10)
                     )));
@@ -157,7 +157,7 @@ class NlServiceTest {
             given(existingPlayer.getId()).willReturn(42L);
 
             given(entityUtils.getEntity(1L, Team.class)).willReturn(mockTeam);
-            given(nlClient.parsePlayers(anyString(), anyList()))
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                     .willReturn(NlParseResult.ofPlayers(List.of(
                             new ParsedPlayer("홍길동", "202600001", 10)
                     )));
@@ -181,7 +181,7 @@ class NlServiceTest {
             );
 
             given(entityUtils.getEntity(1L, Team.class)).willReturn(mockTeam);
-            given(nlClient.parsePlayers(anyString(), anyList()))
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                     .willReturn(NlParseResult.ofPlayers(List.of(
                             new ParsedPlayer("홍길동", "202600001", 10),
                             new ParsedPlayer("김철수", "202600001", 7)
@@ -211,7 +211,7 @@ class NlServiceTest {
                     List.of(), "홍길동 202600001 10\n김철수 202600002 7"
             );
 
-            given(nlClient.parsePlayers(anyString(), anyList()))
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                     .willReturn(NlParseResult.ofPlayers(List.of(
                             new ParsedPlayer("홍길동", "202600001", 10),
                             new ParsedPlayer("김철수", "202600002", 7)
@@ -235,7 +235,7 @@ class NlServiceTest {
                     List.of(), "홍길동 202600001 10\n김철수 202600001 7"
             );
 
-            given(nlClient.parsePlayers(anyString(), anyList()))
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                     .willReturn(NlParseResult.ofPlayers(List.of(
                             new ParsedPlayer("홍길동", "202600001", 10),
                             new ParsedPlayer("김철수", "202600001", 7)
@@ -257,7 +257,7 @@ class NlServiceTest {
                     List.of(), "홍길동 20260001 10"
             );
 
-            given(nlClient.parsePlayers(anyString(), anyList()))
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                     .willReturn(NlParseResult.ofPlayers(List.of(
                             new ParsedPlayer("홍길동", "202600001", 10)
                     )));
@@ -278,7 +278,7 @@ class NlServiceTest {
                     List.of(), "안녕하세요"
             );
 
-            given(nlClient.parsePlayers(anyString(), anyList()))
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
                     .willReturn(NlParseResult.ofText("선수 정보를 입력해주세요."));
 
             // when

--- a/src/test/java/com/sports/server/command/nl/infra/NlGeminiClientManualTest.java
+++ b/src/test/java/com/sports/server/command/nl/infra/NlGeminiClientManualTest.java
@@ -25,7 +25,7 @@ class NlGeminiClientManualTest {
     @DisplayName("정형 텍스트 파싱 - 공백 구분")
     void 정형_텍스트_공백_구분() {
         NlParseResult result = nlGeminiClient.parsePlayers(
-                "홍길동 202600001 10\n김철수 202600002 7\n이영희 202600003 5", List.of());
+                "홍길동 202600001 10\n김철수 202600002 7\n이영희 202600003 5", List.of(), 9);
 
         assertThat(result.parsed()).isTrue();
         assertThat(result.players()).hasSizeGreaterThanOrEqualTo(3);
@@ -35,7 +35,7 @@ class NlGeminiClientManualTest {
     @DisplayName("비정형 텍스트 파싱 - 괄호/쉼표 혼용")
     void 비정형_텍스트_파싱() {
         NlParseResult result = nlGeminiClient.parsePlayers(
-                "홍길동(202600001) 10번, 김철수 202600002번 7, 이영희 / 202600003 / 5번", List.of());
+                "홍길동(202600001) 10번, 김철수 202600002번 7, 이영희 / 202600003 / 5번", List.of(), 9);
 
         assertThat(result.parsed()).isTrue();
         assertThat(result.players()).isNotEmpty();
@@ -45,7 +45,7 @@ class NlGeminiClientManualTest {
     @DisplayName("탭 구분 텍스트 파싱 - 엑셀 복붙")
     void 탭_구분_텍스트_파싱() {
         NlParseResult result = nlGeminiClient.parsePlayers(
-                "홍길동\t202600001\t10\n김철수\t202600002\t7\n이영희\t202600003\t5", List.of());
+                "홍길동\t202600001\t10\n김철수\t202600002\t7\n이영희\t202600003\t5", List.of(), 9);
 
         assertThat(result.parsed()).isTrue();
         assertThat(result.players()).hasSizeGreaterThanOrEqualTo(3);
@@ -55,7 +55,7 @@ class NlGeminiClientManualTest {
     @DisplayName("등번호 없는 텍스트 파싱")
     void 등번호_없는_텍스트() {
         NlParseResult result = nlGeminiClient.parsePlayers(
-                "홍길동 202600001\n김철수 202600002", List.of());
+                "홍길동 202600001\n김철수 202600002", List.of(), 9);
 
         assertThat(result.parsed()).isTrue();
         assertThat(result.players()).hasSize(2);
@@ -66,7 +66,7 @@ class NlGeminiClientManualTest {
     @DisplayName("순서 뒤바뀐 텍스트 파싱")
     void 순서_뒤바뀐_텍스트() {
         NlParseResult result = nlGeminiClient.parsePlayers(
-                "202600001 홍길동 10\n202600002 김철수 7", List.of());
+                "202600001 홍길동 10\n202600002 김철수 7", List.of(), 9);
 
         assertThat(result.parsed()).isTrue();
         assertThat(result.players()).hasSize(2);

--- a/src/test/java/com/sports/server/command/nl/presentation/NlControllerTest.java
+++ b/src/test/java/com/sports/server/command/nl/presentation/NlControllerTest.java
@@ -110,7 +110,7 @@ public class NlControllerTest extends DocumentationTest {
                 )
         );
 
-        given(nlService.parse(any())).willReturn(response);
+        given(nlService.parse(any(), any())).willReturn(response);
 
         Map<String, Object> request = Map.of(
                 "history", List.of(),


### PR DESCRIPTION
## 이슈
closes #565

## 변경 내용
`/nl/parse` 응답에서 10자리 학번 선수가 드롭되는 문제 수정. 기존 구현은
- Gemini Function Calling 스키마가 `"9자리 학번"` 으로 하드코딩
- 시스템 프롬프트가 `"정확히 9자리"` 요구
- `NlService.parse()` 가 org별 자릿수를 사용하지 않음 (9~10 공통 검증만)

경희대(10자리) admin이 `경희일 1234543221 12` 를 입력해도 Gemini가 10자리 학번을 추출조차 하지 않아 응답에서 누락됐다.

### 스펙터-서버 변경
- `NlGeminiClient.java`: 스키마 description `"9자리 학번"` → `"9자리 또는 10자리 학번"`
- `NlController.parse`: `Member` 파라미터 추가 (`/nl/process`와 동일 패턴)
- `NlService.parse(request, member)`: `member.getOrganization().getStudentNumberDigits()` 사용해 org별 검증 수행
- 사용되지 않게 된 단일 인자 `validateParsedPlayer` 삭제

### 프롬프트 변경 (별도 서브모듈 PR)
hufscheer/be-config#10 — `application-dev.yml` / `application-prod.yml` 프롬프트를 9자리 → 9자리/10자리 허용으로 완화.

> be-config PR 머지 후 이 PR에 서브모듈 포인터 bump 커밋을 추가해야 한다.

## 테스트
- [x] `NlServiceTest` 전체 통과 (Parse 4건 + Process/Execute/RegisterTeam/CheckDup)
- [x] `NlControllerTest` 전체 통과 (`팀_컨텍스트_없이_선수_정보를_파싱한다` 포함)
- [x] `NlAcceptanceTest` 전체 통과 (`팀_컨텍스트_없이_선수_정보를_파싱한다` 포함, JWT 쿠키로 Member 주입 확인)

## 영향 API
- `POST /nl/parse`
  - 요청 body: 변경 없음 (`history`, `message`)
  - 이제 **로그인 필수** (쿠키 `HCC_SES` 기반으로 Member 주입). 기존에도 admin 전용 API였으므로 프론트 영향 없음.
  - 응답: 10자리 학번 선수가 정상 포함됨. 계정 org의 `studentNumberDigits`에 맞지 않는 학번은 `preview.parseFailedLines`에 사유와 함께 표시.

## 프론트 참고
변경 사항 없음. 기존 요청 형식 그대로 사용 가능.

- 경희대 admin(10자리 org): 9자리 학번을 입력하면 `parseFailedLines`에 "학번은 10자리 숫자여야 합니다." 로 안내 표시됨
- 한국외대 manager(9자리 org): 10자리 학번을 입력하면 동일 형태로 "학번은 9자리 숫자여야 합니다." 안내