### PR TITLE
feat: NL 파서에 계정 자릿수 불일치 학번 선제 검증 추가

### DIFF
--- a/src/main/java/com/sports/server/command/nl/application/NlService.java
+++ b/src/main/java/com/sports/server/command/nl/application/NlService.java
@@ -176,6 +176,8 @@ public class NlService {
             Player existingPlayer = existingPlayerMap.get(parsed.studentNumber());
             playerPreviews.add(classifyPlayer(parsed, existingPlayer, teamPlayerIdSet));
         }
+
+        addDigitMismatchFailures(originalStudentNumbers, studentNumberDigits, failedLines);
     }
 
     private PlayerPreview classifyPlayer(ParsedPlayer parsed, Player existingPlayer, Set<Long> teamPlayerIdSet) {
@@ -243,6 +245,8 @@ public class NlService {
                     parsed.name(), parsed.studentNumber(), parsed.jerseyNumber()
             ));
         }
+
+        addDigitMismatchFailures(originalStudentNumbers, studentNumberDigits, failedLines);
     }
 
     @Transactional(readOnly = true)
@@ -368,6 +372,26 @@ public class NlService {
             return new NlFailedLine(index + 1, parsed.studentNumber(), NlErrorMessages.INVALID_PLAYER_NAME);
         }
         return null;
+    }
+
+    private void addDigitMismatchFailures(Set<String> originalStudentNumbers, int digits, List<NlFailedLine> failedLines) {
+        Set<String> alreadyReported = failedLines.stream()
+                .map(NlFailedLine::studentNumber)
+                .collect(Collectors.toSet());
+
+        for (String studentNumber : originalStudentNumbers) {
+            if (studentNumber.length() == digits) {
+                continue;
+            }
+            if (!alreadyReported.add(studentNumber)) {
+                continue;
+            }
+            failedLines.add(new NlFailedLine(
+                    failedLines.size() + 1,
+                    studentNumber,
+                    String.format(ExceptionMessages.PLAYER_STUDENT_NUMBER_INVALID, digits)
+            ));
+        }
     }
 
     private Map<String, Player> findExistingPlayerMap(List<String> studentNumbers) {

--- a/src/main/java/com/sports/server/command/nl/application/NlService.java
+++ b/src/main/java/com/sports/server/command/nl/application/NlService.java
@@ -133,7 +133,7 @@ public class NlService {
     // --- process 전용 (팀 컨텍스트 포함) ---
 
     private NlProcessResponse buildProcessPreview(NlProcessRequest request, Team team, List<ParsedPlayer> parsedPlayers, Organization organization) {
-        Set<String> originalStudentNumbers = extractStudentNumbers(request.message());
+        Map<String, Integer> originalStudentNumberLineMap = extractStudentNumberLineMap(request.message());
         Set<Long> teamPlayerIdSet = new HashSet<>(teamPlayerRepository.findPlayerIdsByTeamId(request.teamId()));
         Map<String, Player> existingPlayerMap = findExistingPlayerMap(
                 parsedPlayers.stream().map(ParsedPlayer::studentNumber).filter(Objects::nonNull).toList()
@@ -141,7 +141,7 @@ public class NlService {
 
         List<PlayerPreview> playerPreviews = new ArrayList<>();
         List<NlFailedLine> failedLines = new ArrayList<>();
-        classifyWithTeamContext(parsedPlayers, originalStudentNumbers, teamPlayerIdSet, existingPlayerMap, playerPreviews, failedLines, organization.getStudentNumberDigits());
+        classifyWithTeamContext(parsedPlayers, originalStudentNumberLineMap, teamPlayerIdSet, existingPlayerMap, playerPreviews, failedLines, organization.getStudentNumberDigits());
 
         Summary summary = buildSummary(playerPreviews);
         int registrableCount = summary.newPlayers() + summary.existingPlayers();
@@ -154,7 +154,7 @@ public class NlService {
         return new NlProcessResponse(displayMessage, preview);
     }
 
-    private void classifyWithTeamContext(List<ParsedPlayer> parsedPlayers, Set<String> originalStudentNumbers,
+    private void classifyWithTeamContext(List<ParsedPlayer> parsedPlayers, Map<String, Integer> originalStudentNumberLineMap,
                                          Set<Long> teamPlayerIdSet, Map<String, Player> existingPlayerMap,
                                          List<PlayerPreview> playerPreviews, List<NlFailedLine> failedLines,
                                          int studentNumberDigits) {
@@ -163,7 +163,7 @@ public class NlService {
         for (int i = 0; i < parsedPlayers.size(); i++) {
             ParsedPlayer parsed = parsedPlayers.get(i);
 
-            NlFailedLine failedLine = validateParsedPlayer(i, parsed, originalStudentNumbers, studentNumberDigits);
+            NlFailedLine failedLine = validateParsedPlayer(i, parsed, originalStudentNumberLineMap, studentNumberDigits);
             if (failedLine != null) {
                 failedLines.add(failedLine);
                 continue;
@@ -177,7 +177,7 @@ public class NlService {
             playerPreviews.add(classifyPlayer(parsed, existingPlayer, teamPlayerIdSet));
         }
 
-        addDigitMismatchFailures(originalStudentNumbers, studentNumberDigits, failedLines);
+        addDigitMismatchFailures(originalStudentNumberLineMap, studentNumberDigits, failedLines);
     }
 
     private PlayerPreview classifyPlayer(ParsedPlayer parsed, Player existingPlayer, Set<Long> teamPlayerIdSet) {
@@ -212,18 +212,18 @@ public class NlService {
     // --- parse 전용 (팀 컨텍스트 없음) ---
 
     private NlParseResponse buildParsePreview(String message, List<ParsedPlayer> parsedPlayers, int studentNumberDigits) {
-        Set<String> originalStudentNumbers = extractStudentNumbers(message);
+        Map<String, Integer> originalStudentNumberLineMap = extractStudentNumberLineMap(message);
 
         List<NlParseResponse.ParsedPlayerPreview> playerPreviews = new ArrayList<>();
         List<NlFailedLine> failedLines = new ArrayList<>();
-        classifyWithoutTeamContext(parsedPlayers, originalStudentNumbers, playerPreviews, failedLines, studentNumberDigits);
+        classifyWithoutTeamContext(parsedPlayers, originalStudentNumberLineMap, playerPreviews, failedLines, studentNumberDigits);
 
         String displayMessage = String.format("%d명의 선수가 인식되었습니다.", playerPreviews.size());
         NlParseResponse.Preview preview = new NlParseResponse.Preview(playerPreviews, playerPreviews.size(), failedLines);
         return new NlParseResponse(displayMessage, preview);
     }
 
-    private void classifyWithoutTeamContext(List<ParsedPlayer> parsedPlayers, Set<String> originalStudentNumbers,
+    private void classifyWithoutTeamContext(List<ParsedPlayer> parsedPlayers, Map<String, Integer> originalStudentNumberLineMap,
                                              List<NlParseResponse.ParsedPlayerPreview> playerPreviews,
                                              List<NlFailedLine> failedLines, int studentNumberDigits) {
         Set<String> seenStudentNumbers = new HashSet<>();
@@ -231,7 +231,7 @@ public class NlService {
         for (int i = 0; i < parsedPlayers.size(); i++) {
             ParsedPlayer parsed = parsedPlayers.get(i);
 
-            NlFailedLine failedLine = validateParsedPlayer(i, parsed, originalStudentNumbers, studentNumberDigits);
+            NlFailedLine failedLine = validateParsedPlayer(i, parsed, originalStudentNumberLineMap, studentNumberDigits);
             if (failedLine != null) {
                 failedLines.add(failedLine);
                 continue;
@@ -246,7 +246,7 @@ public class NlService {
             ));
         }
 
-        addDigitMismatchFailures(originalStudentNumbers, studentNumberDigits, failedLines);
+        addDigitMismatchFailures(originalStudentNumberLineMap, studentNumberDigits, failedLines);
     }
 
     @Transactional(readOnly = true)
@@ -360,26 +360,28 @@ public class NlService {
 
     // --- 공용 유틸 ---
 
-    private NlFailedLine validateParsedPlayer(int index, ParsedPlayer parsed, Set<String> originalStudentNumbers, int digits) {
+    private NlFailedLine validateParsedPlayer(int index, ParsedPlayer parsed, Map<String, Integer> originalStudentNumberLineMap, int digits) {
+        int lineIndex = originalStudentNumberLineMap.getOrDefault(parsed.studentNumber(), index + 1);
         if (StudentNumber.isInvalid(parsed.studentNumber(), digits)) {
-            return new NlFailedLine(index + 1, parsed.studentNumber(),
+            return new NlFailedLine(lineIndex, parsed.studentNumber(),
                     String.format(ExceptionMessages.PLAYER_STUDENT_NUMBER_INVALID, digits));
         }
-        if (!originalStudentNumbers.contains(parsed.studentNumber())) {
-            return new NlFailedLine(index + 1, parsed.studentNumber(), NlErrorMessages.STUDENT_NUMBER_NOT_IN_ORIGINAL);
+        if (!originalStudentNumberLineMap.containsKey(parsed.studentNumber())) {
+            return new NlFailedLine(lineIndex, parsed.studentNumber(), NlErrorMessages.STUDENT_NUMBER_NOT_IN_ORIGINAL);
         }
         if (!isValidName(parsed.name())) {
-            return new NlFailedLine(index + 1, parsed.studentNumber(), NlErrorMessages.INVALID_PLAYER_NAME);
+            return new NlFailedLine(lineIndex, parsed.studentNumber(), NlErrorMessages.INVALID_PLAYER_NAME);
         }
         return null;
     }
 
-    private void addDigitMismatchFailures(Set<String> originalStudentNumbers, int digits, List<NlFailedLine> failedLines) {
+    private void addDigitMismatchFailures(Map<String, Integer> originalStudentNumberLineMap, int digits, List<NlFailedLine> failedLines) {
         Set<String> alreadyReported = failedLines.stream()
                 .map(NlFailedLine::studentNumber)
                 .collect(Collectors.toSet());
 
-        for (String studentNumber : originalStudentNumbers) {
+        for (Map.Entry<String, Integer> entry : originalStudentNumberLineMap.entrySet()) {
+            String studentNumber = entry.getKey();
             if (studentNumber.length() == digits) {
                 continue;
             }
@@ -387,7 +389,7 @@ public class NlService {
                 continue;
             }
             failedLines.add(new NlFailedLine(
-                    failedLines.size() + 1,
+                    entry.getValue(),
                     studentNumber,
                     String.format(ExceptionMessages.PLAYER_STUDENT_NUMBER_INVALID, digits)
             ));
@@ -409,12 +411,15 @@ public class NlService {
                 .orElseThrow(() -> new BadRequestException(NlErrorMessages.TEAM_NOT_IN_LEAGUE));
     }
 
-    private Set<String> extractStudentNumbers(String text) {
-        Set<String> numbers = new HashSet<>();
-        Matcher matcher = STUDENT_NUMBER_PATTERN.matcher(text);
-        while (matcher.find()) {
-            numbers.add(matcher.group());
+    private Map<String, Integer> extractStudentNumberLineMap(String text) {
+        Map<String, Integer> lineMap = new LinkedHashMap<>();
+        String[] lines = text.split("\\r?\\n");
+        for (int i = 0; i < lines.length; i++) {
+            Matcher matcher = STUDENT_NUMBER_PATTERN.matcher(lines[i]);
+            while (matcher.find()) {
+                lineMap.putIfAbsent(matcher.group(), i + 1);
+            }
         }
-        return numbers;
+        return lineMap;
     }
 }

--- a/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
+++ b/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -308,8 +309,8 @@ class NlServiceTest {
             // then
             assertThat(response.preview().players()).hasSize(1);
             assertThat(response.preview().parseFailedLines())
-                    .extracting(NlFailedLine::studentNumber)
-                    .contains("123456789");
+                    .extracting(NlFailedLine::studentNumber, NlFailedLine::index)
+                    .contains(tuple("123456789", 2));
         }
     }
 

--- a/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
+++ b/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
@@ -288,6 +288,29 @@ class NlServiceTest {
             assertThat(response.preview()).isNull();
             assertThat(response.displayMessage()).isEqualTo("선수 정보를 입력해주세요.");
         }
+
+        @Test
+        @DisplayName("계정 자릿수와 다른 학번은 Gemini 결과와 무관하게 failedLines에 포함된다")
+        void 자릿수_불일치_학번_failedLines_포함() {
+            // given: 10자리 계정인데 원문에 9자리 학번이 섞여 있고 Gemini가 이를 누락
+            given(mockMember.getOrganization().getStudentNumberDigits()).willReturn(10);
+            NlParseRequest request = new NlParseRequest(
+                    List.of(), "경희일 1234543221 12\n경희이 123456789 2"
+            );
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
+                    .willReturn(NlParseResult.ofPlayers(List.of(
+                            new ParsedPlayer("경희일", "1234543221", 12)
+                    )));
+
+            // when
+            NlParseResponse response = nlService.parse(request, mockMember);
+
+            // then
+            assertThat(response.preview().players()).hasSize(1);
+            assertThat(response.preview().parseFailedLines())
+                    .extracting(NlFailedLine::studentNumber)
+                    .contains("123456789");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 이슈
close #569

## 변경 내용
- `NlService.addDigitMismatchFailures` 헬퍼 추가
- `classifyWithTeamContext`, `classifyWithoutTeamContext` 끝에서 호출
- 원문 정규식 추출 결과 중 계정 자릿수와 다른 값을 `failedLines`에 선제적으로 추가
- Gemini가 누락하든 잘못 뽑든 동일한 이유 메시지(`학번은 N자리 숫자여야 합니다`)로 안내되도록 보장
- `extractStudentNumbers(String) → Set<String>` → `extractStudentNumberLineMap(String) → Map<String, Integer>`로 대체 (LinkedHashMap, 학번→원문 라인번호)
- `validateParsedPlayer`, `addDigitMismatchFailures` 둘 다 원문 라인번호를 `index`로 사용

## 배경
#565 수정으로 Gemini에 per-call 자릿수 제약을 주입했으나, Gemini가 제약에 순응하면 불일치 학번이 응답에서 사라져 사용자가 누락 이유를 알 수 없음 (#569 참고).

## 테스트
- `NlServiceTest.자릿수_불일치_학번_failedLines_포함` 케이스 추가
  - 10자리 계정 + 원문에 9자리 섞인 입력 + Gemini가 9자리 누락 → `parseFailedLines`에 9자리 포함 + `index == 2` (원문 2번째 라인) 확인
- NL 관련 전체 테스트 통과

## 영향 API
- `POST /nl/parse`, `POST /nl/process` — 응답 `preview.parseFailedLines`에 자릿수 불일치 학번이 포함될 수 있음 (기존 구조 재사용, 신규 필드 없음)

## 프론트 참고
- 기존 `parseFailedLines` 렌더링 로직 그대로 사용 가능
- 자릿수 불일치 케이스 노출이 이전보다 잦아질 수 있음 (긍정적)
- `failedLines[].index`가 **원문 입력 라인 번호** 기준으로 통일됨 (Gemini가 순서를 바꿔도 원문 기준 유지)
- `players[].index`와 `failedLines[].index`를 합쳐 정렬하면 원문 순서 그대로 렌더링 가능