### PR TITLE
팀 조회 시 토큰이 필요하지 않도록 매니저 전용 경로 분리

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -352,6 +352,14 @@ operation::team-query-controller-test/팀별보기_페이지를_조회한다[sni
 
 operation::team-query-controller-test/단과대별_팀_유무를_조회한다[snippets='http-request,query-parameters,http-response,response-fields']
 
+=== [매니저] 소속 기준 단과대별 팀 유무 조회
+
+operation::team-manager-query-controller-test/매니저의_소속_기준으로_단과대별_팀_유무를_조회한다[snippets='http-request,request-cookies,query-parameters,http-response,response-fields']
+
+=== [매니저] 소속 기준 전체 팀 조회
+
+operation::team-manager-query-controller-test/매니저의_소속_기준으로_모든_팀을_조회한다[snippets='http-request,request-cookies,query-parameters,http-response,response-fields']
+
 == 자연어 선수 등록 API
 
 === 선수 정보 파싱 (프리뷰)

--- a/src/main/java/com/sports/server/query/application/TeamQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TeamQueryService.java
@@ -47,14 +47,31 @@ public class TeamQueryService {
     private final LeagueStatisticsQueryRepository leagueStatisticsQueryRepository;
     private final GameQueryRepository gameQueryRepository;
 
+    public List<UnitResponse> getUnitsWithTeams(final SportType sportType) {
+        return getUnitsWithTeamsByOrganization(sportType, null);
+    }
+
     public List<UnitResponse> getUnitsWithTeams(final SportType sportType, final Member member) {
         Long organizationId = member.getOrganization().getId();
-        List<Unit> allUnits = unitRepository.findAllByOrganizationId(organizationId);
+        return getUnitsWithTeamsByOrganization(sportType, organizationId);
+    }
+
+    private List<UnitResponse> getUnitsWithTeamsByOrganization(final SportType sportType, final Long organizationId) {
+        List<Unit> allUnits = organizationId != null
+                ? unitRepository.findAllByOrganizationId(organizationId)
+                : unitRepository.findAll();
         Set<Unit> unitsWithTeam = new HashSet<>(
                 teamQueryDynamicRepository.findDistinctUnitsBySportTypeAndOrganizationId(sportType, organizationId)
         );
         return allUnits.stream()
                 .map(unit -> UnitResponse.of(unit, unitsWithTeam.contains(unit)))
+                .toList();
+    }
+
+    public List<TeamResponse> getAllTeamsByUnits(final List<String> units, final SportType sportType) {
+        List<Team> teams = findTeamsByUnits(units, sportType);
+        return teams.stream()
+                .map(TeamResponse::new)
                 .toList();
     }
 

--- a/src/main/java/com/sports/server/query/application/TeamQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TeamQueryService.java
@@ -69,15 +69,17 @@ public class TeamQueryService {
     }
 
     public List<TeamResponse> getAllTeamsByUnits(final List<String> units, final SportType sportType) {
-        List<Team> teams = findTeamsByUnits(units, sportType);
-        return teams.stream()
-                .map(TeamResponse::new)
-                .toList();
+        return getAllTeamsByUnitsByOrganization(units, sportType, null);
     }
 
     public List<TeamResponse> getAllTeamsByUnits(final List<String> units, final SportType sportType,
                                                     final Member member) {
         Long organizationId = member.getOrganization().getId();
+        return getAllTeamsByUnitsByOrganization(units, sportType, organizationId);
+    }
+
+    private List<TeamResponse> getAllTeamsByUnitsByOrganization(final List<String> units, final SportType sportType,
+                                                                   final Long organizationId) {
         List<Team> teams = findTeamsByUnits(units, sportType, organizationId);
         return teams.stream()
                 .map(TeamResponse::new)

--- a/src/main/java/com/sports/server/query/presentation/TeamManagerQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/TeamManagerQueryController.java
@@ -1,0 +1,35 @@
+package com.sports.server.query.presentation;
+
+import com.sports.server.command.league.domain.SportType;
+import com.sports.server.command.member.domain.Member;
+import com.sports.server.query.application.TeamQueryService;
+import com.sports.server.query.dto.response.TeamResponse;
+import com.sports.server.query.dto.response.UnitResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/manager/teams")
+public class TeamManagerQueryController {
+
+    private final TeamQueryService teamQueryService;
+
+    @GetMapping("/units")
+    public ResponseEntity<List<UnitResponse>> getUnitsWithTeams(
+            @RequestParam(required = false) final SportType sportType,
+            final Member member) {
+        return ResponseEntity.ok(teamQueryService.getUnitsWithTeams(sportType, member));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TeamResponse>> getAllTeams(
+            @RequestParam(required = false) final List<String> units,
+            @RequestParam(required = false) final SportType sportType,
+            final Member member) {
+        return ResponseEntity.ok(teamQueryService.getAllTeamsByUnits(units, sportType, member));
+    }
+}

--- a/src/main/java/com/sports/server/query/presentation/TeamQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/TeamQueryController.java
@@ -1,7 +1,6 @@
 package com.sports.server.query.presentation;
 
 import com.sports.server.command.league.domain.SportType;
-import com.sports.server.command.member.domain.Member;
 import com.sports.server.query.application.GameQueryService;
 import com.sports.server.query.application.TeamQueryService;
 import com.sports.server.query.dto.response.*;
@@ -21,17 +20,15 @@ public class TeamQueryController {
 
     @GetMapping("/units")
     public ResponseEntity<List<UnitResponse>> getUnitsWithTeams(
-            @RequestParam(required = false) final SportType sportType,
-            final Member member) {
-        return ResponseEntity.ok(teamQueryService.getUnitsWithTeams(sportType, member));
+            @RequestParam(required = false) final SportType sportType) {
+        return ResponseEntity.ok(teamQueryService.getUnitsWithTeams(sportType));
     }
 
     @GetMapping
     public ResponseEntity<List<TeamResponse>> getAllTeams(
             @RequestParam(required = false) final List<String> units,
-            @RequestParam(required = false) final SportType sportType,
-            final Member member) {
-        return ResponseEntity.ok(teamQueryService.getAllTeamsByUnits(units, sportType, member));
+            @RequestParam(required = false) final SportType sportType) {
+        return ResponseEntity.ok(teamQueryService.getAllTeamsByUnits(units, sportType));
     }
 
     @GetMapping("/{teamId}")

--- a/src/test/java/com/sports/server/query/acceptance/TeamManagerQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/TeamManagerQueryAcceptanceTest.java
@@ -1,0 +1,93 @@
+package com.sports.server.query.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.sports.server.query.dto.response.TeamResponse;
+import com.sports.server.query.dto.response.UnitResponse;
+import com.sports.server.support.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql(scripts = "/team-query-fixture.sql")
+public class TeamManagerQueryAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 매니저는_자신의_조직에_속한_팀만_조회된다() {
+        // given
+        configureMockJwtForEmail("john.doe@example.com");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .cookie(COOKIE_NAME, mockToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/manager/teams")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<TeamResponse> actual = toResponses(response, TeamResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual).hasSize(7),
+                () -> assertThat(actual)
+                        .extracting(TeamResponse::name)
+                        .doesNotContain("다른조직팀")
+        );
+    }
+
+    @Test
+    void 다른_조직의_매니저는_자신의_조직_팀만_조회된다() {
+        // given
+        configureMockJwtForEmail("non.manager@example.com");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .cookie(COOKIE_NAME, mockToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/manager/teams")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<TeamResponse> actual = toResponses(response, TeamResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual).hasSize(1),
+                () -> assertThat(actual.get(0).name()).isEqualTo("다른조직팀")
+        );
+    }
+
+    @Test
+    void 매니저의_소속_기준으로_단과대별_팀_유무가_조회된다() {
+        // given
+        configureMockJwtForEmail("john.doe@example.com");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .cookie(COOKIE_NAME, mockToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/manager/teams/units")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<UnitResponse> actual = toResponses(response, UnitResponse.class);
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(actual).hasSize(3),
+                () -> assertThat(actual)
+                        .extracting(UnitResponse::unitName)
+                        .containsExactlyInAnyOrder("사회과학대학", "기타", "영어대학")
+        );
+    }
+}

--- a/src/test/java/com/sports/server/query/acceptance/TeamQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/TeamQueryAcceptanceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.sports.server.query.dto.response.TeamResponse;
+import com.sports.server.query.dto.response.UnitResponse;
 import com.sports.server.support.AcceptanceTest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -18,14 +19,10 @@ import org.springframework.test.context.jdbc.Sql;
 public class TeamQueryAcceptanceTest extends AcceptanceTest {
 
     @Test
-    void 자신의_조직에_속한_팀만_조회된다() {
-        // given
-        configureMockJwtForEmail("john.doe@example.com");
-
+    void 전체_팀이_조회된다() {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
-                .cookie(COOKIE_NAME, mockToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .get("/teams")
                 .then().log().all()
@@ -35,33 +32,25 @@ public class TeamQueryAcceptanceTest extends AcceptanceTest {
         List<TeamResponse> actual = toResponses(response, TeamResponse.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(actual).hasSize(7),
-                () -> assertThat(actual)
-                        .extracting(TeamResponse::name)
-                        .doesNotContain("다른조직팀")
+                () -> assertThat(actual).hasSize(8)
         );
     }
 
     @Test
-    void 다른_조직의_멤버는_자신의_조직_팀만_조회된다() {
-        // given
-        configureMockJwtForEmail("non.manager@example.com");
-
+    void 전체_단과대별_팀_유무가_조회된다() {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .when()
-                .cookie(COOKIE_NAME, mockToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .get("/teams")
+                .get("/teams/units")
                 .then().log().all()
                 .extract();
 
         // then
-        List<TeamResponse> actual = toResponses(response, TeamResponse.class);
+        List<UnitResponse> actual = toResponses(response, UnitResponse.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(actual).hasSize(1),
-                () -> assertThat(actual.get(0).name()).isEqualTo("다른조직팀")
+                () -> assertThat(actual).hasSize(4)
         );
     }
 }

--- a/src/test/java/com/sports/server/query/presentation/TeamManagerQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TeamManagerQueryControllerTest.java
@@ -1,0 +1,107 @@
+package com.sports.server.query.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sports.server.command.league.domain.SportType;
+import com.sports.server.command.member.domain.Member;
+import com.sports.server.query.dto.response.TeamResponse;
+import com.sports.server.query.dto.response.UnitResponse;
+import com.sports.server.support.DocumentationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+public class TeamManagerQueryControllerTest extends DocumentationTest {
+
+    @Test
+    void 매니저의_소속_기준으로_단과대별_팀_유무를_조회한다() throws Exception {
+        // given
+        List<UnitResponse> response = List.of(
+                new UnitResponse(1L, "영어대학", true),
+                new UnitResponse(2L, "서양어대학", false),
+                new UnitResponse(3L, "사회과학대학", true),
+                new UnitResponse(4L, "경영대학", true),
+                new UnitResponse(5L, "기타", false)
+        );
+
+        Cookie cookie = new Cookie(COOKIE_NAME, "temp-cookie");
+
+        given(teamQueryService.getUnitsWithTeams(any(SportType.class), any(Member.class))).willReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/manager/teams/units")
+                .param("sportType", "SOCCER")
+                .cookie(cookie)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocsHandler.document(
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        ),
+                        queryParameters(
+                                parameterWithName("sportType").description("종목 필터 (SOCCER, BASKETBALL)").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("단과대 ID"),
+                                fieldWithPath("[].unitName").type(JsonFieldType.STRING).description("단과대 이름"),
+                                fieldWithPath("[].hasTeam").type(JsonFieldType.BOOLEAN).description("해당 단과대에 팀 존재 여부")
+                        )
+                ));
+    }
+
+    @Test
+    void 매니저의_소속_기준으로_모든_팀을_조회한다() throws Exception {
+        // given
+        List<TeamResponse> response = List.of(
+                new TeamResponse(1L, "정치외교학과 PSD", "s3:logoImageUrl1", "사회과학대학", "#F7CAC9", "SOCCER"),
+                new TeamResponse(2L, "국제통상학과 무역풍", "s3:logoImageUrl2", "사회과학대학", "#92A8D1", "SOCCER"),
+                new TeamResponse(3L, "영어영문학과", "s3:logoImageUrl2", "영어대학", "#92A8D1", "SOCCER")
+        );
+
+        Cookie cookie = new Cookie(COOKIE_NAME, "temp-cookie");
+
+        given(teamQueryService.getAllTeamsByUnits(any(), any(), any(Member.class))).willReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/manager/teams")
+                .param("units", "사회과학대학", "영어대학")
+                .param("sportType", "SOCCER")
+                .cookie(cookie)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocsHandler.document(
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        ),
+                        queryParameters(
+                                parameterWithName("units").description("필터링할 소속 리스트").optional(),
+                                parameterWithName("sportType").description("종목 필터 (SOCCER, BASKETBALL)").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("팀의 ID"),
+                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("팀의 이름"),
+                                fieldWithPath("[].logoImageUrl").type(JsonFieldType.STRING).description("팀의 로고 이미지 URL"),
+                                fieldWithPath("[].unit").type(JsonFieldType.STRING).description("팀의 소속 단위"),
+                                fieldWithPath("[].teamColor").type(JsonFieldType.STRING).description("팀의 대표 색상"),
+                                fieldWithPath("[].sportType").type(JsonFieldType.STRING).description("팀의 종목 (SOCCER, BASKETBALL)")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
@@ -37,7 +37,7 @@ public class TeamQueryControllerTest extends DocumentationTest {
                 new UnitResponse(5L, "기타", false)
         );
 
-        given(teamQueryService.getUnitsWithTeams(any(SportType.class), any())).willReturn(response);
+        given(teamQueryService.getUnitsWithTeams(any())).willReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(get("/teams/units")
@@ -68,7 +68,7 @@ public class TeamQueryControllerTest extends DocumentationTest {
                 new TeamResponse(3L, "영어영문학과", "s3:logoImageUrl2", "영어대학", "#92A8D1", "SOCCER")
         );
 
-        given(teamQueryService.getAllTeamsByUnits(any(), any(), any())).willReturn(response);
+        given(teamQueryService.getAllTeamsByUnits(any(), any())).willReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(get("/teams")

--- a/src/test/java/com/sports/server/support/DocumentationTest.java
+++ b/src/test/java/com/sports/server/support/DocumentationTest.java
@@ -23,9 +23,7 @@ import com.sports.server.command.player.presentation.PlayerController;
 import com.sports.server.command.report.application.ReportService;
 import com.sports.server.command.report.presentation.ReportController;
 import com.sports.server.command.team.application.TeamService;
-import com.sports.server.command.team.domain.Team;
 import com.sports.server.command.team.presentation.TeamController;
-import com.sports.server.command.team.presentation.TeamControllerTest;
 import com.sports.server.command.timeline.application.TimelineService;
 import com.sports.server.command.timeline.presentation.TimelineController;
 import com.sports.server.common.log.TimeLogTemplate;
@@ -59,6 +57,7 @@ import org.springframework.test.web.servlet.MockMvc;
                 LeagueQueryController.class,
                 TeamController.class,
                 TeamQueryController.class,
+                TeamManagerQueryController.class,
                 TimelineQueryController.class,
                 AuthController.class,
                 LeagueController.class,


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #570 

 ## 팀 조회 API 경로 분리                                                                                                                                                  
                                                                                                                                                                            
  ### 변경 사항                                                                                                                                                             
  기존 `/teams`, `/teams/units` API에서 인증과 organization 필터링을 제거하고, 매니저 전용 경로를 신설했습니다.
                                                                                                                                                                            
  ### 변경 전                                                                                                                                                             
                                                                                                                                                                            
  | 엔드포인트 | 권한 | 필터링 |                                                                                                                                            
  |---|---|---|
  | `GET /teams` | 인증 필요 | organization 기준 |                                                                                                                          
  | `GET /teams/units` | 인증 필요 | organization 기준 |                                                                                                                    
                                                                                                                                                                            
  ### 변경 지점                                                                                                                                                        
                                                                                                                                                                          
  | 엔드포인트 | 권한 | 필터링 |                                                                                                                                          
  |---|---|---|
  | `GET /teams` | 불필요 | 전체 조회 |
  | `GET /teams/units` | 불필요 | 전체 조회 |                                                                                                                               
  | `GET /manager/teams` | 인증 필요 | organization 기준 |
  | `GET /manager/teams/units` | 인증 필요 | organization 기준 |
