### PR TITLE
[FIX] 축구 후반전 종료 후 '경기 종료' 액션 노출 제거

### DIFF
--- a/src/main/java/com/sports/server/command/league/domain/SoccerQuarter.java
+++ b/src/main/java/com/sports/server/command/league/domain/SoccerQuarter.java
@@ -38,7 +38,7 @@ public enum SoccerQuarter implements Quarter {
 
     @Override
     public boolean canEndGameAfterQuarterEnd() {
-        return canEndGame();
+        return this != SECOND_HALF && canEndGame();
     }
 
     public static Optional<SoccerQuarter> tryResolve(String value) {

--- a/src/test/java/com/sports/server/query/application/AvailableProgressQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/AvailableProgressQueryServiceTest.java
@@ -121,12 +121,11 @@ class AvailableProgressQueryServiceTest extends ServiceTest {
     class 후반전_종료_후 {
 
         @Test
-        void 연장전_시작과_경기_종료_액션을_반환한다() {
+        void 연장전_시작_액션_하나만_반환한다() {
             List<ProgressAction> actions = timelineQueryService.getAvailableProgress(GAME_SECOND_HALF_ENDED).availableActions();
 
-            assertThat(actions).hasSize(2);
+            assertThat(actions).hasSize(1);
             assertAction(actions.get(0), SoccerQuarter.EXTRA_TIME, GameProgressType.QUARTER_START, "연장전 시작");
-            assertAction(actions.get(1), SoccerQuarter.SECOND_HALF, GameProgressType.GAME_END, "경기 종료");
         }
     }
 


### PR DESCRIPTION
## 이슈

- 관련 이슈: #572
- 축구 경기에서 후반전을 종료하면 `경기 종료` 액션이 `연장전 시작`과 함께 노출되던 문제

## 변경 내용

- `SoccerQuarter.canEndGameAfterQuarterEnd()`에서 SECOND_HALF만 `false` 반환하도록 조정
- `FIRST_HALF`: 기존과 동일 (canEndGame=false 라 영향 없음)
- `SECOND_HALF`: **변경** — 후반전 종료 후에는 `연장전 시작`만 노출
- `EXTRA_TIME`: 기존 유지 — 연장전 종료 후 `승부차기 시작 / 경기 종료` 경로 보존
- `PENALTY_SHOOTOUT`: 무관 (canHaveQuarterEnd=false)

## 테스트

- `AvailableProgressQueryServiceTest`
  - `후반전_종료_후` 케이스를 "연장전 시작 액션 하나만 반환한다"로 수정
  - 연장전 종료 후 케이스(승부차기 시작 + 경기 종료), 후반전 진행 중 케이스, 농구 케이스는 영향 없음

## 영향 API

- `GET /games/{gameId}/available-progress`
  - 축구 경기의 `SECOND_HALF` + `QUARTER_END` 상태에서 반환되는 `availableActions`에서 `GAME_END` 항목 제거

## 프론트 참고

- 상태변경 시트에서 기존에 `후반전 종료` 직후 2개 액션이 노출되던 화면이 1개 액션만 노출되도록 바뀜
- 서버 측 상태 전이 허용 범위(`TimelineService.isValidFromQuarterEnd`)는 기존과 동일하므로, 예전에 만들어진 타임라인/직접 API 호출에는 영향 없음