### PR TITLE
[FEAT] NL 실패 라인 응답에 이름/등번호 필드 추가

### DIFF
--- a/src/main/java/com/sports/server/command/nl/application/NlService.java
+++ b/src/main/java/com/sports/server/command/nl/application/NlService.java
@@ -363,14 +363,16 @@ public class NlService {
     private NlFailedLine validateParsedPlayer(int index, ParsedPlayer parsed, Map<String, Integer> originalStudentNumberLineMap, int digits) {
         int lineIndex = originalStudentNumberLineMap.getOrDefault(parsed.studentNumber(), index + 1);
         if (StudentNumber.isInvalid(parsed.studentNumber(), digits)) {
-            return new NlFailedLine(lineIndex, parsed.studentNumber(),
+            return new NlFailedLine(lineIndex, parsed.studentNumber(), parsed.name(), parsed.jerseyNumber(),
                     String.format(ExceptionMessages.PLAYER_STUDENT_NUMBER_INVALID, digits));
         }
         if (!originalStudentNumberLineMap.containsKey(parsed.studentNumber())) {
-            return new NlFailedLine(lineIndex, parsed.studentNumber(), NlErrorMessages.STUDENT_NUMBER_NOT_IN_ORIGINAL);
+            return new NlFailedLine(lineIndex, parsed.studentNumber(), parsed.name(), parsed.jerseyNumber(),
+                    NlErrorMessages.STUDENT_NUMBER_NOT_IN_ORIGINAL);
         }
         if (!isValidName(parsed.name())) {
-            return new NlFailedLine(lineIndex, parsed.studentNumber(), NlErrorMessages.INVALID_PLAYER_NAME);
+            return new NlFailedLine(lineIndex, parsed.studentNumber(), parsed.name(), parsed.jerseyNumber(),
+                    NlErrorMessages.INVALID_PLAYER_NAME);
         }
         return null;
     }
@@ -391,6 +393,8 @@ public class NlService {
             failedLines.add(new NlFailedLine(
                     entry.getValue(),
                     studentNumber,
+                    null,
+                    null,
                     String.format(ExceptionMessages.PLAYER_STUDENT_NUMBER_INVALID, digits)
             ));
         }

--- a/src/main/java/com/sports/server/command/nl/application/NlService.java
+++ b/src/main/java/com/sports/server/command/nl/application/NlService.java
@@ -361,20 +361,20 @@ public class NlService {
     // --- 공용 유틸 ---
 
     private NlFailedLine validateParsedPlayer(int index, ParsedPlayer parsed, Map<String, Integer> originalStudentNumberLineMap, int digits) {
-        int lineIndex = originalStudentNumberLineMap.getOrDefault(parsed.studentNumber(), index + 1);
+        String reason = null;
         if (StudentNumber.isInvalid(parsed.studentNumber(), digits)) {
-            return new NlFailedLine(lineIndex, parsed.studentNumber(), parsed.name(), parsed.jerseyNumber(),
-                    String.format(ExceptionMessages.PLAYER_STUDENT_NUMBER_INVALID, digits));
+            reason = String.format(ExceptionMessages.PLAYER_STUDENT_NUMBER_INVALID, digits);
+        } else if (!originalStudentNumberLineMap.containsKey(parsed.studentNumber())) {
+            reason = NlErrorMessages.STUDENT_NUMBER_NOT_IN_ORIGINAL;
+        } else if (!isValidName(parsed.name())) {
+            reason = NlErrorMessages.INVALID_PLAYER_NAME;
         }
-        if (!originalStudentNumberLineMap.containsKey(parsed.studentNumber())) {
-            return new NlFailedLine(lineIndex, parsed.studentNumber(), parsed.name(), parsed.jerseyNumber(),
-                    NlErrorMessages.STUDENT_NUMBER_NOT_IN_ORIGINAL);
+
+        if (reason == null) {
+            return null;
         }
-        if (!isValidName(parsed.name())) {
-            return new NlFailedLine(lineIndex, parsed.studentNumber(), parsed.name(), parsed.jerseyNumber(),
-                    NlErrorMessages.INVALID_PLAYER_NAME);
-        }
-        return null;
+        int lineIndex = originalStudentNumberLineMap.getOrDefault(parsed.studentNumber(), index + 1);
+        return new NlFailedLine(lineIndex, parsed.studentNumber(), parsed.name(), parsed.jerseyNumber(), reason);
     }
 
     private void addDigitMismatchFailures(Map<String, Integer> originalStudentNumberLineMap, int digits, List<NlFailedLine> failedLines) {

--- a/src/main/java/com/sports/server/command/nl/dto/NlFailedLine.java
+++ b/src/main/java/com/sports/server/command/nl/dto/NlFailedLine.java
@@ -3,6 +3,8 @@ package com.sports.server.command.nl.dto;
 public record NlFailedLine(
         int index,
         String studentNumber,
+        String name,
+        Integer jerseyNumber,
         String reason
 ) {
 }

--- a/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
+++ b/src/test/java/com/sports/server/command/nl/application/NlServiceTest.java
@@ -312,6 +312,51 @@ class NlServiceTest {
                     .extracting(NlFailedLine::studentNumber, NlFailedLine::index)
                     .contains(tuple("123456789", 2));
         }
+
+        @Test
+        @DisplayName("Gemini가 파싱한 9자리 학번은 이름/등번호를 포함해 failedLines에 담긴다")
+        void 자릿수_불일치_Gemini_파싱값_이름_등번호_보존() {
+            // given: 10자리 계정인데 Gemini가 9자리 학번을 이름/등번호와 함께 파싱
+            given(mockMember.getOrganization().getStudentNumberDigits()).willReturn(10);
+            NlParseRequest request = new NlParseRequest(
+                    List.of(), "경희이 123456789 2"
+            );
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
+                    .willReturn(NlParseResult.ofPlayers(List.of(
+                            new ParsedPlayer("경희이", "123456789", 2)
+                    )));
+
+            // when
+            NlParseResponse response = nlService.parse(request, mockMember);
+
+            // then
+            assertThat(response.preview().players()).isEmpty();
+            assertThat(response.preview().parseFailedLines())
+                    .extracting(NlFailedLine::studentNumber, NlFailedLine::name, NlFailedLine::jerseyNumber)
+                    .contains(tuple("123456789", "경희이", 2));
+        }
+
+        @Test
+        @DisplayName("Gemini가 누락한 9자리 학번은 이름/등번호가 null로 담긴다")
+        void 자릿수_불일치_Gemini_누락_이름_등번호_null() {
+            // given: 10자리 계정인데 Gemini가 9자리 학번을 누락
+            given(mockMember.getOrganization().getStudentNumberDigits()).willReturn(10);
+            NlParseRequest request = new NlParseRequest(
+                    List.of(), "경희일 1234543221 12\n경희이 123456789 2"
+            );
+            given(nlClient.parsePlayers(anyString(), anyList(), anyInt()))
+                    .willReturn(NlParseResult.ofPlayers(List.of(
+                            new ParsedPlayer("경희일", "1234543221", 12)
+                    )));
+
+            // when
+            NlParseResponse response = nlService.parse(request, mockMember);
+
+            // then
+            assertThat(response.preview().parseFailedLines())
+                    .extracting(NlFailedLine::studentNumber, NlFailedLine::name, NlFailedLine::jerseyNumber)
+                    .contains(tuple("123456789", null, null));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 이슈

- Closes #575
- 경희대(10자리 학번) 환경에서 9자리 학번이 섞여 들어오면 실패 라인에 학번과 에러 메시지만 내려가고, Gemini가 이름/등번호까지 파싱한 경우에도 해당 정보가 프론트에서 누락되어 UI 표시가 깨지던 문제

## 변경 내용

- `NlFailedLine`에 `name`(nullable), `jerseyNumber`(nullable) 필드 추가
- `validateParsedPlayer`: Gemini가 파싱한 `ParsedPlayer`의 이름/등번호를 실패 라인에 그대로 전달
- `addDigitMismatchFailures`: 원본 regex로 추출된(Gemini가 놓친) 학번은 `name = null`, `jerseyNumber = null`로 채움

## 테스트

- `NlServiceTest`
  - `자릿수_불일치_Gemini_파싱값_이름_등번호_보존`: 9자리 학번을 Gemini가 이름/등번호와 함께 내려준 경우 failedLines에 그대로 보존되는지 검증
  - `자릿수_불일치_Gemini_누락_이름_등번호_null`: Gemini가 학번을 놓친 경우 name/jerseyNumber가 null로 담기는지 검증
  - 기존 `자릿수_불일치_학번_failedLines_포함` 테스트 유지

## 영향 API

- `POST /api/nl/process`, `POST /api/nl/parse` 응답의 `preview.parseFailedLines[]`에 `name`, `jerseyNumber` 필드 추가

## 프론트 참고

- `parseFailedLines[].name`, `parseFailedLines[].jerseyNumber` 새 필드 사용 가능 — 두 값이 **모두 null**이면 Gemini가 해당 줄을 인식하지 못한 케이스(원문 확인 유도), **null이 아니면** Gemini가 파싱했지만 자릿수/이름 검증에서 걸러진 케이스(파싱 값 그대로 노출)로 구분 가능