### PR TITLE
[FEAT] NL 선수 파싱 AI 프로바이더 OpenRouter 지원

### DIFF
--- a/src/main/java/com/sports/server/command/nl/infra/NlFunctionCallArgs.java
+++ b/src/main/java/com/sports/server/command/nl/infra/NlFunctionCallArgs.java
@@ -6,5 +6,5 @@ import com.sports.server.command.nl.dto.NlParseResult.ParsedPlayer;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-record GeminiFunctionCallArgs(List<ParsedPlayer> players) {
+record NlFunctionCallArgs(List<ParsedPlayer> players) {
 }

--- a/src/main/java/com/sports/server/command/nl/infra/NlGeminiClient.java
+++ b/src/main/java/com/sports/server/command/nl/infra/NlGeminiClient.java
@@ -6,6 +6,7 @@ import com.sports.server.command.nl.dto.NlParseResult;
 import com.sports.server.common.exception.CustomException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -19,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Component
+@ConditionalOnProperty(name = "nl.provider", havingValue = "gemini", matchIfMissing = true)
 public class NlGeminiClient implements NlClient {
 
     private final WebClient geminiWebClient;

--- a/src/main/java/com/sports/server/command/nl/infra/NlGeminiClient.java
+++ b/src/main/java/com/sports/server/command/nl/infra/NlGeminiClient.java
@@ -150,7 +150,7 @@ public class NlGeminiClient implements NlClient {
             return NlParseResult.ofText(text.isEmpty() ? null : text);
         }
 
-        GeminiFunctionCallArgs args = response.getArgsAs(objectMapper, GeminiFunctionCallArgs.class);
+        NlFunctionCallArgs args = response.getArgsAs(objectMapper, NlFunctionCallArgs.class);
         if (args == null || args.players() == null || args.players().isEmpty()) {
             return NlParseResult.ofPlayers(List.of());
         }

--- a/src/main/java/com/sports/server/command/nl/infra/NlOpenRouterClient.java
+++ b/src/main/java/com/sports/server/command/nl/infra/NlOpenRouterClient.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.util.retry.Retry;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -33,7 +34,7 @@ public class NlOpenRouterClient implements NlClient {
     public NlOpenRouterClient(
             WebClient openRouterWebClient,
             ObjectMapper objectMapper,
-            @Value("${gemini.api.nl-prompt}") String systemPrompt,
+            @Value("${openrouter.api.nl-prompt:${gemini.api.nl-prompt}}") String systemPrompt,
             @Value("${openrouter.api.model:qwen/qwen-2.5-72b-instruct}") String model
     ) {
         this.openRouterWebClient = openRouterWebClient;
@@ -77,31 +78,33 @@ public class NlOpenRouterClient implements NlClient {
     private OpenRouterChatResponse callWithRetry(String message, List<Map<String, String>> history, int studentNumberDigits) {
         Map<String, Object> body = buildRequestBody(message, history, studentNumberDigits);
 
-        for (int attempt = 0; attempt <= MAX_RETRY; attempt++) {
-            try {
-                return openRouterWebClient.post()
-                        .uri("/chat/completions")
-                        .bodyValue(body)
-                        .retrieve()
-                        .bodyToMono(OpenRouterChatResponse.class)
-                        .block(Duration.ofSeconds(60));
-            } catch (WebClientResponseException.TooManyRequests
-                     | WebClientResponseException.ServiceUnavailable
-                     | WebClientResponseException.InternalServerError e) {
-                log.warn("OpenRouter transient error. attempt={}/{}, status={}",
-                        attempt + 1, MAX_RETRY + 1, e.getStatusCode());
-                if (attempt < MAX_RETRY) {
-                    sleep(RETRY_DELAY);
-                }
-            } catch (IllegalStateException e) {
-                log.warn("OpenRouter timeout. attempt={}/{}", attempt + 1, MAX_RETRY + 1);
-                if (attempt < MAX_RETRY) {
-                    sleep(RETRY_DELAY);
-                }
-            }
+        try {
+            return openRouterWebClient.post()
+                    .uri("/chat/completions")
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(OpenRouterChatResponse.class)
+                    .retryWhen(Retry.fixedDelay(MAX_RETRY, RETRY_DELAY)
+                            .filter(NlOpenRouterClient::isRetryable)
+                            .doBeforeRetry(signal -> log.warn(
+                                    "OpenRouter retry. attempt={}/{}, cause={}",
+                                    signal.totalRetries() + 1, MAX_RETRY + 1,
+                                    signal.failure().getClass().getSimpleName()))
+                            .onRetryExhaustedThrow((spec, signal) -> signal.failure()))
+                    .block(Duration.ofSeconds(60));
+        } catch (WebClientResponseException | IllegalStateException e) {
+            log.error("OpenRouter call failed after retries: {}", e.getMessage());
+            throw new CustomException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "AI 서비스가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요.");
         }
-        throw new CustomException(HttpStatus.SERVICE_UNAVAILABLE,
-                "AI 서비스가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요.");
+    }
+
+    private static boolean isRetryable(Throwable ex) {
+        if (ex instanceof WebClientResponseException wcre) {
+            int status = wcre.getStatusCode().value();
+            return status == 429 || status == 500 || status == 503;
+        }
+        return false;
     }
 
     private Map<String, Object> buildRequestBody(String message, List<Map<String, String>> history, int studentNumberDigits) {
@@ -139,18 +142,11 @@ public class NlOpenRouterClient implements NlClient {
             return NlParseResult.ofText(text == null || text.isEmpty() ? null : text);
         }
 
-        GeminiFunctionCallArgs args = response.getArgsAs(objectMapper, GeminiFunctionCallArgs.class);
+        NlFunctionCallArgs args = response.getArgsAs(objectMapper, NlFunctionCallArgs.class);
         if (args == null || args.players() == null || args.players().isEmpty()) {
             return NlParseResult.ofPlayers(List.of());
         }
         return NlParseResult.ofPlayers(args.players());
     }
 
-    private void sleep(Duration duration) {
-        try {
-            Thread.sleep(duration.toMillis());
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
 }

--- a/src/main/java/com/sports/server/command/nl/infra/NlOpenRouterClient.java
+++ b/src/main/java/com/sports/server/command/nl/infra/NlOpenRouterClient.java
@@ -1,0 +1,156 @@
+package com.sports.server.command.nl.infra;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sports.server.command.nl.application.NlClient;
+import com.sports.server.command.nl.dto.NlParseResult;
+import com.sports.server.common.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "nl.provider", havingValue = "openrouter")
+public class NlOpenRouterClient implements NlClient {
+
+    private final WebClient openRouterWebClient;
+    private final ObjectMapper objectMapper;
+    private final String systemPrompt;
+    private final String model;
+
+    private static final int MAX_RETRY = 2;
+    private static final Duration RETRY_DELAY = Duration.ofSeconds(2);
+
+    public NlOpenRouterClient(
+            WebClient openRouterWebClient,
+            ObjectMapper objectMapper,
+            @Value("${gemini.api.nl-prompt}") String systemPrompt,
+            @Value("${openrouter.api.model:qwen/qwen-2.5-72b-instruct}") String model
+    ) {
+        this.openRouterWebClient = openRouterWebClient;
+        this.objectMapper = objectMapper;
+        this.systemPrompt = systemPrompt;
+        this.model = model;
+    }
+
+    private static final Map<String, Object> FUNCTION_TOOL = Map.of(
+            "type", "function",
+            "function", Map.of(
+                    "name", "parse_players",
+                    "description", "텍스트에서 추출한 선수 정보 목록",
+                    "parameters", Map.of(
+                            "type", "object",
+                            "properties", Map.of(
+                                    "players", Map.of(
+                                            "type", "array",
+                                            "items", Map.of(
+                                                    "type", "object",
+                                                    "properties", Map.of(
+                                                            "name", Map.of("type", "string", "description", "선수 이름"),
+                                                            "studentNumber", Map.of("type", "string", "description", "9자리 또는 10자리 학번"),
+                                                            "jerseyNumber", Map.of("type", "integer", "description", "등번호 (1~99)")
+                                                    ),
+                                                    "required", List.of("name", "studentNumber")
+                                            )
+                                    )
+                            ),
+                            "required", List.of("players")
+                    )
+            )
+    );
+
+    @Override
+    public NlParseResult parsePlayers(String message, List<Map<String, String>> history, int studentNumberDigits) {
+        OpenRouterChatResponse response = callWithRetry(message, history, studentNumberDigits);
+        return toParseResult(response);
+    }
+
+    private OpenRouterChatResponse callWithRetry(String message, List<Map<String, String>> history, int studentNumberDigits) {
+        Map<String, Object> body = buildRequestBody(message, history, studentNumberDigits);
+
+        for (int attempt = 0; attempt <= MAX_RETRY; attempt++) {
+            try {
+                return openRouterWebClient.post()
+                        .uri("/chat/completions")
+                        .bodyValue(body)
+                        .retrieve()
+                        .bodyToMono(OpenRouterChatResponse.class)
+                        .block(Duration.ofSeconds(60));
+            } catch (WebClientResponseException.TooManyRequests
+                     | WebClientResponseException.ServiceUnavailable
+                     | WebClientResponseException.InternalServerError e) {
+                log.warn("OpenRouter transient error. attempt={}/{}, status={}",
+                        attempt + 1, MAX_RETRY + 1, e.getStatusCode());
+                if (attempt < MAX_RETRY) {
+                    sleep(RETRY_DELAY);
+                }
+            } catch (IllegalStateException e) {
+                log.warn("OpenRouter timeout. attempt={}/{}", attempt + 1, MAX_RETRY + 1);
+                if (attempt < MAX_RETRY) {
+                    sleep(RETRY_DELAY);
+                }
+            }
+        }
+        throw new CustomException(HttpStatus.SERVICE_UNAVAILABLE,
+                "AI 서비스가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요.");
+    }
+
+    private Map<String, Object> buildRequestBody(String message, List<Map<String, String>> history, int studentNumberDigits) {
+        String perCallInstruction = String.format(
+                "이 요청의 학번 자릿수는 정확히 %d자리다. %d자리가 아닌 숫자는 학번으로 추출하지 마.",
+                studentNumberDigits, studentNumberDigits
+        );
+        List<Map<String, Object>> messages = new ArrayList<>();
+        messages.add(Map.of("role", "system", "content", systemPrompt + "\n\n" + perCallInstruction));
+        if (history != null) {
+            for (Map<String, String> entry : history) {
+                String role = entry.get("role");
+                String content = entry.get("content");
+                if ("user".equals(role) && content != null) {
+                    messages.add(Map.of("role", "user", "content", content));
+                }
+            }
+        }
+        messages.add(Map.of("role", "user", "content", message));
+
+        return Map.of(
+                "model", model,
+                "messages", messages,
+                "tools", List.of(FUNCTION_TOOL),
+                "tool_choice", Map.of(
+                        "type", "function",
+                        "function", Map.of("name", "parse_players")
+                )
+        );
+    }
+
+    private NlParseResult toParseResult(OpenRouterChatResponse response) {
+        if (response == null || !response.hasToolCall()) {
+            String text = response == null ? null : response.getText();
+            return NlParseResult.ofText(text == null || text.isEmpty() ? null : text);
+        }
+
+        GeminiFunctionCallArgs args = response.getArgsAs(objectMapper, GeminiFunctionCallArgs.class);
+        if (args == null || args.players() == null || args.players().isEmpty()) {
+            return NlParseResult.ofPlayers(List.of());
+        }
+        return NlParseResult.ofPlayers(args.players());
+    }
+
+    private void sleep(Duration duration) {
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/com/sports/server/command/nl/infra/OpenRouterChatResponse.java
+++ b/src/main/java/com/sports/server/command/nl/infra/OpenRouterChatResponse.java
@@ -1,0 +1,55 @@
+package com.sports.server.command.nl.infra;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record OpenRouterChatResponse(List<Choice> choices) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Choice(Message message) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Message(String content, List<ToolCall> tool_calls) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ToolCall(FunctionPayload function) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record FunctionPayload(String name, String arguments) {
+    }
+
+    public boolean hasToolCall() {
+        if (choices == null || choices.isEmpty()) {
+            return false;
+        }
+        Message message = choices.get(0).message();
+        return message != null && message.tool_calls() != null && !message.tool_calls().isEmpty();
+    }
+
+    public String getText() {
+        if (choices == null || choices.isEmpty()) {
+            return null;
+        }
+        Message message = choices.get(0).message();
+        return message == null ? null : message.content();
+    }
+
+    public <T> T getArgsAs(ObjectMapper mapper, Class<T> clazz) {
+        if (!hasToolCall()) {
+            return null;
+        }
+        String arguments = choices.get(0).message().tool_calls().get(0).function().arguments();
+        try {
+            return mapper.readValue(arguments, clazz);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/sports/server/command/nl/infra/OpenRouterWebClientConfig.java
+++ b/src/main/java/com/sports/server/command/nl/infra/OpenRouterWebClientConfig.java
@@ -1,0 +1,28 @@
+package com.sports.server.command.nl.infra;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@ConditionalOnProperty(name = "nl.provider", havingValue = "openrouter")
+public class OpenRouterWebClientConfig {
+
+    @Value("${openrouter.api.base-url:https://openrouter.ai/api/v1}")
+    private String baseUrl;
+
+    @Value("${openrouter.api.key}")
+    private String apiKey;
+
+    @Bean
+    public WebClient openRouterWebClient() {
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader("Authorization", "Bearer " + apiKey)
+                .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}


### PR DESCRIPTION
## 이슈

close #578

DEV Gemini 2.5-flash 503/403이 지속 발생 (4/22 기준 ~54% 실패율). 근본 원인: 무료 티어 백엔드 과부하 + retry 로직 미비.

## 변경 내용

- `NlOpenRouterClient` 구현체 추가 (OpenAI 호환 Chat Completions + Function Calling)
- `OpenRouterWebClientConfig` — WebClient Bean 전용 설정 (Bearer 인증 헤더)
- `OpenRouterChatResponse` — 응답 DTO (tool_calls 파싱)
- `NlGeminiClient`에 `@ConditionalOnProperty(havingValue="gemini", matchIfMissing=true)` 추가
- `NlOpenRouterClient`는 `@ConditionalOnProperty(havingValue="openrouter")` 로 활성
- OpenRouter 쪽은 503/500 transient 에러도 retry catch (Gemini 버전은 기존 유지)
- be-config 서브모듈 포인터 bump — hufscheer/be-config#11 병행 진행

## 테스트

- [x] `./gradlew compileJava` 성공
- [x] `./gradlew test --tests "com.sports.server.command.nl.*"` 통과
- [x] OpenRouter Qwen2.5-72B 실제 Function Calling 스모크 테스트 성공 (요청당 약 $0.00013)

## 영향 API

- `POST /nl/parse`, `POST /nl/process` — 응답 스펙 동일, 구현체만 교체
- `nl.provider` yaml 플래그로 즉시 Gemini 복귀 가능

## 프론트 참고

응답 구조 변화 없음.

## 배포 순서

1. hufscheer/be-config#11 먼저 머지 (main)
2. 이 PR 머지 (develop → main)
3. DEV 안정화 확인 후 prod 설정 별도 PR