### PR TITLE
[FIX] 팀 수정 시 로고 재업로드 없이 저장 가능하도록 처리

### DIFF
--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -179,7 +179,7 @@ public class TeamService {
     }
 
     private String resolveLogoImageUrl(String requestLogoImageUrl, Team team) {
-        if (requestLogoImageUrl == null) {
+        if (requestLogoImageUrl == null || requestLogoImageUrl.equals(team.getLogoImageUrl())) {
             return null;
         }
         String convertedUrl = changeLogoImageUrlToBeSaved(requestLogoImageUrl);


### PR DESCRIPTION
## 관련 이슈

- Closes #583

## 변경 내용

- `TeamService.resolveLogoImageUrl`에서 요청 로고 URL이 기존 팀 로고 URL과 동일할 경우 변경 없이 `null`을 반환하도록 처리

## 원인

- 저장된 로고 URL은 `replacePrefix`(CloudFront) 형식(`https://images.hufscheer.com/...`)
- 프론트에서 기존 URL을 그대로 전달하면 `changeLogoImageUrlToBeSaved`의 `originPrefix`(S3) 검증에서 `BAD_REQUEST "잘못된 이미지 url 입니다."` 예외 발생 → 로고를 다시 업로드해야만 저장 가능했던 버그

## 테스트

- [x] `./gradlew compileJava` 통과
- [ ] [팀 관리] → [참가 팀 수정]에서 로고를 건드리지 않고 다른 필드만 수정 → 정상 저장 확인
- [ ] 로고를 새로 업로드 후 수정 → 정상 저장 확인

## 영향 API

- `PATCH /leagues/{leagueId}/teams/{teamId}`

## 프론트 참고

- 프론트에서 별도 변경 불필요 (기존 로고 URL 그대로 전달해도 통과)