### PR TITLE
[FIX] 신고된 응원톡이 [신고된 응원톡] 탭에 노출되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/sports/server/command/report/application/ReportProcessor.java
+++ b/src/main/java/com/sports/server/command/report/application/ReportProcessor.java
@@ -24,6 +24,10 @@ public class ReportProcessor {
     public void check(Long reportId) {
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new IllegalStateException("Report not found: " + reportId));
+
+        if (!report.isUnchecked()) {
+            return;
+        }
         CheerTalk cheerTalk = report.getCheerTalk();
 
         if (cachedBadWords == null) {

--- a/src/main/java/com/sports/server/command/report/application/ReportProcessor.java
+++ b/src/main/java/com/sports/server/command/report/application/ReportProcessor.java
@@ -2,6 +2,7 @@ package com.sports.server.command.report.application;
 
 import com.sports.server.command.cheertalk.domain.CheerTalk;
 import com.sports.server.command.report.domain.Report;
+import com.sports.server.command.report.domain.ReportRepository;
 import com.sports.server.common.application.TextFileProcessor;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -14,12 +15,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReportProcessor {
 
     private final TextFileProcessor textFileProcessor;
+    private final ReportRepository reportRepository;
     private static final String FILE_NAME = "static/extra_bad_words.txt";
     private static final String DELIM = ",";
 
     private Set<String> cachedBadWords;
 
-    public void check(CheerTalk cheerTalk, Report report) {
+    public void check(Long reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new IllegalStateException("Report not found: " + reportId));
+        CheerTalk cheerTalk = report.getCheerTalk();
 
         if (cachedBadWords == null) {
             cachedBadWords = textFileProcessor.readFile(FILE_NAME, DELIM);

--- a/src/main/java/com/sports/server/command/report/domain/ReportRepository.java
+++ b/src/main/java/com/sports/server/command/report/domain/ReportRepository.java
@@ -8,6 +8,8 @@ public interface ReportRepository extends Repository<Report, Long> {
 
     void save(Report report);
 
+    Optional<Report> findById(Long id);
+
     Optional<Report> findByCheerTalk(CheerTalk cheerTalk);
     Report findByCheerTalkId(Long cheerTalkId);
 }

--- a/src/main/java/com/sports/server/command/report/infrastructure/ReportEventHandler.java
+++ b/src/main/java/com/sports/server/command/report/infrastructure/ReportEventHandler.java
@@ -1,6 +1,5 @@
 package com.sports.server.command.report.infrastructure;
 
-import com.sports.server.command.cheertalk.domain.CheerTalk;
 import com.sports.server.command.report.application.ReportProcessor;
 import com.sports.server.command.report.domain.Report;
 import com.sports.server.command.report.domain.ReportEvent;
@@ -20,13 +19,8 @@ public class ReportEventHandler {
     public void handle(ReportEvent event) {
         Report report = event.report();
         if (report.isUnchecked()) {
-            checkReport(report);
+            reportProcessor.check(report.getId());
         }
-    }
-
-    private void checkReport(Report report) {
-        CheerTalk cheerTalk = report.getCheerTalk();
-        reportProcessor.check(cheerTalk, report);
     }
 
 // 추후 람다로 이전 시 필요한 메서드들

--- a/src/test/java/com/sports/server/command/report/acceptance/ReportAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/report/acceptance/ReportAcceptanceTest.java
@@ -40,7 +40,7 @@ class ReportAcceptanceTest extends AcceptanceTest {
             // then
             assertAll(
                     () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
-                    () -> verify(reportProcessor).check(any(), any())
+                    () -> verify(reportProcessor).check(any())
             );
         }
 
@@ -56,7 +56,7 @@ class ReportAcceptanceTest extends AcceptanceTest {
             // then
             assertAll(
                     () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value()),
-                    () -> verify(reportProcessor, never()).check(any(), any())
+                    () -> verify(reportProcessor, never()).check(any())
             );
         }
 
@@ -72,7 +72,7 @@ class ReportAcceptanceTest extends AcceptanceTest {
             // then
             assertAll(
                     () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
-                    () -> verify(reportProcessor, never()).check(any(), any())
+                    () -> verify(reportProcessor, never()).check(any())
             );
         }
 
@@ -89,7 +89,7 @@ class ReportAcceptanceTest extends AcceptanceTest {
             // then
             assertAll(
                     () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
-                    () -> verify(reportProcessor, times(2)).check(any(), any())
+                    () -> verify(reportProcessor, times(2)).check(any())
             );
         }
     }

--- a/src/test/java/com/sports/server/command/report/application/ReportProcessorTest.java
+++ b/src/test/java/com/sports/server/command/report/application/ReportProcessorTest.java
@@ -3,20 +3,26 @@ package com.sports.server.command.report.application;
 import static com.sports.server.support.fixture.FixtureMonkeyUtils.entityBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
 
 import com.sports.server.command.cheertalk.domain.CheerTalk;
 import com.sports.server.command.report.domain.Report;
+import com.sports.server.command.report.domain.ReportRepository;
 import com.sports.server.command.report.domain.ReportState;
 import com.sports.server.support.ServiceTest;
+import java.util.Optional;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class ReportProcessorTest extends ServiceTest {
 
     @Autowired
     private ReportProcessor reportProcessor;
+
+    @MockBean
+    private ReportRepository reportRepository;
 
     @ParameterizedTest
     @ValueSource(strings = {"개같아", "뒤질", "ezr"})
@@ -32,8 +38,10 @@ public class ReportProcessorTest extends ServiceTest {
                 .set("state", ReportState.UNCHECKED)
                 .sample();
 
+        given(reportRepository.findById(report.getId())).willReturn(Optional.of(report));
+
         // when
-        reportProcessor.check(cheerTalk, report);
+        reportProcessor.check(report.getId());
 
         // then
         assertAll(
@@ -56,8 +64,10 @@ public class ReportProcessorTest extends ServiceTest {
                 .set("state", ReportState.UNCHECKED)
                 .sample();
 
+        given(reportRepository.findById(report.getId())).willReturn(Optional.of(report));
+
         // when
-        reportProcessor.check(cheerTalk, report);
+        reportProcessor.check(report.getId());
 
         // then
         assertThat(report.getState()).isEqualTo(ReportState.PENDING);

--- a/src/test/java/com/sports/server/command/report/application/ReportProcessorTest.java
+++ b/src/test/java/com/sports/server/command/report/application/ReportProcessorTest.java
@@ -72,4 +72,27 @@ public class ReportProcessorTest extends ServiceTest {
         // then
         assertThat(report.getState()).isEqualTo(ReportState.PENDING);
     }
+
+    @ParameterizedTest
+    @org.junit.jupiter.params.provider.EnumSource(value = ReportState.class, names = {"PENDING", "VALID", "INVALID"})
+    void UNCHECKED가_아닌_신고는_상태가_변경되지_않는다(ReportState initialState) {
+
+        // given
+        CheerTalk cheerTalk = entityBuilder(CheerTalk.class)
+                .set("is_blocked", false)
+                .set("content", "개같아").sample();
+
+        Report report = entityBuilder(Report.class)
+                .set("cheerTalk", cheerTalk)
+                .set("state", initialState)
+                .sample();
+
+        given(reportRepository.findById(report.getId())).willReturn(Optional.of(report));
+
+        // when
+        reportProcessor.check(report.getId());
+
+        // then
+        assertThat(report.getState()).isEqualTo(initialState);
+    }
 }

--- a/src/test/java/com/sports/server/command/report/infrastructure/ReportEventHandlerTest.java
+++ b/src/test/java/com/sports/server/command/report/infrastructure/ReportEventHandlerTest.java
@@ -60,9 +60,7 @@ class ReportEventHandlerTest extends ServiceTest {
             reportEventHandler.handle(reportEvent);
 
             // then
-            verify(reportProcessor).check(
-                    any(), any()
-            );
+            verify(reportProcessor).check(REPORT_ID);
         }
 
         @Test
@@ -75,7 +73,7 @@ class ReportEventHandlerTest extends ServiceTest {
             reportEventHandler.handle(reportEvent);
 
             // then
-            verify(reportProcessor, never()).check(any(CheerTalk.class), any(Report.class));
+            verify(reportProcessor, never()).check(any(Long.class));
         }
 
 


### PR DESCRIPTION
## 관련 이슈

- Closes #585

## 변경 내용

- `ReportProcessor.check()` 시그니처를 `(CheerTalk, Report)` → `(Long reportId)`로 변경
  - ID로 `reportRepository.findById()`를 통해 **managed entity**로 재조회
  - Report→CheerTalk LAZY 관계로 `accept()` 내부 `cheerTalk.blockByAdmin()`도 managed 상태에서 변경 → dirty checking으로 정상 저장
- `ReportEventHandler`도 시그니처 맞춰 `reportProcessor.check(report.getId())` 호출
- `ReportRepository.findById(Long)` 메서드 추가
- 테스트는 `@MockBean ReportRepository`로 `findById` 스텁 처리

## 원인

`@TransactionalEventListener` + `@Async` 조합으로 새 스레드에서 실행될 때, 이벤트에 담긴 `Report`/`CheerTalk`은 **detached entity**. 이 상태에서 `report.updateToPending()`/`accept()`를 호출해도 새 트랜잭션의 PersistenceContext가 해당 엔티티를 관리하지 않아 dirty checking 대상에서 제외됨 → UPDATE SQL 미발행 → state가 `UNCHECKED` 그대로 DB에 남음.

쿼리는 `state = PENDING`만 필터링하므로 신고된 응원톡이 [신고된 응원톡] 탭에 나타나지 않았음.

## 증거 (test_sports_live prod DB)

```
state      count
VALID      39
INVALID    16
PENDING    3
UNCHECKED  16  ← 버그로 전이 실패한 레코드
```

최근 UNCHECKED 레코드: 2026-03-22, 2025-05-09, 2025-03-27 등 2년 넘게 누적.

## 테스트

- [x] `./gradlew test` 통과 (전체 테스트)
- [x] `ReportProcessorTest`, `ReportEventHandlerTest` 통과
- [ ] dev 배포 후 실제 신고 → [신고된 응원톡] 탭 노출 확인

## 영향 API

- `POST /reports` (신고 생성)
- `GET /cheer-talks/reported`
- `GET /leagues/{leagueId}/cheer-talks/reported`
- `GET /games/{gameId}/cheer-talks/reported`

## 프론트 참고

- 프론트 수정 불필요. 백엔드 내부 로직만 변경

## 기존 UNCHECKED 데이터

이번 수정은 앞으로의 신고만 정상 처리. 과거 UNCHECKED 16건은 모두 오래된 레코드라 당분간 영향 적음. 필요시 수동 마이그레이션 또는 후속 이슈로 처리.