### PR TITLE
[REFACTOR] 경기후 > 경기종료로 변경

### DIFF
--- a/src/main/java/com/sports/server/command/league/domain/CommonQuarter.java
+++ b/src/main/java/com/sports/server/command/league/domain/CommonQuarter.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 @Getter
 public enum CommonQuarter implements Quarter {
     PRE_GAME("경기전", 0),
-    POST_GAME("경기후", 99);
+    POST_GAME("경기 종료", 99);
 
     private final String displayName;
     private final int order;

--- a/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
@@ -211,7 +211,7 @@ public class GameServiceTest extends ServiceTest {
         void 게임을_직접_종료하면_결과가_저장된다() {
             // given
             GameRequest.Update finishRequest = new GameRequest.Update(
-                    nameOfGame, 4, "경기후", "FINISHED", LocalDateTime.of(2024, 9, 11, 12, 0, 0), "videoId"
+                    nameOfGame, 4, "경기 종료", "FINISHED", LocalDateTime.of(2024, 9, 11, 12, 0, 0), "videoId"
             );
 
             // when


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #588

## 📝 구현 내용
- '경기후'라는 네이밍이 어색해서 일관성 있게 '경기 종료'로 변경
