### PR TITLE
[FEAT] 관객 화면 팀/단과대 조회 API에 organizationId 필터 추가

### DIFF
--- a/src/main/java/com/sports/server/query/application/TeamQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TeamQueryService.java
@@ -47,8 +47,8 @@ public class TeamQueryService {
     private final LeagueStatisticsQueryRepository leagueStatisticsQueryRepository;
     private final GameQueryRepository gameQueryRepository;
 
-    public List<UnitResponse> getUnitsWithTeams(final SportType sportType) {
-        return getUnitsWithTeamsByOrganization(sportType, null);
+    public List<UnitResponse> getUnitsWithTeams(final SportType sportType, final Long organizationId) {
+        return getUnitsWithTeamsByOrganization(sportType, organizationId);
     }
 
     public List<UnitResponse> getUnitsWithTeams(final SportType sportType, final Member member) {
@@ -68,8 +68,9 @@ public class TeamQueryService {
                 .toList();
     }
 
-    public List<TeamResponse> getAllTeamsByUnits(final List<String> units, final SportType sportType) {
-        return getAllTeamsByUnitsByOrganization(units, sportType, null);
+    public List<TeamResponse> getAllTeamsByUnits(final List<String> units, final SportType sportType,
+                                                    final Long organizationId) {
+        return getAllTeamsByUnitsByOrganization(units, sportType, organizationId);
     }
 
     public List<TeamResponse> getAllTeamsByUnits(final List<String> units, final SportType sportType,
@@ -111,8 +112,9 @@ public class TeamQueryService {
         return new TeamDetailResponse(team, teamPlayers, teamGameResult, scorers, trophies);
     }
 
-    public List<TeamSummaryResponse> getAllTeamsSummary(final List<String> units, final SportType sportType) {
-        List<Team> teams = findTeamsByUnits(units, sportType);
+    public List<TeamSummaryResponse> getAllTeamsSummary(final List<String> units, final SportType sportType,
+                                                        final Long organizationId) {
+        List<Team> teams = findTeamsByUnits(units, sportType, organizationId);
         if (teams.isEmpty()) return Collections.emptyList();
 
         List<Long> teamIds = teams.stream().map(Team::getId).toList();
@@ -134,10 +136,6 @@ public class TeamQueryService {
                 getTrophies(teamIds),
                 getRecentGames(teamIds)
         );
-    }
-
-    private List<Team> findTeamsByUnits(final List<String> units, final SportType sportType) {
-        return findTeamsByUnits(units, sportType, null);
     }
 
     private List<Team> findTeamsByUnits(final List<String> units, final SportType sportType,

--- a/src/main/java/com/sports/server/query/presentation/TeamQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/TeamQueryController.java
@@ -20,15 +20,17 @@ public class TeamQueryController {
 
     @GetMapping("/units")
     public ResponseEntity<List<UnitResponse>> getUnitsWithTeams(
-            @RequestParam(required = false) final SportType sportType) {
-        return ResponseEntity.ok(teamQueryService.getUnitsWithTeams(sportType));
+            @RequestParam(required = false) final SportType sportType,
+            @RequestParam(required = false) final Long organizationId) {
+        return ResponseEntity.ok(teamQueryService.getUnitsWithTeams(sportType, organizationId));
     }
 
     @GetMapping
     public ResponseEntity<List<TeamResponse>> getAllTeams(
             @RequestParam(required = false) final List<String> units,
-            @RequestParam(required = false) final SportType sportType) {
-        return ResponseEntity.ok(teamQueryService.getAllTeamsByUnits(units, sportType));
+            @RequestParam(required = false) final SportType sportType,
+            @RequestParam(required = false) final Long organizationId) {
+        return ResponseEntity.ok(teamQueryService.getAllTeamsByUnits(units, sportType, organizationId));
     }
 
     @GetMapping("/{teamId}")
@@ -49,7 +51,8 @@ public class TeamQueryController {
     @GetMapping("/summary")
     public ResponseEntity<List<TeamSummaryResponse>> getAllTeamsSummary(
             @RequestParam(required = false) final List<String> units,
-            @RequestParam(required = false) final SportType sportType) {
-        return ResponseEntity.ok(teamQueryService.getAllTeamsSummary(units, sportType));
+            @RequestParam(required = false) final SportType sportType,
+            @RequestParam(required = false) final Long organizationId) {
+        return ResponseEntity.ok(teamQueryService.getAllTeamsSummary(units, sportType, organizationId));
     }
 }

--- a/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
@@ -73,6 +73,22 @@ public class TeamQueryServiceTest extends ServiceTest {
                     .isNotEmpty()
                     .allSatisfy(r -> assertThat(r.hasTeam()).isTrue());
         }
+
+        @Test
+        void 관객은_organizationId로_해당_조직의_단과대만_조회한다() {
+            // when
+            List<UnitResponse> org1Responses = teamQueryService.getUnitsWithTeams(null, 1L);
+            List<UnitResponse> org2Responses = teamQueryService.getUnitsWithTeams(null, 2L);
+
+            // then
+            assertAll(
+                    () -> assertThat(org1Responses).hasSize(3),
+                    () -> assertThat(org1Responses).extracting(UnitResponse::unitName)
+                            .containsExactlyInAnyOrder("사회과학대학", "기타", "영어대학"),
+                    () -> assertThat(org2Responses).hasSize(1),
+                    () -> assertThat(org2Responses.get(0).unitName()).isEqualTo("경영대학")
+            );
+        }
     }
 
     @Nested
@@ -149,6 +165,29 @@ public class TeamQueryServiceTest extends ServiceTest {
                     () -> assertThat(responses).hasSize(1),
                     () -> assertThat(responses.get(0).name()).isEqualTo("다른조직팀")
             );
+        }
+
+        @Test
+        void 관객은_organizationId로_해당_조직의_팀만_조회한다() {
+            // when
+            List<TeamResponse> org1Responses = teamQueryService.getAllTeamsByUnits(null, null, 1L);
+            List<TeamResponse> org2Responses = teamQueryService.getAllTeamsByUnits(null, null, 2L);
+
+            // then
+            assertAll(
+                    () -> assertThat(org1Responses).hasSize(7),
+                    () -> assertThat(org2Responses).hasSize(1),
+                    () -> assertThat(org2Responses.get(0).name()).isEqualTo("다른조직팀")
+            );
+        }
+
+        @Test
+        void 관객은_organizationId가_null이면_전체_조직의_팀을_조회한다() {
+            // when
+            List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(null, null, (Long) null);
+
+            // then
+            assertThat(responses).hasSize(8);
         }
     }
 
@@ -326,7 +365,7 @@ public class TeamQueryServiceTest extends ServiceTest {
 
                 leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGameId);
 
-                this.responses = teamQueryService.getAllTeamsSummary(units, null);
+                this.responses = teamQueryService.getAllTeamsSummary(units, null, null);
                 this.teamAResponse = responses.get(3);
                 this.teamBResponse = responses.get(4);
                 this.teamDResponse = responses.get(5);
@@ -403,7 +442,7 @@ public class TeamQueryServiceTest extends ServiceTest {
             List<String> units = List.of("기타");
 
             // when
-            List<TeamSummaryResponse> responses = teamQueryService.getAllTeamsSummary(units, null);
+            List<TeamSummaryResponse> responses = teamQueryService.getAllTeamsSummary(units, null, null);
 
             TeamSummaryResponse noGameTeamResponse = responses.stream()
                     .filter(response -> response.teamDetail().name().equals("게임없는팀"))
@@ -423,7 +462,7 @@ public class TeamQueryServiceTest extends ServiceTest {
             List<String> units = List.of("기타");
 
             // when
-            List<TeamSummaryResponse> responses = teamQueryService.getAllTeamsSummary(units, null);
+            List<TeamSummaryResponse> responses = teamQueryService.getAllTeamsSummary(units, null, null);
 
             TeamSummaryResponse fewGameTeamResponse = responses.stream()
                     .filter(response -> response.teamDetail().name().equals("게임2개팀"))
@@ -445,7 +484,7 @@ public class TeamQueryServiceTest extends ServiceTest {
             List<String> units = List.of("기타");
 
             // when
-            List<TeamSummaryResponse> responses = teamQueryService.getAllTeamsSummary(units, null);
+            List<TeamSummaryResponse> responses = teamQueryService.getAllTeamsSummary(units, null, null);
 
             TeamSummaryResponse manyGameTeamResponse = responses.stream()
                     .filter(response -> response.teamDetail().name().equals("게임많은팀"))
@@ -468,7 +507,7 @@ public class TeamQueryServiceTest extends ServiceTest {
             List<String> units = List.of("기타");
 
             // when
-            List<TeamSummaryResponse> responses = teamQueryService.getAllTeamsSummary(units, null);
+            List<TeamSummaryResponse> responses = teamQueryService.getAllTeamsSummary(units, null, null);
 
             TeamSummaryResponse manyGameTeamResponse = responses.stream()
                     .filter(response -> response.teamDetail().name().equals("게임많은팀"))
@@ -489,7 +528,7 @@ public class TeamQueryServiceTest extends ServiceTest {
             List<String> units = List.of("기타");
 
             // when
-            List<TeamSummaryResponse> responses = teamQueryService.getAllTeamsSummary(units, null);
+            List<TeamSummaryResponse> responses = teamQueryService.getAllTeamsSummary(units, null, null);
 
             TeamSummaryResponse noGameTeam = responses.stream()
                     .filter(r -> r.teamDetail().name().equals("게임없는팀"))

--- a/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
@@ -1,6 +1,7 @@
 package com.sports.server.query.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 
 import com.sports.server.command.league.domain.SportType;
@@ -37,7 +38,7 @@ public class TeamQueryControllerTest extends DocumentationTest {
                 new UnitResponse(5L, "기타", false)
         );
 
-        given(teamQueryService.getUnitsWithTeams(any())).willReturn(response);
+        given(teamQueryService.getUnitsWithTeams(any(SportType.class), nullable(Long.class))).willReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(get("/teams/units")
@@ -68,7 +69,7 @@ public class TeamQueryControllerTest extends DocumentationTest {
                 new TeamResponse(3L, "영어영문학과", "s3:logoImageUrl2", "영어대학", "#92A8D1", "SOCCER")
         );
 
-        given(teamQueryService.getAllTeamsByUnits(any(), any())).willReturn(response);
+        given(teamQueryService.getAllTeamsByUnits(any(), nullable(SportType.class), nullable(Long.class))).willReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(get("/teams")
@@ -259,7 +260,7 @@ public class TeamQueryControllerTest extends DocumentationTest {
 
         List<TeamSummaryResponse> teamSummaryResponses = List.of(new TeamSummaryResponse(teamDetail, recentGames));
 
-        given(teamQueryService.getAllTeamsSummary(units, null)).willReturn(teamSummaryResponses);
+        given(teamQueryService.getAllTeamsSummary(units, null, null)).willReturn(teamSummaryResponses);
 
         // when
         ResultActions result = mockMvc.perform(get("/teams/summary")

--- a/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
@@ -38,7 +38,7 @@ public class TeamQueryControllerTest extends DocumentationTest {
                 new UnitResponse(5L, "기타", false)
         );
 
-        given(teamQueryService.getUnitsWithTeams(any(SportType.class), nullable(Long.class))).willReturn(response);
+        given(teamQueryService.getUnitsWithTeams(nullable(SportType.class), nullable(Long.class))).willReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(get("/teams/units")
@@ -49,7 +49,8 @@ public class TeamQueryControllerTest extends DocumentationTest {
         result.andExpect(status().isOk())
                 .andDo(restDocsHandler.document(
                         queryParameters(
-                                parameterWithName("sportType").description("종목 필터 (SOCCER, BASKETBALL)").optional()
+                                parameterWithName("sportType").description("종목 필터 (SOCCER, BASKETBALL)").optional(),
+                                parameterWithName("organizationId").description("조직 ID 필터 (학교 등)").optional()
                         ),
                         responseFields(
                                 fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("단과대 ID"),
@@ -82,7 +83,9 @@ public class TeamQueryControllerTest extends DocumentationTest {
                         queryParameters(
                                 parameterWithName("units").description("필터링할 소속 리스트 (영어대학, 서양어대학, 아시아언어문화대학," +
                                         " 중국학대학, 일본어대학, 사회과학대학, 상경대학, 경영대학, 사범대학, AI융합대학, 국제학부, LD/LT학부," +
-                                        " KFL학부, 자유전공학부, 기타)").optional()
+                                        " KFL학부, 자유전공학부, 기타)").optional(),
+                                parameterWithName("sportType").description("종목 필터 (SOCCER, BASKETBALL)").optional(),
+                                parameterWithName("organizationId").description("조직 ID 필터 (학교 등)").optional()
                         ),
                         responseFields(
                                 combineFields(
@@ -273,7 +276,9 @@ public class TeamQueryControllerTest extends DocumentationTest {
                         queryParameters(
                                 parameterWithName("units").description("필터링할 소속 리스트 (영어대학, 서양어대학, 아시아언어문화대학," +
                                         " 중국학대학, 일본어대학, 사회과학대학, 상경대학, 경영대학, 사범대학, AI융합대학, 국제학부, LD/LT학부," +
-                                        " KFL학부, 자유전공학부, 기타)").optional()
+                                        " KFL학부, 자유전공학부, 기타)").optional(),
+                                parameterWithName("sportType").description("종목 필터 (SOCCER, BASKETBALL)").optional(),
+                                parameterWithName("organizationId").description("조직 ID 필터 (학교 등)").optional()
                         ),
                         responseFields(
                                 combineFields(


### PR DESCRIPTION
## 관련 이슈

- Closes #590

## 변경 내용

- `/teams`, `/teams/units`, `/teams/summary` 엔드포인트에 `organizationId` 쿼리 파라미터 추가 (선택)
- `TeamQueryService`의 관객용 오버로드 시그니처 변경
  - `getUnitsWithTeams(SportType)` → `getUnitsWithTeams(SportType, Long organizationId)`
  - `getAllTeamsByUnits(List<String>, SportType)` → `getAllTeamsByUnits(List<String>, SportType, Long organizationId)`
  - `getAllTeamsSummary(List<String>, SportType)` → `getAllTeamsSummary(List<String>, SportType, Long organizationId)`
- 매니저용 `Member` 기반 오버로드는 그대로 유지 (조직 자동 추출)
- 내부 로직은 기존 `getUnitsWithTeamsByOrganization`, `getAllTeamsByUnitsByOrganization`, `findTeamsByUnits(units, sportType, organizationId)`를 재사용

## 원인

- 매니저 API(`TeamManagerQueryController`)는 `Member.getOrganization()`을 통해 자동으로 조직 필터를 적용하고 있었지만, 관객용 API(`TeamQueryController`)는 조직 필터가 없어 모든 조직의 팀이 함께 노출되는 상태였음
- 한국외대 → 경희대로 멀티 테넌시가 확장되면서 관객 화면에서도 학교별 팀 분리가 필요해진 상황

## 테스트

- [x] `./gradlew test --tests TeamQueryServiceTest` 통과
- [x] `./gradlew test --tests TeamQueryControllerTest` 통과
- [x] 신규 테스트: `관객은_organizationId로_해당_조직의_단과대만_조회한다`, `관객은_organizationId로_해당_조직의_팀만_조회한다`, `관객은_organizationId가_null이면_전체_조직의_팀을_조회한다`
- [ ] dev 배포 후 `GET /teams?organizationId=1` / `?organizationId=2` 응답 확인

## 영향 API

- `GET /teams`
- `GET /teams/units`
- `GET /teams/summary`

## 프론트 참고

- 기존 호출 그대로 두면 `organizationId=null` → 전체 조직 응답 (호환됨)
- 학교별 분리가 필요한 화면에서 `?organizationId=N` 쿼리 파라미터 추가 필요