### PR TITLE
[FIX] 응원톡 마스킹 OpenRouter 호출 메시지 포맷 수정

### DIFF
--- a/src/main/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClient.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClient.java
@@ -35,11 +35,11 @@ public class OpenRouterMaskingClient implements MaskingClient {
 
     @Override
     public String mask(String content) {
+        String fullInput = systemPrompt + "\n" + content;
         Map<String, Object> body = Map.of(
                 "model", model,
                 "messages", List.of(
-                        Map.of("role", "system", "content", systemPrompt),
-                        Map.of("role", "user", "content", content)
+                        Map.of("role", "user", "content", fullInput)
                 )
         );
 

--- a/src/test/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClientTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClientTest.java
@@ -1,0 +1,106 @@
+package com.sports.server.command.cheertalk.infra;
+
+import com.sports.server.common.infra.openrouter.OpenRouterChatCaller;
+import com.sports.server.common.infra.openrouter.OpenRouterChatResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+class OpenRouterMaskingClientTest {
+
+    private static final String SYSTEM_PROMPT = "마스킹 규칙\n[입력 문장]";
+    private static final String MODEL = "qwen/qwen-2.5-72b-instruct";
+
+    private OpenRouterChatCaller chatCaller;
+    private OpenRouterMaskingClient client;
+
+    @BeforeEach
+    void setUp() {
+        chatCaller = mock(OpenRouterChatCaller.class);
+        client = new OpenRouterMaskingClient(chatCaller, SYSTEM_PROMPT, MODEL);
+    }
+
+    @Test
+    @DisplayName("프롬프트와 콘텐츠를 단일 user 메시지로 합쳐 호출한다")
+    @SuppressWarnings("unchecked")
+    void 단일_user_메시지로_호출() {
+        // given
+        OpenRouterChatResponse response = responseOf("아무거나");
+        when(chatCaller.call(any(), any(Duration.class))).thenReturn(response);
+
+        // when
+        client.mask("입력 콘텐츠");
+
+        // then
+        ArgumentCaptor<Map<String, Object>> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(chatCaller).call(bodyCaptor.capture(), any(Duration.class));
+        Map<String, Object> body = bodyCaptor.getValue();
+
+        List<Map<String, String>> messages = (List<Map<String, String>>) body.get("messages");
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0).get("role")).isEqualTo("user");
+        assertThat(messages.get(0).get("content")).isEqualTo(SYSTEM_PROMPT + "\n입력 콘텐츠");
+    }
+
+    @Test
+    @DisplayName("정상 응답이면 마스킹된 텍스트를 반환한다")
+    void 정상_응답_텍스트_반환() {
+        when(chatCaller.call(any(), any(Duration.class)))
+                .thenReturn(responseOf("** 비속어"));
+
+        String result = client.mask("씨발 비속어");
+
+        assertThat(result).isEqualTo("** 비속어");
+    }
+
+    @Test
+    @DisplayName("응답이 null이면 원문을 반환한다")
+    void 응답_null이면_원문() {
+        when(chatCaller.call(any(), any(Duration.class))).thenReturn(null);
+
+        String result = client.mask("그대로");
+
+        assertThat(result).isEqualTo("그대로");
+    }
+
+    @Test
+    @DisplayName("응답 텍스트가 비어있으면 원문을 반환한다")
+    void 빈_텍스트면_원문() {
+        when(chatCaller.call(any(), any(Duration.class)))
+                .thenReturn(responseOf(""));
+
+        String result = client.mask("그대로");
+
+        assertThat(result).isEqualTo("그대로");
+    }
+
+    @Test
+    @DisplayName("호출이 예외를 던지면 원문을 반환한다")
+    void 예외_발생시_원문() {
+        when(chatCaller.call(any(), any(Duration.class)))
+                .thenThrow(new RuntimeException("network error"));
+
+        String result = client.mask("그대로");
+
+        assertThat(result).isEqualTo("그대로");
+    }
+
+    private OpenRouterChatResponse responseOf(String text) {
+        return new OpenRouterChatResponse(List.of(
+                new OpenRouterChatResponse.Choice(
+                        new OpenRouterChatResponse.Message(text, null)
+                )
+        ));
+    }
+}


### PR DESCRIPTION
## 이슈
관객 응원톡 마스킹 결과가 입력과 무관하게 모든 글자가 `***`으로 노출되는 운영 이슈.

## 변경내용
`OpenRouterMaskingClient`의 OpenRouter 호출을 system+user 분리 메시지 → 단일 user 메시지로 변경.
- 기존 프롬프트(`gemini.api.prompt`)는 끝부분이 `[입력 문장]` 라벨로 끝나며, Gemini 호출 시 `prompt + "\n" + content` 단일 텍스트로 합쳐 전송하도록 설계됨
- OpenRouter 전환(#581) 후 system/user 분리하면서 `[입력 문장]` 라벨이 system 끝에 dangling되고 user 메시지에 단순 content만 들어가, Qwen이 표지 포맷을 못 살려 전체 마스킹 응답을 반환
- Gemini와 동일하게 `prompt + "\n" + content`를 단일 user 메시지로 보내도록 수정 → 검증된 호출 패턴 복원
- be-config(프롬프트) 변경 없음, 백엔드 단일 파일만 수정

## 테스트
- `OpenRouterMaskingClientTest` 5케이스 추가 (단일 user 메시지 구성 / 정상 응답 / null 응답 / 빈 텍스트 / 예외) — 통과
- dev 배포 후 실제 응원톡으로 동작 확인 필요

## 영향 API
- 응원톡 등록 시 비동기 마스킹 결과 (`POST /cheer-talks` 후속 처리)

## 프론트 참고
- 별도 작업 없음. 마스킹 결과 정상화만 확인하면 됨.