### PR TITLE
feat: prod 무중단 배포 적용 (Blue/Green + nginx router)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,15 +53,15 @@ jobs:
       - name: Docker Hub push
         run: docker push ${{ steps.env.outputs.IMG }}
 
-      - name: scp docker-compose (prod)
+      - name: scp be-config docker (prod)
         if: steps.env.outputs.TARGET == 'prod'
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.WAS_HOST }}
           username: ubuntu
           key: ${{ secrets.KEY }}
-          source: "./src/main/resources/be-config/docker/docker-compose.yml"
-          target: "/home/ubuntu"
+          source: "./src/main/resources/be-config/docker/"
+          target: "/home/ubuntu/staging"
           strip_components: 6
 
       - name: scp monitoring compose (prod)
@@ -86,7 +86,7 @@ jobs:
           target: "/home/ubuntu/monitoring"
           strip_components: 6
 
-      - name: 배포 (prod)
+      - name: 배포 (prod, blue/green)
         if: steps.env.outputs.TARGET == 'prod'
         uses: appleboy/ssh-action@v0.1.6
         with:
@@ -94,9 +94,34 @@ jobs:
           username: ubuntu
           key: ${{ secrets.KEY }}
           script: |
-            docker pull ${{ steps.env.outputs.IMG }}
-            docker compose -f docker-compose.yml up -d --force-recreate --no-deps web
-            docker image prune -f
+            set -e
+            cd /home/ubuntu
+
+            cp /home/ubuntu/staging/docker-compose.yml /home/ubuntu/docker-compose.yml
+            cp /home/ubuntu/staging/deploy.sh /home/ubuntu/deploy.sh
+            chmod +x /home/ubuntu/deploy.sh
+
+            mkdir -p /home/ubuntu/nginx/conf.d
+            cp /home/ubuntu/staging/nginx/blue.conf /home/ubuntu/nginx/conf.d/blue.conf
+            cp /home/ubuntu/staging/nginx/green.conf /home/ubuntu/nginx/conf.d/green.conf
+
+            if [ ! -L /home/ubuntu/nginx/conf.d/default.conf ]; then
+                ln -sfn /home/ubuntu/nginx/conf.d/blue.conf /home/ubuntu/nginx/conf.d/default.conf
+            fi
+
+            if docker ps --format '{{.Names}}' | grep -q '^hufscheer-server$'; then
+                echo "[cutover] removing legacy hufscheer-server"
+                docker stop hufscheer-server || true
+                docker rm hufscheer-server || true
+            fi
+
+            if [ ! -f /home/ubuntu/.active_slot ]; then
+                echo green > /home/ubuntu/.active_slot
+            fi
+
+            docker compose -f docker-compose.yml up -d router
+
+            bash /home/ubuntu/deploy.sh
 
       - name: scp docker-compose (dev)
         if: steps.env.outputs.TARGET == 'dev'

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ COPY build/libs/*.jar /home/spring/app.jar
 
 ENV SPRING_PROFILE=prod
 
+STOPSIGNAL SIGTERM
+
 CMD ["sh", "-c", "exec java -Dspring.profiles.active=${SPRING_PROFILE} -Xmx512m -Xms256m -jar /home/spring/app.jar"]


### PR DESCRIPTION
## 이슈/배경
- 기존 prod 배포는 \`docker compose up --force-recreate\` → 10~30초 다운타임
- 내일부터 대회라 무중단 배포 필요

## 변경 내용
### 인프라 신구조
\`\`\`
NPM(:443) → host:8080 → [hufscheer-router (nginx)] → web-blue / web-green
\`\`\`

### 변경 파일
- **be-config 포인터 업데이트** (PR #15 머지 반영, hufscheer/be-config#15)
  - \`docker-compose.yml\`: router(nginx:alpine) + web-blue + web-green
  - \`docker/nginx/blue.conf\`, \`green.conf\`: WebSocket 헤더 + 3600s timeout
  - \`docker/deploy.sh\`: 비활성 슬롯 부팅 → 헬스체크 → upstream swap → 구 슬롯 stop
- **Dockerfile**: \`STOPSIGNAL SIGTERM\` 명시 (Spring graceful shutdown 보장)
- **.github/workflows/cd.yml** prod 분기:
  - docker/ 전체를 \`/home/ubuntu/staging\`으로 SCP
  - 배포 step에서 nginx config + 심링크 + 첫 cutover 처리 후 \`deploy.sh\` 호출
  - dev 분기는 변경 없음

### 기존 설정 활용
- \`application.yaml\`의 \`server.shutdown: graceful\` + \`spring.lifecycle.timeout-per-shutdown-phase: 30s\` 그대로 사용
- 컨테이너 \`stop_grace_period: 40s\` (Spring graceful 30s + 여유)

## 테스트 / 검증
- 머지 후 main CD 자동 실행 → prod에 cutover (최초 1회 다운타임 ~30초 예상)
- 이후 매 배포: 무중단

## WebSocket(STOMP) 영향
- cutover 시점에 STOMP 연결 끊김 발생
- 프론트(\`apps/spectator/src/hooks/useSocket.ts\`)에서 \`@stomp/stompjs\` v7 자동 재연결(5s) 확인됨 → 사용자 체감 거의 없음

## 롤백 절차
- 문제 시 cd.yml을 이전 커밋으로 revert + push → 기존 단일 컨테이너 구조로 복귀
- 또는 prod 서버에서 직접 \`docker compose stop router web-blue web-green && docker run -d --name hufscheer-server ...\`

## 영향 API
- 모든 prod API (\`POST /cheer-talks\`, \`/api/games\`, \`/api/leagues\` 등)