### PR TITLE
fix: nginx blue/green 설정을 templates 디렉터리로 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,12 +101,13 @@ jobs:
             cp /home/ubuntu/staging/deploy.sh /home/ubuntu/deploy.sh
             chmod +x /home/ubuntu/deploy.sh
 
-            mkdir -p /home/ubuntu/nginx/conf.d
-            cp /home/ubuntu/staging/nginx/blue.conf /home/ubuntu/nginx/conf.d/blue.conf
-            cp /home/ubuntu/staging/nginx/green.conf /home/ubuntu/nginx/conf.d/green.conf
+            mkdir -p /home/ubuntu/nginx/conf.d /home/ubuntu/nginx/templates
+            cp /home/ubuntu/staging/nginx/blue.conf /home/ubuntu/nginx/templates/blue.conf
+            cp /home/ubuntu/staging/nginx/green.conf /home/ubuntu/nginx/templates/green.conf
 
-            if [ ! -L /home/ubuntu/nginx/conf.d/default.conf ]; then
-                ln -sfn /home/ubuntu/nginx/conf.d/blue.conf /home/ubuntu/nginx/conf.d/default.conf
+            if [ ! -f /home/ubuntu/nginx/conf.d/default.conf ] || [ -L /home/ubuntu/nginx/conf.d/default.conf ]; then
+                rm -f /home/ubuntu/nginx/conf.d/default.conf
+                cp /home/ubuntu/nginx/templates/blue.conf /home/ubuntu/nginx/conf.d/default.conf
             fi
 
             if docker ps --format '{{.Names}}' | grep -q '^hufscheer-server$'; then


### PR DESCRIPTION
## 이슈

PR #599 머지 후 첫 prod 배포에서 router 컨테이너가 부팅 실패해 짧은 다운타임 발생.

원인 2가지:
1. \`ln -sfn\`이 절대경로 symlink를 생성 → 컨테이너 마운트(\`/etc/nginx/conf.d\`) 안에서 타깃이 깨짐
2. \`blue.conf\`, \`green.conf\`, \`default.conf\`가 같은 디렉터리에 공존 → nginx가 모두 include하면서 \`duplicate upstream "backend"\` 에러

## 변경 내용

- be-config 서브모듈 bump (deploy.sh의 nginx swap 로직을 \`cp templates/\$TARGET.conf conf.d/default.conf\`로 변경)
- cd.yml: blue/green 원본을 \`/home/ubuntu/nginx/templates/\`로 SCP, conf.d에는 default.conf 일반 파일만 둠
- 기존 symlink default.conf가 남아있는 환경에서도 안전하게 마이그레이션되도록 조건 보강

## 테스트

- prod에 동일 구조로 수동 적용 후 router 정상 부팅 확인
- 본 PR 머지 후 prod CD 사이클에서 blue → green cutover 검증 예정

## 영향 API

없음

## 프론트 참고

없음