### PR TITLE
fix: 팀 단과대 변경 시 어드민이 다른 학교 unit으로 갈아끼우는 mismatch 차단

### DIFF
--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -69,8 +69,11 @@ public class TeamService {
         Team team = entityUtils.getEntity(teamId, Team.class);
         PermissionValidator.checkPermission(team, member);
 
+        Long unitOrgId = team.getOrganization() != null
+                ? team.getOrganization().getId()
+                : member.getOrganization().getId();
         Unit unit = Optional.ofNullable(request.unit())
-                .map(unitName -> findUnit(unitName, member.getOrganization().getId()))
+                .map(unitName -> findUnit(unitName, unitOrgId))
                 .orElse(null);
         team.update(request.name(), resolveLogoImageUrl(request.logoImageUrl(), team), unit, request.teamColor());
 

--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -69,11 +69,13 @@ public class TeamService {
         Team team = entityUtils.getEntity(teamId, Team.class);
         PermissionValidator.checkPermission(team, member);
 
-        Long unitOrgId = team.getOrganization() != null
-                ? team.getOrganization().getId()
-                : member.getOrganization().getId();
         Unit unit = Optional.ofNullable(request.unit())
-                .map(unitName -> findUnit(unitName, unitOrgId))
+                .map(unitName -> {
+                    Long unitOrgId = team.getOrganization() != null
+                            ? team.getOrganization().getId()
+                            : (member.getOrganization() != null ? member.getOrganization().getId() : null);
+                    return findUnit(unitName, unitOrgId);
+                })
                 .orElse(null);
         team.update(request.name(), resolveLogoImageUrl(request.logoImageUrl(), team), unit, request.teamColor());
 


### PR DESCRIPTION
Closes #602

## 이슈

dev에서 \`SoccerTestTeamA\` 데이터 부정합 발견.

| 컬럼 | 값 |
|---|---|
| team.organization_id | 1 (한국외대) |
| team.unit_id | 4 |
| unit(id=4).organization_id | 2 (경희대) |

→ team.org와 unit.org가 다른 학교를 가리킴.

## 원인

\`TeamService.update\`가 unit 조회 시 매니저 organization 기준으로 검색하는데, \`Team.isManagedBy\` 안에 \`isAdministrator()\` 우회가 있어서 어드민이 다른 학교 팀을 수정할 때 mismatch 발생 가능.

```java
// 기존
Unit unit = Optional.ofNullable(request.unit())
        .map(unitName -> findUnit(unitName, member.getOrganization().getId()))  // ← 매니저 org
        .orElse(null);
```

재현 시나리오:
1. SoccerTestTeamA 한국외대(org=1) 매니저로 등록 → team.org=1
2. 어드민(org=2 경희대)이 SoccerTestTeamA를 update + unit name 입력
3. PermissionValidator: \`isAdministrator()\` true → 통과
4. \`findUnit(unitName, 어드민org=2)\` → unit_id=4 (경희대 단과대)
5. team.org=1 그대로, unit_id=4 → **mismatch**

쿠키 이중 시나리오는 백엔드 코드상 불가능 (\`HCC_SES\` 단일 토큰).

## 변경 내용

unit 조회 기준을 매니저 org → **team org**로 변경. team.org가 null인 legacy 케이스만 매니저 org로 fallback. Gemini 리뷰 반영해 unit이 실제로 있을 때만 org 결정 로직 실행되도록 \`map\` 내부로 이동.

```java
Unit unit = Optional.ofNullable(request.unit())
        .map(unitName -> {
            Long unitOrgId = team.getOrganization() != null
                    ? team.getOrganization().getId()
                    : (member.getOrganization() != null ? member.getOrganization().getId() : null);
            return findUnit(unitName, unitOrgId);
        })
        .orElse(null);
```

이제 어드민이라도 unit은 항상 팀이 속한 학교의 단과대 중에서만 선택 가능.

## 테스트

- 일반 매니저: 자기 학교 팀 수정 시 자기 학교 unit 검색 (변화 없음 — team.org == member.org)
- 어드민: 타 학교 팀 수정 시 그 팀 학교의 unit만 검색

## 영향 API

- \`PATCH /teams/{teamId}\`

## 프론트 참고

없음 — 어드민이 타 학교 팀의 단과대를 잘못 변경하는 시나리오만 차단되며, 일반 매니저 동작은 동일.

## 데이터 정정

dev SoccerTestTeamA는 본 PR과 별개로 SQL 한 줄로 직접 정정 필요.