### PR TITLE
release: 재교체 차단 prod 반영 (#608)

### DIFF
--- a/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
@@ -47,6 +47,12 @@ public abstract class ReplacementTimeline extends Timeline {
         if (!originLineupPlayer.isSameTeam(replacedLineupPlayer)) {
             throw new BadRequestException(ExceptionMessages.INVALID_PLAYER_SUBSTITUTION);
         }
+        if (!originLineupPlayer.isPlaying()) {
+            throw new BadRequestException(ExceptionMessages.REPLACEMENT_ORIGIN_NOT_IN_GAME);
+        }
+        if (replacedLineupPlayer.isPlaying()) {
+            throw new BadRequestException(ExceptionMessages.REPLACEMENT_TARGET_ALREADY_IN_GAME);
+        }
     }
 
     @Override

--- a/src/main/java/com/sports/server/common/exception/ExceptionMessages.java
+++ b/src/main/java/com/sports/server/common/exception/ExceptionMessages.java
@@ -13,6 +13,8 @@ public class ExceptionMessages {
 
     // Player 관련
     public static final String INVALID_PLAYER_SUBSTITUTION = "다른 팀의 선수끼리 교체할 수 없습니다.";
+    public static final String REPLACEMENT_ORIGIN_NOT_IN_GAME = "이미 코트에 없는 선수는 교체할 수 없습니다.";
+    public static final String REPLACEMENT_TARGET_ALREADY_IN_GAME = "이미 코트에 있는 선수는 교체 투입할 수 없습니다.";
     public static final String INVALID_ASSIST_PLAYER = "어시스트 선수는 득점 선수와 같은 팀이어야 하며, 본인일 수 없습니다.";
 
     // CheerTalk 관련

--- a/src/test/java/com/sports/server/command/game/domain/GameTest.java
+++ b/src/test/java/com/sports/server/command/game/domain/GameTest.java
@@ -89,6 +89,8 @@ class GameTest {
         void 참여하지_않는_선수는_득점할_수_없다() {
             // given
             GameTeam otherTeam = entityBuilder(GameTeam.class)
+                    .set("id", 999L)
+                    .set("game", game2)
                     .sample();
 
             LineupPlayer scorer = entityBuilder(LineupPlayer.class)
@@ -232,6 +234,8 @@ class GameTest {
         void 참여하지_않는_선수는_득점을_취소할_수_없다() {
             // given
             GameTeam otherTeam = entityBuilder(GameTeam.class)
+                    .set("id", 999L)
+                    .set("game", game2)
                     .sample();
 
             LineupPlayer scorer = entityBuilder(LineupPlayer.class)
@@ -247,6 +251,8 @@ class GameTest {
         void 참여하지_않는_선수는_승부차기_득점을_취소할_수_없다() {
             // given
             GameTeam otherTeam = entityBuilder(GameTeam.class)
+                    .set("id", 999L)
+                    .set("game", game2)
                     .sample();
 
             LineupPlayer scorer = entityBuilder(LineupPlayer.class)

--- a/src/test/java/com/sports/server/command/timeline/domain/BasketballReplacementTimelineTest.java
+++ b/src/test/java/com/sports/server/command/timeline/domain/BasketballReplacementTimelineTest.java
@@ -28,8 +28,10 @@ class BasketballReplacementTimelineTest {
         @Test
         void 파울_아웃으로_생성된다() {
             // given
-            LineupPlayer origin = entityBuilder(LineupPlayer.class).set("gameTeam", gameTeam).sample();
-            LineupPlayer replacement = entityBuilder(LineupPlayer.class).set("gameTeam", gameTeam).sample();
+            LineupPlayer origin = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).set("isPlaying", true).sample();
+            LineupPlayer replacement = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).set("isPlaying", false).sample();
 
             // when
             BasketballReplacementTimeline timeline = new BasketballReplacementTimeline(
@@ -48,8 +50,10 @@ class BasketballReplacementTimelineTest {
         @Test
         void 일반_교체로_생성된다() {
             // given
-            LineupPlayer origin = entityBuilder(LineupPlayer.class).set("gameTeam", gameTeam).sample();
-            LineupPlayer replacement = entityBuilder(LineupPlayer.class).set("gameTeam", gameTeam).sample();
+            LineupPlayer origin = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).set("isPlaying", true).sample();
+            LineupPlayer replacement = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).set("isPlaying", false).sample();
 
             // when
             BasketballReplacementTimeline timeline = new BasketballReplacementTimeline(
@@ -64,13 +68,47 @@ class BasketballReplacementTimelineTest {
         void 다른_팀_선수와는_생성할_수_없다() {
             // given
             GameTeam otherTeam = entityBuilder(GameTeam.class).set("id", 2L).set("game", game).sample();
-            LineupPlayer origin = entityBuilder(LineupPlayer.class).set("gameTeam", gameTeam).sample();
-            LineupPlayer replacement = entityBuilder(LineupPlayer.class).set("gameTeam", otherTeam).sample();
+            LineupPlayer origin = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).set("isPlaying", true).sample();
+            LineupPlayer replacement = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", otherTeam).set("isPlaying", false).sample();
 
             // when & then
             assertThatThrownBy(() -> new BasketballReplacementTimeline(
                     game, quarter, 10, origin, replacement, false
             )).isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        void 이미_코트에_없는_선수는_OUT_할_수_없다() {
+            // given
+            LineupPlayer originAlreadyOut = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).set("isPlaying", false).sample();
+            LineupPlayer replacement = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).set("isPlaying", false).sample();
+
+            // when & then
+            assertThatThrownBy(() -> new BasketballReplacementTimeline(
+                    game, quarter, 10, originAlreadyOut, replacement, false
+            ))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("이미 코트에 없는 선수");
+        }
+
+        @Test
+        void 이미_코트에_있는_선수는_IN_할_수_없다() {
+            // given
+            LineupPlayer origin = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).set("isPlaying", true).sample();
+            LineupPlayer replacementAlreadyIn = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam).set("isPlaying", true).sample();
+
+            // when & then
+            assertThatThrownBy(() -> new BasketballReplacementTimeline(
+                    game, quarter, 10, origin, replacementAlreadyIn, false
+            ))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("이미 코트에 있는 선수");
         }
     }
 }

--- a/src/test/java/com/sports/server/command/timeline/domain/ReplacementTimelineTest.java
+++ b/src/test/java/com/sports/server/command/timeline/domain/ReplacementTimelineTest.java
@@ -34,10 +34,12 @@ class ReplacementTimelineTest {
             // given
             LineupPlayer originLineupPlayer = entityBuilder(LineupPlayer.class)
                     .set("gameTeam", gameTeam)
+                    .set("isPlaying", true)
                     .sample();
 
             LineupPlayer replacedLineupPlayer = entityBuilder(LineupPlayer.class)
                     .set("gameTeam", gameTeam)
+                    .set("isPlaying", false)
                     .sample();
 
             // when
@@ -64,10 +66,12 @@ class ReplacementTimelineTest {
 
             LineupPlayer originLineupPlayer = entityBuilder(LineupPlayer.class)
                     .set("gameTeam", gameTeam)
+                    .set("isPlaying", true)
                     .sample();
 
             LineupPlayer replacedLineupPlayer = entityBuilder(LineupPlayer.class)
                     .set("gameTeam", otherTeam)
+                    .set("isPlaying", false)
                     .sample();
 
             // when then
@@ -78,6 +82,56 @@ class ReplacementTimelineTest {
                     originLineupPlayer,
                     replacedLineupPlayer
             )).isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        void 이미_코트에_없는_선수는_OUT_할_수_없다() {
+            // given
+            LineupPlayer originAlreadyOut = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam)
+                    .set("isPlaying", false)
+                    .sample();
+
+            LineupPlayer replacedLineupPlayer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam)
+                    .set("isPlaying", false)
+                    .sample();
+
+            // when then
+            assertThatThrownBy(() -> new SoccerReplacementTimeline(
+                    game,
+                    quarter,
+                    10,
+                    originAlreadyOut,
+                    replacedLineupPlayer
+            ))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("이미 코트에 없는 선수");
+        }
+
+        @Test
+        void 이미_코트에_있는_선수는_IN_할_수_없다() {
+            // given
+            LineupPlayer originLineupPlayer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam)
+                    .set("isPlaying", true)
+                    .sample();
+
+            LineupPlayer replacedAlreadyIn = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", gameTeam)
+                    .set("isPlaying", true)
+                    .sample();
+
+            // when then
+            assertThatThrownBy(() -> new SoccerReplacementTimeline(
+                    game,
+                    quarter,
+                    10,
+                    originLineupPlayer,
+                    replacedAlreadyIn
+            ))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("이미 코트에 있는 선수");
         }
     }
 }

--- a/src/test/resources/timeline-fixture.sql
+++ b/src/test/resources/timeline-fixture.sql
@@ -89,7 +89,7 @@ VALUES (1, 1, 1, 1, 15, 0, null), -- 팀 A
 
 -- 라인업 선수 (1번 경기 - 팀A)
 INSERT INTO lineup_players (id, game_team_id, player_id, jersey_number, is_captain, state, is_playing, replaced_player_id)
-VALUES (1, 1, 1, 1, TRUE, 'STARTER', FALSE, null),
+VALUES (1, 1, 1, 1, TRUE, 'STARTER', TRUE, null),
        (2, 1, 2, 2, FALSE, 'STARTER', FALSE, null),
        (3, 1, 3, 3, FALSE, 'STARTER', FALSE, null),
        (4, 1, 4, 4, FALSE, 'STARTER', FALSE, null),
@@ -97,7 +97,7 @@ VALUES (1, 1, 1, 1, TRUE, 'STARTER', FALSE, null),
 
 -- 라인업 선수 (1번 경기 - 팀B)
 INSERT INTO lineup_players (id, game_team_id, player_id, jersey_number, is_captain, state, is_playing, replaced_player_id)
-VALUES (6, 2, 6, 6, TRUE, 'STARTER', FALSE, null),
+VALUES (6, 2, 6, 6, TRUE, 'STARTER', TRUE, null),
        (7, 2, 7, 7, FALSE, 'STARTER', FALSE, null),
        (8, 2, 8, 8, FALSE, 'STARTER', FALSE, null),
        (9, 2, 9, 9, FALSE, 'STARTER', FALSE, null),


### PR DESCRIPTION
## 포함 PR
- #608 [FIX] 이미 IN/OUT 된 선수 재교체 차단

## 이슈
호라이즌 농구 라인업 4명 표시 사례 디버깅 중 발견. 교체 타임라인 등록 시 origin/replaced의 isPlaying 상태 검증이 없어, 매니저가 같은 선수를 두 번 IN 또는 두 번 OUT 시킬 수 있었음. 그 결과 `replaced_player_id`가 덮어써져 viewer/매니저 라인업·교체 표시가 어긋남.

## 변경 내용
- `ReplacementTimeline.validatePlayers`에 isPlaying 검증 2개 추가
  - origin이 코트 위(isPlaying=true)일 때만 OUT 허용
  - replaced가 코트 밖(isPlaying=false)일 때만 IN 허용
- 예외 메시지 2개 추가
- 도메인 단위 테스트(축구/농구) 회귀 케이스 추가
- timeline-fixture 보정
- (부가) GameTest의 otherTeam id 충돌로 인한 flaky 제거

## 테스트
- `./gradlew test` 통과
- CI(MySQL 8.0) 통과

## 영향 API
- `POST /games/{gameId}/timelines/replacement`
  - 이미 OUT/IN 된 선수에 대한 재교체 요청 → 400 반환

## 프론트 참고
- 이미 코트에 없는 선수에 OUT 요청 → 400 ("이미 코트에 없는 선수는 교체할 수 없습니다.")
- 이미 코트 위 선수에 IN 요청 → 400 ("이미 코트에 있는 선수는 교체 투입할 수 없습니다.")