### PR TITLE
fix: 팀 페이지 득점 집계 시 다른 종목 득점이 섞이던 버그 차단

### DIFF
--- a/src/main/java/com/sports/server/query/application/TeamQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TeamQueryService.java
@@ -91,7 +91,7 @@ public class TeamQueryService {
         List<TeamPlayer> teamPlayers = teamQueryRepository.findTeamPlayersByTeamId(teamId);
         List<Long> playerIds = teamPlayerRepository.findPlayerIdsByTeamId(teamId);
 
-        Map<Long, Integer> playerTotalGoalCountInfo = playerInfoProvider.getPlayersTotalGoalInfo(playerIds);
+        Map<Long, Integer> playerTotalGoalCountInfo = playerInfoProvider.getPlayersGoalInfoInTeam(playerIds, teamId);
         return teamPlayers.stream()
                 .map(tp -> {
                     Player player = tp.getPlayer();

--- a/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
@@ -23,7 +23,7 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
     @Query("SELECT st FROM ScoreTimeline st JOIN FETCH st.scorer sc JOIN FETCH sc.gameTeam WHERE st.game.id = :gameId")
     List<ScoreTimeline> findScoreTimelinesByGameId(@Param("gameId") Long gameId);
 
-    @Query("SELECT count(st) FROM ScoreTimeline st WHERE st.scorer.id = :playerId")
+    @Query("SELECT count(st) FROM ScoreTimeline st WHERE st.scorer.player.id = :playerId")
     int countTotalGoalsByPlayerId(@Param("playerId") Long playerId);
 
     @Query("SELECT new com.sports.server.command.team.domain.PlayerGoalCount(st.scorer.player.id, COUNT(st.id)) " +
@@ -32,22 +32,29 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             "GROUP BY st.scorer.player.id")
     List<PlayerGoalCount> countTotalGoalsByPlayerId(@Param("playerIds") List<Long> playerIds);
 
+    @Query("SELECT new com.sports.server.command.team.domain.PlayerGoalCount(st.scorer.player.id, COUNT(st.id)) " +
+            "FROM ScoreTimeline st " +
+            "WHERE st.scorer.player.id IN :playerIds " +
+            "AND st.scorer.gameTeam.team.id = :teamId " +
+            "GROUP BY st.scorer.player.id")
+    List<PlayerGoalCount> countTotalGoalsByPlayerIdInTeam(@Param("playerIds") List<Long> playerIds,
+                                                          @Param("teamId") Long teamId);
+
     @Query("""
             SELECT new com.sports.server.query.dto.TeamTopScorerResult(
-                tp.team.id,
+                sc.gameTeam.team.id,
                 new com.sports.server.command.team.domain.PlayerGoalCountWithRank(
                     p.id, p.studentNumber, p.name, COUNT(st.id),
-                    RANK() OVER (PARTITION BY tp.team.id ORDER BY COUNT(st.id) DESC)
+                    RANK() OVER (PARTITION BY sc.gameTeam.team.id ORDER BY COUNT(st.id) DESC)
                 )
             )
             FROM ScoreTimeline st
             JOIN st.scorer sc
             JOIN sc.player p
-            JOIN p.teamPlayers tp
-            WHERE tp.team.id IN :teamIds
-            GROUP BY tp.team.id, p.id, p.studentNumber, p.name
+            WHERE sc.gameTeam.team.id IN :teamIds
+            GROUP BY sc.gameTeam.team.id, p.id, p.studentNumber, p.name
             HAVING COUNT(st.id) > 0
-            ORDER BY tp.team.id, COUNT(st.id) DESC, p.name ASC
+            ORDER BY sc.gameTeam.team.id, COUNT(st.id) DESC, p.name ASC
             """)
     List<TeamTopScorerResult> findTopScorersByTeamIds(@Param("teamIds") List<Long> teamIds);
 

--- a/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
@@ -23,16 +23,16 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
     @Query("SELECT st FROM ScoreTimeline st JOIN FETCH st.scorer sc JOIN FETCH sc.gameTeam WHERE st.game.id = :gameId")
     List<ScoreTimeline> findScoreTimelinesByGameId(@Param("gameId") Long gameId);
 
-    @Query("SELECT count(st) FROM ScoreTimeline st WHERE st.scorer.player.id = :playerId")
+    @Query("SELECT COALESCE(SUM(st.score), 0) FROM ScoreTimeline st WHERE st.scorer.player.id = :playerId")
     int countTotalGoalsByPlayerId(@Param("playerId") Long playerId);
 
-    @Query("SELECT new com.sports.server.command.team.domain.PlayerGoalCount(st.scorer.player.id, COUNT(st.id)) " +
+    @Query("SELECT new com.sports.server.command.team.domain.PlayerGoalCount(st.scorer.player.id, SUM(st.score)) " +
             "FROM ScoreTimeline st " +
             "WHERE st.scorer.player.id IN :playerIds " +
             "GROUP BY st.scorer.player.id")
     List<PlayerGoalCount> countTotalGoalsByPlayerId(@Param("playerIds") List<Long> playerIds);
 
-    @Query("SELECT new com.sports.server.command.team.domain.PlayerGoalCount(st.scorer.player.id, COUNT(st.id)) " +
+    @Query("SELECT new com.sports.server.command.team.domain.PlayerGoalCount(st.scorer.player.id, SUM(st.score)) " +
             "FROM ScoreTimeline st " +
             "WHERE st.scorer.player.id IN :playerIds " +
             "AND st.scorer.gameTeam.team.id = :teamId " +
@@ -44,8 +44,8 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             SELECT new com.sports.server.query.dto.TeamTopScorerResult(
                 sc.gameTeam.team.id,
                 new com.sports.server.command.team.domain.PlayerGoalCountWithRank(
-                    p.id, p.studentNumber, p.name, COUNT(st.id),
-                    RANK() OVER (PARTITION BY sc.gameTeam.team.id ORDER BY COUNT(st.id) DESC)
+                    p.id, p.studentNumber, p.name, SUM(st.score),
+                    RANK() OVER (PARTITION BY sc.gameTeam.team.id ORDER BY SUM(st.score) DESC)
                 )
             )
             FROM ScoreTimeline st
@@ -53,8 +53,8 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             JOIN sc.player p
             WHERE sc.gameTeam.team.id IN :teamIds
             GROUP BY sc.gameTeam.team.id, p.id, p.studentNumber, p.name
-            HAVING COUNT(st.id) > 0
-            ORDER BY sc.gameTeam.team.id, COUNT(st.id) DESC, p.name ASC
+            HAVING SUM(st.score) > 0
+            ORDER BY sc.gameTeam.team.id, SUM(st.score) DESC, p.name ASC
             """)
     List<TeamTopScorerResult> findTopScorersByTeamIds(@Param("teamIds") List<Long> teamIds);
 
@@ -62,16 +62,16 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
             "       p.id, " +
             "       p.studentNumber, " +
             "       p.name, " +
-            "       COUNT(st.id), " +
-            "       RANK() OVER (ORDER BY COUNT(st.id) DESC)) " +
+            "       SUM(st.score), " +
+            "       RANK() OVER (ORDER BY SUM(st.score) DESC)) " +
             "FROM ScoreTimeline st " +
             "JOIN st.scorer sc " +
             "JOIN sc.player p " +
             "JOIN st.game g " +
             "WHERE g.league.id = :leagueId " +
             "GROUP BY p.id, p.studentNumber, p.name " +
-            "HAVING COUNT(st.id) > 0 " +
-            "ORDER BY COUNT(st.id) DESC, p.name ASC")
+            "HAVING SUM(st.score) > 0 " +
+            "ORDER BY SUM(st.score) DESC, p.name ASC")
     List<PlayerGoalCountWithRank> findTopScorersByLeagueId(@Param("leagueId") Long leagueId, Pageable pageable);
 
 }

--- a/src/main/java/com/sports/server/query/support/PlayerInfoProvider.java
+++ b/src/main/java/com/sports/server/query/support/PlayerInfoProvider.java
@@ -33,6 +33,17 @@ public class PlayerInfoProvider {
                 ));
     }
 
+    public Map<Long, Integer> getPlayersGoalInfoInTeam(List<Long> playerIds, Long teamId) {
+        if (playerIds == null || playerIds.isEmpty()) return Collections.emptyMap();
+
+        List<PlayerGoalCount> results = timelineQueryRepository.countTotalGoalsByPlayerIdInTeam(playerIds, teamId);
+        return results.stream()
+                .collect(Collectors.toMap(
+                        PlayerGoalCount::playerId,
+                        dto -> dto.playerTotalGoalCount().intValue()
+                ));
+    }
+
     public List<PlayerGoalCountWithRank> getLeagueTopScorers(Long leagueId, int size) {
         Pageable sizeRequest = PageRequest.of(0, size);
         return timelineQueryRepository.findTopScorersByLeagueId(leagueId, sizeRequest);

--- a/src/test/java/com/sports/server/query/acceptance/TeamQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/TeamQueryAcceptanceTest.java
@@ -32,7 +32,7 @@ public class TeamQueryAcceptanceTest extends AcceptanceTest {
         List<TeamResponse> actual = toResponses(response, TeamResponse.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(actual).hasSize(8)
+                () -> assertThat(actual).hasSize(12)
         );
     }
 
@@ -50,7 +50,7 @@ public class TeamQueryAcceptanceTest extends AcceptanceTest {
         List<UnitResponse> actual = toResponses(response, UnitResponse.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(actual).hasSize(4)
+                () -> assertThat(actual).hasSize(5)
         );
     }
 }

--- a/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
@@ -233,7 +233,7 @@ public class TeamQueryServiceTest extends ServiceTest {
                     () -> assertThat(basketballTeamPlayers)
                             .filteredOn(p -> p.name().equals("멀티선수50"))
                             .extracting(PlayerResponse::totalGoalCount)
-                            .containsExactly(3)
+                            .containsExactly(5)
             );
         }
     }
@@ -332,7 +332,7 @@ public class TeamQueryServiceTest extends ServiceTest {
                     () -> assertThat(basketballResponse.topScorers())
                             .extracting(TeamDetailResponse.TeamTopScorer::playerName,
                                     TeamDetailResponse.TeamTopScorer::totalGoals)
-                            .containsExactly(tuple("멀티선수50", 3))
+                            .containsExactly(tuple("멀티선수50", 5))
             );
         }
 

--- a/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/TeamQueryServiceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDateTime;
@@ -187,7 +188,7 @@ public class TeamQueryServiceTest extends ServiceTest {
             List<TeamResponse> responses = teamQueryService.getAllTeamsByUnits(null, null, (Long) null);
 
             // then
-            assertThat(responses).hasSize(8);
+            assertThat(responses).hasSize(12);
         }
     }
 
@@ -210,6 +211,29 @@ public class TeamQueryServiceTest extends ServiceTest {
                             .containsExactlyInAnyOrder("선수1", "선수2", "선수3", "선수4", "선수5"),
                     () -> assertThat(responses).extracting(PlayerResponse::totalGoalCount)
                             .containsExactlyInAnyOrder(0, 1, 3, 0, 0)
+            );
+        }
+
+        @Test
+        void 다른_종목_팀에서의_득점은_현재_팀의_총득점에_합산되지_않는다() {
+            // given (선수50은 축구팀50에서 2골, 농구팀51에서 5골)
+            Long soccerTeamId = 50L;
+            Long basketballTeamId = 51L;
+
+            // when
+            List<PlayerResponse> soccerTeamPlayers = teamQueryService.getAllTeamPlayers(soccerTeamId);
+            List<PlayerResponse> basketballTeamPlayers = teamQueryService.getAllTeamPlayers(basketballTeamId);
+
+            // then
+            assertAll(
+                    () -> assertThat(soccerTeamPlayers)
+                            .filteredOn(p -> p.name().equals("멀티선수50"))
+                            .extracting(PlayerResponse::totalGoalCount)
+                            .containsExactly(2),
+                    () -> assertThat(basketballTeamPlayers)
+                            .filteredOn(p -> p.name().equals("멀티선수50"))
+                            .extracting(PlayerResponse::totalGoalCount)
+                            .containsExactly(3)
             );
         }
     }
@@ -286,6 +310,29 @@ public class TeamQueryServiceTest extends ServiceTest {
                     () -> assertThat(response.topScorers().get(1).playerName()).isEqualTo("선수2"),
                     () -> assertThat(response.topScorers().get(1).totalGoals()).isEqualTo(1),
                     () -> assertThat(response.topScorers().get(1).admissionYear()).isEqualTo("21")
+            );
+        }
+
+        @Test
+        void 다른_종목_팀에서의_득점은_득점왕에_합산되지_않는다() {
+            // given (선수50은 축구팀50에서 2골, 농구팀51에서 5골)
+            Long soccerTeamId = 50L;
+            Long basketballTeamId = 51L;
+
+            // when
+            TeamDetailResponse soccerResponse = teamQueryService.getTeamDetail(soccerTeamId);
+            TeamDetailResponse basketballResponse = teamQueryService.getTeamDetail(basketballTeamId);
+
+            // then
+            assertAll(
+                    () -> assertThat(soccerResponse.topScorers())
+                            .extracting(TeamDetailResponse.TeamTopScorer::playerName,
+                                    TeamDetailResponse.TeamTopScorer::totalGoals)
+                            .containsExactly(tuple("멀티선수50", 2)),
+                    () -> assertThat(basketballResponse.topScorers())
+                            .extracting(TeamDetailResponse.TeamTopScorer::playerName,
+                                    TeamDetailResponse.TeamTopScorer::totalGoals)
+                            .containsExactly(tuple("멀티선수50", 3))
             );
         }
 

--- a/src/test/resources/team-query-fixture.sql
+++ b/src/test/resources/team-query-fixture.sql
@@ -215,8 +215,60 @@ VALUES
     (104, 104, 12, 0, 1, 0, 'WIN');
 
 INSERT INTO game_teams (id, game_id, team_id, cheer_count, score, pk_score, result)
-VALUES 
+VALUES
     (200, 200, 11, 0, 1, 0, 'WIN'),
     (201, 201, 11, 0, 0, 0, 'LOSE');
+
+
+-- === 다중 종목(축구/농구) 동시 등록 선수 데이터 (별도 organization=3로 격리) ===
+-- 선수50은 축구팀(50)과 농구팀(51)에 모두 등록되어 있다.
+-- 축구 게임에서 2득점, 농구 게임에서 5득점.
+-- 각 팀 화면에서는 자기 팀 게임 득점만 보여야 한다.
+
+INSERT INTO organizations (id, name, student_number_digits)
+VALUES (3, '멀티스포츠 학교', 9);
+
+INSERT INTO units (id, name, organization_id)
+VALUES (50, '멀티스포츠과', 3);
+
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color, organization_id, sport_type)
+VALUES (50, 50, '멀티스포츠 축구팀', 'http://example.com/logo_soccer.png', '#111111', 3, 'SOCCER'),
+       (51, 50, '멀티스포츠 농구팀', 'http://example.com/logo_basket.png', '#222222', 3, 'BASKETBALL'),
+       (52, 50, '상대 축구팀', 'http://example.com/logo_op_soccer.png', '#333333', 3, 'SOCCER'),
+       (53, 50, '상대 농구팀', 'http://example.com/logo_op_basket.png', '#444444', 3, 'BASKETBALL');
+
+INSERT INTO players (id, name, student_number)
+VALUES (50, '멀티선수50', '202100050');
+
+INSERT INTO team_players (id, team_id, player_id, jersey_number)
+VALUES (50, 50, 50, 7),
+       (51, 51, 50, 7);
+
+INSERT INTO leagues (id, organization_id, administrator_id, name, start_at, end_at, is_deleted, max_round, in_progress_round, sport_type)
+VALUES (50, 3, 1, '멀티스포츠 축구리그', '2024-03-01 00:00:00', '2024-03-31 23:59:59', FALSE, '결승', '결승', 'SOCCER'),
+       (51, 3, 1, '멀티스포츠 농구리그', '2024-03-01 00:00:00', '2024-03-31 23:59:59', FALSE, '결승', '결승', 'BASKETBALL');
+
+INSERT INTO games (id, administrator_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter, state, round, is_pk_taken)
+VALUES (50, 1, 50, '멀티 축구 경기', '2024-03-10 10:00:00', null, '2024-03-10 10:15:00', 'SECOND_HALF', 'FINISHED', '결승', FALSE),
+       (51, 1, 51, '멀티 농구 경기', '2024-03-15 14:00:00', null, '2024-03-15 14:30:00', 'FOURTH_QUARTER', 'FINISHED', '결승', FALSE);
+
+INSERT INTO game_teams (id, game_id, team_id, cheer_count, score, pk_score, result)
+VALUES (50, 50, 50, 0, 2, 0, 'WIN'),   -- 축구: 멀티 축구팀
+       (51, 50, 52, 0, 0, 0, 'LOSE'),  -- 축구: 상대 축구팀
+       (52, 51, 51, 0, 5, 0, 'WIN'),   -- 농구: 멀티 농구팀
+       (53, 51, 53, 0, 3, 0, 'LOSE');  -- 농구: 상대 농구팀
+
+INSERT INTO lineup_players (id, game_team_id, player_id, jersey_number, is_captain, state, is_playing, replaced_player_id)
+VALUES (50, 50, 50, 7, TRUE, 'STARTER', TRUE, null),  -- 축구 게임의 멀티선수
+       (51, 52, 50, 7, TRUE, 'STARTER', TRUE, null);  -- 농구 게임의 멀티선수
+
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, score, game_team1_id, snapshot_score1, game_team2_id, snapshot_score2)
+VALUES
+    ('SCORE', 50, 'FIRST_HALF', 5, 50, 1, 50, 1, 51, 0),
+    ('SCORE', 50, 'SECOND_HALF', 60, 50, 1, 50, 2, 51, 0),
+    ('SCORE', 51, 'FIRST_QUARTER', 1, 51, 1, 52, 1, 53, 0),
+    ('SCORE', 51, 'FIRST_QUARTER', 5, 51, 2, 52, 3, 53, 0),
+    ('SCORE', 51, 'SECOND_QUARTER', 3, 51, 2, 52, 5, 53, 0);
+
 
 SET foreign_key_checks = 1;


### PR DESCRIPTION
## 이슈
1. 한 선수가 축구팀과 농구팀 양쪽에 등록되어 있을 때, 팀 상세 페이지(`GET /teams/{teamId}`)와 팀 선수 목록(`GET /teams/{teamId}/players`)에서 노출되는 득점왕/선수 총득점에 **다른 종목에서 낸 득점이 합산**되어 보이는 문제가 있었습니다. (e.g. 축구팀 페이지인데 그 선수의 농구 득점이 합쳐져 표시)
2. 득점 집계가 `COUNT(st.id)` 기반이라 농구처럼 1회 득점이 1점이 아닌 종목(2점/3점슛)에서 실제 점수와 다른 값이 노출되었습니다.

원인은 (1) 득점 집계 쿼리들이 `Player`만 기준으로 group by 하고 `gameTeam.team.id`로 필터링하지 않았다는 점, (2) 득점 메트릭이 timeline row 수 카운트라 점수 가중치가 반영되지 않았다는 점입니다.

## 변경 내용
- `TimelineQueryRepository`
  - 팀 스코프 선수 총득점 쿼리 신규 추가: `countTotalGoalsByPlayerIdInTeam(playerIds, teamId)` — `sc.gameTeam.team.id = :teamId` 조건으로 해당 팀에서 낸 득점만 집계
  - `findTopScorersByTeamIds`를 `Player.teamPlayers` 조인 방식에서 `sc.gameTeam.team.id` 기반으로 재작성 → 다른 종목 팀 득점 누수 차단
  - 단일 `playerId` 버전 `countTotalGoalsByPlayerId` 쿼리에 있던 `st.scorer.id = :playerId` (LineupPlayer.id 비교) 오타를 `st.scorer.player.id = :playerId`로 수정
  - 모든 득점 집계 쿼리(선수 단일/리스트, 팀 스코프, 팀 득점왕, 리그 득점왕)를 `COUNT(st.id)` → `SUM(st.score)`로 통일하여 종목별 점수 가중치(2점/3점슛 등) 반영
- `PlayerInfoProvider#getPlayersGoalInfoInTeam(playerIds, teamId)` 추가
- `TeamQueryService#getAllTeamPlayers`가 신규 팀 스코프 메서드를 호출하도록 변경
- 픽스처: `team-query-fixture.sql`에 멀티스포츠 회귀 케이스 추가 (org=3, 한 선수가 SOCCER/BASKETBALL 양쪽 팀에 등록 + 양쪽에서 득점, 농구는 1+2+2=5점)

## 테스트
- `TeamQueryServiceTest` 회귀 케이스 2건 추가:
  - `다른_종목_팀에서의_득점은_현재_팀의_총득점에_합산되지_않는다` — `getAllTeamPlayers` (축구 2점, 농구 5점)
  - `다른_종목_팀에서의_득점은_득점왕에_합산되지_않는다` — `getTeamDetail`의 `topScorers`
- 기존 픽스처 변경에 따라 `TeamQueryAcceptanceTest`/`TeamQueryServiceTest`의 전체 카운트 기대값 보정
- `./gradlew test` 전체 통과

## 영향 API
- `GET /teams/{teamId}` (팀 상세 — 득점왕)
- `GET /teams/{teamId}/players` (팀 선수 목록 — 선수별 총득점)
- `GET /leagues/{leagueId}/top-scorers` (리그 득점왕) — 동일 모델 사용으로 점수합 기반으로 변경됨
- 그 외 단일 선수 총득점을 사용하는 API

## 프론트 참고
응답 스키마/필드명은 변경 없습니다 (`totalGoals`, `goalCount` 그대로). 다만 **농구 페이지에서 노출되는 값의 의미가 "득점 횟수 → 총 점수"로 바뀝니다** (축구는 1득점=1점이라 변화 없음).

### 농구에서 어색해지는 부분 (FE 측 수정 필요)

확인된 하드코딩 위치 (`hufscheer/web` 레포 기준):

1. **`apps/spectator/src/app/[sport]/(home)/teams/_components/score-list.tsx`**
   ```
   {player.totalGoals}골
   ```
   → 농구일 때 "5골"이 아니라 "5점"으로 표시되어야 자연스러움

2. **`apps/spectator/src/app/[sport]/(home)/previous/_components/league-card.tsx`**
   ```
   {scorer.goalCount}골
   ```
   → 동일 (리그 득점왕 카드)

3. **`apps/spectator/src/app/[sport]/(home)/teams/_components/score-modal.tsx`**
   ```
   {teamName} <span className="font-semibold">득점왕</span> ⚽
   ```
   → ⚽ 이모지가 농구에서도 노출됨. 농구는 🏀 등 종목별 분기 권장
   → 모달 내부 `{r.totalGoalCount}` 옆에는 단위가 없으므로 OK

### 권장 수정안
경로에 이미 `[sport]` 파라미터가 있으므로 종목별 분기:

| 위치 | 축구 (SOCCER) | 농구 (BASKETBALL) |
|------|---------------|-------------------|
| 단위 라벨 | "골" | "점" |
| 이모지 | ⚽ | 🏀 |

"득점", "득점왕" 같은 종목 무관 라벨은 그대로 유지해도 됩니다.

### 우선순위
- ⚽ 이모지가 농구 페이지에 그대로 노출되는 것이 가장 눈에 띄므로 최우선 수정 권장
- 단위 라벨("골" → "점")은 의미 정확성 측면에서 함께 수정 권장