### PR TITLE
fix: 응원톡 마스킹 LLM 추론 텍스트 누수 차단

### DIFF
--- a/src/main/java/com/sports/server/command/cheertalk/infra/GeminiClient.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/GeminiClient.java
@@ -37,8 +37,7 @@ public class GeminiClient implements MaskingClient {
             if (response == null) {
                 return content;
             }
-            String text = response.getFirstText();
-            return text == null || text.isEmpty() ? content : text;
+            return MaskingOutputSanitizer.sanitize(content, response.getFirstText());
         } catch (Exception e) {
             log.error("Gemini masking failed: {}", e.getMessage());
             return content;

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
@@ -1,0 +1,78 @@
+package com.sports.server.command.cheertalk.infra;
+
+import java.util.List;
+
+/**
+ * LLM 응답 텍스트에서 추론/메타 코멘트가 새어 나온 경우를 탐지해 원문으로 폴백한다.
+ * "의심스러우면 마스킹하지 않는다"는 기존 정책의 출력단 방어선.
+ */
+public final class MaskingOutputSanitizer {
+
+    private static final int LENGTH_BUFFER = 50;
+    private static final int LENGTH_MULTIPLIER = 3;
+    private static final int MAX_NEWLINES_FOR_SINGLE_LINE_INPUT = 2;
+
+    private static final List<String> LEAK_MARKERS = List.of(
+            "---",
+            "처리하겠습니다",
+            "본 답변은",
+            "다음과 같이",
+            "필터링 범위",
+            "범위를 벗어",
+            "응원톡 필터링",
+            "포함되어 있지 않아",
+            "보입니다",
+            "출력합니다",
+            "마스킹하지 않",
+            "마스킹할 필요"
+    );
+
+    private MaskingOutputSanitizer() {
+    }
+
+    public static String sanitize(String original, String modelOutput) {
+        if (modelOutput == null || modelOutput.isBlank()) {
+            return original;
+        }
+        if (isTooLong(original, modelOutput)) {
+            return original;
+        }
+        if (hasUnexpectedNewlines(original, modelOutput)) {
+            return original;
+        }
+        if (containsLeakMarker(modelOutput)) {
+            return original;
+        }
+        return modelOutput;
+    }
+
+    private static boolean isTooLong(String original, String modelOutput) {
+        return modelOutput.length() > original.length() * LENGTH_MULTIPLIER + LENGTH_BUFFER;
+    }
+
+    private static boolean hasUnexpectedNewlines(String original, String modelOutput) {
+        if (countNewlines(original) > 0) {
+            return false;
+        }
+        return countNewlines(modelOutput) > MAX_NEWLINES_FOR_SINGLE_LINE_INPUT;
+    }
+
+    private static int countNewlines(String s) {
+        int count = 0;
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) == '\n') {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static boolean containsLeakMarker(String modelOutput) {
+        for (String marker : LEAK_MARKERS) {
+            if (modelOutput.contains(marker)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
@@ -10,19 +10,18 @@ public final class MaskingOutputSanitizer {
 
     private static final int LENGTH_BUFFER = 50;
     private static final int LENGTH_MULTIPLIER = 3;
-    private static final int MAX_NEWLINES_FOR_SINGLE_LINE_INPUT = 2;
+    private static final int NEWLINE_BUFFER = 2;
 
     private static final List<String> LEAK_MARKERS = List.of(
             "---",
             "처리하겠습니다",
             "본 답변은",
-            "다음과 같이",
+            "다음과 같이 처리",
             "필터링 범위",
             "범위를 벗어",
             "응원톡 필터링",
             "포함되어 있지 않아",
-            "보입니다",
-            "출력합니다",
+            "그대로 출력합니다",
             "마스킹하지 않",
             "마스킹할 필요"
     );
@@ -51,10 +50,7 @@ public final class MaskingOutputSanitizer {
     }
 
     private static boolean hasUnexpectedNewlines(String original, String modelOutput) {
-        if (countNewlines(original) > 0) {
-            return false;
-        }
-        return countNewlines(modelOutput) > MAX_NEWLINES_FOR_SINGLE_LINE_INPUT;
+        return countNewlines(modelOutput) > countNewlines(original) + NEWLINE_BUFFER;
     }
 
     private static int countNewlines(String s) {

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
@@ -30,19 +30,30 @@ public final class MaskingOutputSanitizer {
     }
 
     public static String sanitize(String original, String modelOutput) {
-        if (modelOutput == null || modelOutput.isBlank()) {
+        if (modelOutput == null) {
             return original;
         }
-        if (isTooLong(original, modelOutput)) {
+        String stripped = modelOutput.strip();
+        if (stripped.isEmpty()) {
             return original;
         }
-        if (hasUnexpectedNewlines(original, modelOutput)) {
+        if (isTooLong(original, stripped)) {
             return original;
         }
-        if (containsLeakMarker(modelOutput)) {
+        if (hasUnexpectedNewlines(original, stripped)) {
             return original;
         }
-        return modelOutput;
+        if (containsLeakMarker(stripped)) {
+            return original;
+        }
+        if (isModifiedWithoutMask(original, stripped)) {
+            return original;
+        }
+        return stripped;
+    }
+
+    private static boolean isModifiedWithoutMask(String original, String modelOutput) {
+        return !modelOutput.equals(original) && !modelOutput.contains("*");
     }
 
     private static boolean isTooLong(String original, String modelOutput) {

--- a/src/main/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClient.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClient.java
@@ -48,8 +48,7 @@ public class OpenRouterMaskingClient implements MaskingClient {
             if (response == null) {
                 return content;
             }
-            String text = response.getText();
-            return text == null || text.isEmpty() ? content : text;
+            return MaskingOutputSanitizer.sanitize(content, response.getText());
         } catch (Exception e) {
             log.error("OpenRouter masking failed: {}", e.getMessage());
             return content;

--- a/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
@@ -86,6 +86,37 @@ class MaskingOutputSanitizerTest {
             String result = MaskingOutputSanitizer.sanitize(original, leaked);
             assertThat(result).isEqualTo(original);
         }
+
+        @Test
+        void 마스킹_없이_변형된_응답은_원문() {
+            String result = MaskingOutputSanitizer.sanitize("벤치라네", "벤치라네요");
+            assertThat(result).isEqualTo("벤치라네");
+        }
+
+        @Test
+        void 짧은_판단문은_원문() {
+            assertThat(MaskingOutputSanitizer.sanitize("벤치라네", "욕설 없음"))
+                    .isEqualTo("벤치라네");
+            assertThat(MaskingOutputSanitizer.sanitize("벤치라네", "해당 문장은 문제 없습니다."))
+                    .isEqualTo("벤치라네");
+        }
+    }
+
+    @Nested
+    @DisplayName("응답을 정규화한다")
+    class Normalize {
+
+        @Test
+        void 좌우_공백과_개행을_제거한다() {
+            String result = MaskingOutputSanitizer.sanitize("씨발 비속어", "** 비속어\n");
+            assertThat(result).isEqualTo("** 비속어");
+        }
+
+        @Test
+        void 전후_공백도_제거한다() {
+            String result = MaskingOutputSanitizer.sanitize("씨발 비속어", "  ** 비속어  ");
+            assertThat(result).isEqualTo("** 비속어");
+        }
     }
 
     @Nested

--- a/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
@@ -64,6 +64,22 @@ class MaskingOutputSanitizerTest {
         }
 
         @Test
+        void 다중라인_입력_대비_개행이_급증하면_원문() {
+            String original = "1줄\n2줄";
+            String leaked = "1줄\n2줄\n\n\n\n추론이 새는 케이스";
+            String result = MaskingOutputSanitizer.sanitize(original, leaked);
+            assertThat(result).isEqualTo(original);
+        }
+
+        @Test
+        void 다중라인_입력에_같은_라인수_응답은_통과() {
+            String original = "1줄\n2줄";
+            String masked = "1줄\n** 마스킹";
+            String result = MaskingOutputSanitizer.sanitize(original, masked);
+            assertThat(result).isEqualTo(masked);
+        }
+
+        @Test
         void 추론_누수_마커_포함시_원문() {
             String original = "벤치라네";
             String leaked = "벤치라네 --- 해당 요청에 다음과 같이 처리하겠습니다: 벤치라네";

--- a/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
@@ -1,0 +1,93 @@
+package com.sports.server.command.cheertalk.infra;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MaskingOutputSanitizerTest {
+
+    @Nested
+    @DisplayName("정상 응답은 그대로 통과한다")
+    class PassThrough {
+
+        @Test
+        void 마스킹된_텍스트_그대로_반환() {
+            String result = MaskingOutputSanitizer.sanitize("씨발 비속어", "** 비속어");
+            assertThat(result).isEqualTo("** 비속어");
+        }
+
+        @Test
+        void 변경_없는_원문도_그대로_반환() {
+            String result = MaskingOutputSanitizer.sanitize("파이팅", "파이팅");
+            assertThat(result).isEqualTo("파이팅");
+        }
+    }
+
+    @Nested
+    @DisplayName("출력이 비정상이면 원문으로 폴백한다")
+    class Fallback {
+
+        @Test
+        void null_응답은_원문() {
+            String result = MaskingOutputSanitizer.sanitize("응원톡", null);
+            assertThat(result).isEqualTo("응원톡");
+        }
+
+        @Test
+        void 빈_응답은_원문() {
+            String result = MaskingOutputSanitizer.sanitize("응원톡", "");
+            assertThat(result).isEqualTo("응원톡");
+        }
+
+        @Test
+        void 공백만_있는_응답은_원문() {
+            String result = MaskingOutputSanitizer.sanitize("응원톡", "   \n  ");
+            assertThat(result).isEqualTo("응원톡");
+        }
+
+        @Test
+        void 길이가_원본의_3배_초과면_원문() {
+            String original = "벤치라네";
+            String leaked = "벤치라네 ".repeat(20);
+            String result = MaskingOutputSanitizer.sanitize(original, leaked);
+            assertThat(result).isEqualTo(original);
+        }
+
+        @Test
+        void 단일라인_입력에_여러줄_응답이면_원문() {
+            String original = "응원톡 한줄";
+            String leaked = "응원톡 한줄\n\n\n추론이 새는 케이스";
+            String result = MaskingOutputSanitizer.sanitize(original, leaked);
+            assertThat(result).isEqualTo(original);
+        }
+
+        @Test
+        void 추론_누수_마커_포함시_원문() {
+            String original = "벤치라네";
+            String leaked = "벤치라네 --- 해당 요청에 다음과 같이 처리하겠습니다: 벤치라네";
+            String result = MaskingOutputSanitizer.sanitize(original, leaked);
+            assertThat(result).isEqualTo(original);
+        }
+    }
+
+    @Nested
+    @DisplayName("실제 운영 누수 케이스 회귀")
+    class RealWorldRegression {
+
+        @Test
+        @DisplayName("일본어 오인식 케이스 — 모델이 추론 텍스트와 결과를 함께 출력")
+        void 일본어_오인식_누수() {
+            String original = "벤치라네";
+            String leaked = "ベンチラね Deze 문장은 일본어로 보이는데, 스포츠 응원톡 필터링 범위를 벗어납니다."
+                    + " 하지만 비속어나 욕설이 포함되어 있지 않아 그대로 출력합니다."
+                    + " (본 답변은 일본어 문장에 대한 처리를 위해 추가되었으며, 일반적인 응원톡 필터링 범위에서는 적용되지 않습니다.)"
+                    + " --- 해당 요청에 다음과 같이 처리하겠습니다: 벤치라네요";
+
+            String result = MaskingOutputSanitizer.sanitize(original, leaked);
+
+            assertThat(result).isEqualTo(original);
+        }
+    }
+}

--- a/src/test/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClientTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClientTest.java
@@ -96,6 +96,19 @@ class OpenRouterMaskingClientTest {
         assertThat(result).isEqualTo("그대로");
     }
 
+    @Test
+    @DisplayName("모델이 추론 텍스트를 함께 뱉어도 원문을 반환한다")
+    void 추론_누수_시_원문() {
+        String leaked = "ベンチラね 문장은 일본어로 보이는데, 스포츠 응원톡 필터링 범위를 벗어납니다."
+                + " --- 해당 요청에 다음과 같이 처리하겠습니다: 벤치라네요";
+        when(chatCaller.call(any(), any(Duration.class)))
+                .thenReturn(responseOf(leaked));
+
+        String result = client.mask("벤치라네");
+
+        assertThat(result).isEqualTo("벤치라네");
+    }
+
     private OpenRouterChatResponse responseOf(String text) {
         return new OpenRouterChatResponse(List.of(
                 new OpenRouterChatResponse.Choice(


### PR DESCRIPTION
## 이슈

closes #611

## 변경 내용

응원톡 마스킹 모듈이 LLM 응답 텍스트를 sanitization 없이 그대로 응원톡 내용으로 저장하던 문제 수정. **출력단 sanitizer + 프롬프트 강화** 2축 방어선.

### 1. 출력단 가드 (`MaskingOutputSanitizer`)
- 응답 길이가 원본의 3배+50자 초과 → 원문 폴백
- 단일라인 입력에 다중 개행(2줄 초과) 응답 → 원문 폴백
- 누수 마커 포함(`---`, `처리하겠습니다`, `본 답변은`, `필터링 범위`, `보입니다`, `출력합니다` 등) → 원문 폴백
- `GeminiClient.mask()` / `OpenRouterMaskingClient.mask()` 둘 다 sanitizer 통과
- 기존 정책("의심스러우면 마스킹하지 마")을 출력단에도 적용

### 2. 프롬프트 강화 (be-config 서브모듈)
- 한국어 외 언어/의미 불명 시 입력 그대로 출력 규칙 추가 (운영 누수 케이스 직접 대응)
- 출력 규칙 강화: 메타 코멘트/구분선/유도 표현 명시 금지
- few-shot 예시 4개로 형식 앵커링
- 서브모듈 PR: hufs-sports-live/be-config#17

## 테스트

- `MaskingOutputSanitizerTest` 신규 — 정상 통과 / 길이·개행·마커 폴백 / 운영 누수 케이스 회귀
- `OpenRouterMaskingClientTest`에 추론 누수 회귀 추가
- 운영에서 실제 노출됐던 일본어 오인식 케이스(`ベンチラね Deze ... 처리하겠습니다: 벤치라네요`) → 원문 `벤치라네`로 폴백 검증
- 빌드/테스트 그린 (`BUILD SUCCESSFUL`)

## 영향 API

내부 변경(infra 레이어). API 시그니처 변화 없음.

`POST /cheer-talks/masking` 응답 동작:
- 정상 마스킹: 기존 동작 유지
- 모델 추론 누수 시: 마스킹 안 한 것으로 간주(`maskingState=false`, 원문 반환)

## 프론트 참고

API 동작 변화 없음. 누수 케이스에서 마스킹 미적용으로 처리되므로, 일부 false negative가 발생할 수 있으나 추후 구조화 출력(JSON Schema) 후속 PR에서 추가 강화 예정.

## 머지 순서 주의

이 PR은 서브모듈 포인터를 be-config#17 브랜치 tip으로 가리킴. 순서:
1. be-config#17 먼저 머지
2. 머지된 커밋으로 서브모듈 포인터 re-bump (이 PR에 추가 커밋)
3. 이 PR 머지

## 후속 작업

- 구조화 출력 강제 (Gemini `responseSchema`, OpenRouter `response_format`) — 별도 PR