### PR TITLE
refactor: 응원톡 마스킹 누수 마커 yml 외부화 (#612 후속)

### DIFF
--- a/src/main/java/com/sports/server/command/cheertalk/infra/GeminiClient.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/GeminiClient.java
@@ -16,15 +16,18 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class GeminiClient implements MaskingClient {
 
     private final WebClient geminiWebClient;
+    private final MaskingOutputSanitizer sanitizer;
     private final String apiKey;
     private final String prompt;
 
     public GeminiClient(
             WebClient geminiWebClient,
+            MaskingOutputSanitizer sanitizer,
             @Value("${gemini.api.key}") String apiKey,
             @Value("${gemini.api.prompt}") String prompt
     ) {
         this.geminiWebClient = geminiWebClient;
+        this.sanitizer = sanitizer;
         this.apiKey = apiKey;
         this.prompt = prompt;
     }
@@ -37,7 +40,7 @@ public class GeminiClient implements MaskingClient {
             if (response == null) {
                 return content;
             }
-            return MaskingOutputSanitizer.sanitize(content, response.getFirstText());
+            return sanitizer.sanitize(content, response.getFirstText());
         } catch (Exception e) {
             log.error("Gemini masking failed: {}", e.getMessage());
             return content;

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
@@ -4,6 +4,10 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+/**
+ * LLM 응답 텍스트에서 추론/메타 코멘트가 새어 나온 경우를 탐지해 원문으로 폴백한다.
+ * "의심스러우면 마스킹하지 않는다"는 기존 정책의 출력단 방어선.
+ */
 @Component
 public class MaskingOutputSanitizer {
 
@@ -11,7 +15,7 @@ public class MaskingOutputSanitizer {
     private static final int LENGTH_MULTIPLIER = 3;
     private static final int NEWLINE_BUFFER = 2;
 
-    static final List<String> DEFAULT_LEAK_MARKERS = List.of(
+    private static final List<String> DEFAULT_LEAK_MARKERS = List.of(
             "---",
             "처리하겠습니다",
             "본 답변은",
@@ -32,6 +36,7 @@ public class MaskingOutputSanitizer {
     ) {
         List<String> filtered = leakMarkers.stream()
                 .filter(s -> s != null && !s.isBlank())
+                .map(String::strip)
                 .toList();
         this.leakMarkers = filtered.isEmpty() ? DEFAULT_LEAK_MARKERS : filtered;
     }

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
@@ -1,18 +1,17 @@
 package com.sports.server.command.cheertalk.infra;
 
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
-/**
- * LLM 응답 텍스트에서 추론/메타 코멘트가 새어 나온 경우를 탐지해 원문으로 폴백한다.
- * "의심스러우면 마스킹하지 않는다"는 기존 정책의 출력단 방어선.
- */
-public final class MaskingOutputSanitizer {
+@Component
+public class MaskingOutputSanitizer {
 
     private static final int LENGTH_BUFFER = 50;
     private static final int LENGTH_MULTIPLIER = 3;
     private static final int NEWLINE_BUFFER = 2;
 
-    private static final List<String> LEAK_MARKERS = List.of(
+    static final List<String> DEFAULT_LEAK_MARKERS = List.of(
             "---",
             "처리하겠습니다",
             "본 답변은",
@@ -26,10 +25,18 @@ public final class MaskingOutputSanitizer {
             "마스킹할 필요"
     );
 
-    private MaskingOutputSanitizer() {
+    private final List<String> leakMarkers;
+
+    public MaskingOutputSanitizer(
+            @Value("${masking.leak-markers:}") List<String> leakMarkers
+    ) {
+        List<String> filtered = leakMarkers.stream()
+                .filter(s -> s != null && !s.isBlank())
+                .toList();
+        this.leakMarkers = filtered.isEmpty() ? DEFAULT_LEAK_MARKERS : filtered;
     }
 
-    public static String sanitize(String original, String modelOutput) {
+    public String sanitize(String original, String modelOutput) {
         if (modelOutput == null) {
             return original;
         }
@@ -52,19 +59,19 @@ public final class MaskingOutputSanitizer {
         return stripped;
     }
 
-    private static boolean isModifiedWithoutMask(String original, String modelOutput) {
+    private boolean isModifiedWithoutMask(String original, String modelOutput) {
         return !modelOutput.equals(original) && !modelOutput.contains("*");
     }
 
-    private static boolean isTooLong(String original, String modelOutput) {
+    private boolean isTooLong(String original, String modelOutput) {
         return modelOutput.length() > original.length() * LENGTH_MULTIPLIER + LENGTH_BUFFER;
     }
 
-    private static boolean hasUnexpectedNewlines(String original, String modelOutput) {
+    private boolean hasUnexpectedNewlines(String original, String modelOutput) {
         return countNewlines(modelOutput) > countNewlines(original) + NEWLINE_BUFFER;
     }
 
-    private static int countNewlines(String s) {
+    private int countNewlines(String s) {
         int count = 0;
         for (int i = 0; i < s.length(); i++) {
             if (s.charAt(i) == '\n') {
@@ -74,8 +81,8 @@ public final class MaskingOutputSanitizer {
         return count;
     }
 
-    private static boolean containsLeakMarker(String modelOutput) {
-        for (String marker : LEAK_MARKERS) {
+    private boolean containsLeakMarker(String modelOutput) {
+        for (String marker : leakMarkers) {
             if (modelOutput.contains(marker)) {
                 return true;
             }

--- a/src/main/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClient.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClient.java
@@ -20,15 +20,18 @@ public class OpenRouterMaskingClient implements MaskingClient {
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
 
     private final OpenRouterChatCaller chatCaller;
+    private final MaskingOutputSanitizer sanitizer;
     private final String systemPrompt;
     private final String model;
 
     public OpenRouterMaskingClient(
             OpenRouterChatCaller chatCaller,
+            MaskingOutputSanitizer sanitizer,
             @Value("${openrouter.api.masking-prompt:${gemini.api.prompt}}") String systemPrompt,
             @Value("${openrouter.api.masking-model:${openrouter.api.model:qwen/qwen-2.5-72b-instruct}}") String model
     ) {
         this.chatCaller = chatCaller;
+        this.sanitizer = sanitizer;
         this.systemPrompt = systemPrompt;
         this.model = model;
     }
@@ -48,7 +51,7 @@ public class OpenRouterMaskingClient implements MaskingClient {
             if (response == null) {
                 return content;
             }
-            return MaskingOutputSanitizer.sanitize(content, response.getText());
+            return sanitizer.sanitize(content, response.getText());
         } catch (Exception e) {
             log.error("OpenRouter masking failed: {}", e.getMessage());
             return content;

--- a/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
@@ -1,5 +1,6 @@
 package com.sports.server.command.cheertalk.infra;
 
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -8,19 +9,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class MaskingOutputSanitizerTest {
 
+    private final MaskingOutputSanitizer sanitizer = new MaskingOutputSanitizer(List.of());
+
     @Nested
     @DisplayName("정상 응답은 그대로 통과한다")
     class PassThrough {
 
         @Test
         void 마스킹된_텍스트_그대로_반환() {
-            String result = MaskingOutputSanitizer.sanitize("씨발 비속어", "** 비속어");
+            String result = sanitizer.sanitize("씨발 비속어", "** 비속어");
             assertThat(result).isEqualTo("** 비속어");
         }
 
         @Test
         void 변경_없는_원문도_그대로_반환() {
-            String result = MaskingOutputSanitizer.sanitize("파이팅", "파이팅");
+            String result = sanitizer.sanitize("파이팅", "파이팅");
             assertThat(result).isEqualTo("파이팅");
         }
     }
@@ -31,19 +34,19 @@ class MaskingOutputSanitizerTest {
 
         @Test
         void null_응답은_원문() {
-            String result = MaskingOutputSanitizer.sanitize("응원톡", null);
+            String result = sanitizer.sanitize("응원톡", null);
             assertThat(result).isEqualTo("응원톡");
         }
 
         @Test
         void 빈_응답은_원문() {
-            String result = MaskingOutputSanitizer.sanitize("응원톡", "");
+            String result = sanitizer.sanitize("응원톡", "");
             assertThat(result).isEqualTo("응원톡");
         }
 
         @Test
         void 공백만_있는_응답은_원문() {
-            String result = MaskingOutputSanitizer.sanitize("응원톡", "   \n  ");
+            String result = sanitizer.sanitize("응원톡", "   \n  ");
             assertThat(result).isEqualTo("응원톡");
         }
 
@@ -51,7 +54,7 @@ class MaskingOutputSanitizerTest {
         void 길이가_원본의_3배_초과면_원문() {
             String original = "벤치라네";
             String leaked = "벤치라네 ".repeat(20);
-            String result = MaskingOutputSanitizer.sanitize(original, leaked);
+            String result = sanitizer.sanitize(original, leaked);
             assertThat(result).isEqualTo(original);
         }
 
@@ -59,7 +62,7 @@ class MaskingOutputSanitizerTest {
         void 단일라인_입력에_여러줄_응답이면_원문() {
             String original = "응원톡 한줄";
             String leaked = "응원톡 한줄\n\n\n추론이 새는 케이스";
-            String result = MaskingOutputSanitizer.sanitize(original, leaked);
+            String result = sanitizer.sanitize(original, leaked);
             assertThat(result).isEqualTo(original);
         }
 
@@ -67,7 +70,7 @@ class MaskingOutputSanitizerTest {
         void 다중라인_입력_대비_개행이_급증하면_원문() {
             String original = "1줄\n2줄";
             String leaked = "1줄\n2줄\n\n\n\n추론이 새는 케이스";
-            String result = MaskingOutputSanitizer.sanitize(original, leaked);
+            String result = sanitizer.sanitize(original, leaked);
             assertThat(result).isEqualTo(original);
         }
 
@@ -75,7 +78,7 @@ class MaskingOutputSanitizerTest {
         void 다중라인_입력에_같은_라인수_응답은_통과() {
             String original = "1줄\n2줄";
             String masked = "1줄\n** 마스킹";
-            String result = MaskingOutputSanitizer.sanitize(original, masked);
+            String result = sanitizer.sanitize(original, masked);
             assertThat(result).isEqualTo(masked);
         }
 
@@ -83,21 +86,21 @@ class MaskingOutputSanitizerTest {
         void 추론_누수_마커_포함시_원문() {
             String original = "벤치라네";
             String leaked = "벤치라네 --- 해당 요청에 다음과 같이 처리하겠습니다: 벤치라네";
-            String result = MaskingOutputSanitizer.sanitize(original, leaked);
+            String result = sanitizer.sanitize(original, leaked);
             assertThat(result).isEqualTo(original);
         }
 
         @Test
         void 마스킹_없이_변형된_응답은_원문() {
-            String result = MaskingOutputSanitizer.sanitize("벤치라네", "벤치라네요");
+            String result = sanitizer.sanitize("벤치라네", "벤치라네요");
             assertThat(result).isEqualTo("벤치라네");
         }
 
         @Test
         void 짧은_판단문은_원문() {
-            assertThat(MaskingOutputSanitizer.sanitize("벤치라네", "욕설 없음"))
+            assertThat(sanitizer.sanitize("벤치라네", "욕설 없음"))
                     .isEqualTo("벤치라네");
-            assertThat(MaskingOutputSanitizer.sanitize("벤치라네", "해당 문장은 문제 없습니다."))
+            assertThat(sanitizer.sanitize("벤치라네", "해당 문장은 문제 없습니다."))
                     .isEqualTo("벤치라네");
         }
     }
@@ -108,13 +111,13 @@ class MaskingOutputSanitizerTest {
 
         @Test
         void 좌우_공백과_개행을_제거한다() {
-            String result = MaskingOutputSanitizer.sanitize("씨발 비속어", "** 비속어\n");
+            String result = sanitizer.sanitize("씨발 비속어", "** 비속어\n");
             assertThat(result).isEqualTo("** 비속어");
         }
 
         @Test
         void 전후_공백도_제거한다() {
-            String result = MaskingOutputSanitizer.sanitize("씨발 비속어", "  ** 비속어  ");
+            String result = sanitizer.sanitize("씨발 비속어", "  ** 비속어  ");
             assertThat(result).isEqualTo("** 비속어");
         }
     }
@@ -132,9 +135,36 @@ class MaskingOutputSanitizerTest {
                     + " (본 답변은 일본어 문장에 대한 처리를 위해 추가되었으며, 일반적인 응원톡 필터링 범위에서는 적용되지 않습니다.)"
                     + " --- 해당 요청에 다음과 같이 처리하겠습니다: 벤치라네요";
 
-            String result = MaskingOutputSanitizer.sanitize(original, leaked);
+            String result = sanitizer.sanitize(original, leaked);
 
             assertThat(result).isEqualTo(original);
+        }
+    }
+
+    @Nested
+    @DisplayName("yml 외부 설정")
+    class ExternalConfig {
+
+        @Test
+        void yml에서_커스텀_마커를_받으면_default를_대체한다() {
+            MaskingOutputSanitizer custom = new MaskingOutputSanitizer(List.of("커스텀마커"));
+
+            assertThat(custom.sanitize("응원 비속어", "** 커스텀마커")).isEqualTo("응원 비속어");
+            assertThat(custom.sanitize("응원 비속어", "** 처리하겠습니다")).isEqualTo("** 처리하겠습니다");
+        }
+
+        @Test
+        void 빈_리스트면_default_마커가_적용된다() {
+            MaskingOutputSanitizer empty = new MaskingOutputSanitizer(List.of());
+
+            assertThat(empty.sanitize("응원 비속어", "** 처리하겠습니다")).isEqualTo("응원 비속어");
+        }
+
+        @Test
+        void 공백_엔트리는_무시되고_default가_적용된다() {
+            MaskingOutputSanitizer blanks = new MaskingOutputSanitizer(List.of("  ", ""));
+
+            assertThat(blanks.sanitize("응원 비속어", "** 처리하겠습니다")).isEqualTo("응원 비속어");
         }
     }
 }

--- a/src/test/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClientTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClientTest.java
@@ -28,7 +28,8 @@ class OpenRouterMaskingClientTest {
     @BeforeEach
     void setUp() {
         chatCaller = mock(OpenRouterChatCaller.class);
-        client = new OpenRouterMaskingClient(chatCaller, SYSTEM_PROMPT, MODEL);
+        MaskingOutputSanitizer sanitizer = new MaskingOutputSanitizer(List.of());
+        client = new OpenRouterMaskingClient(chatCaller, sanitizer, SYSTEM_PROMPT, MODEL);
     }
 
     @Test


### PR DESCRIPTION
## 이슈
PR #612 리뷰 반영

1. \`MaskingOutputSanitizer\`가 정적 메서드 + 상수 \`LEAK_MARKERS\` 구성이라 운영 중 누수 패턴 변경 시 코드 수정 + 재배포가 필요했던 점
2. yml 외부화로 환경별 마커 셋 분리 가능하도록 개선 요청

## 변경 내용
### spectator-server
- \`MaskingOutputSanitizer\` 정적 클래스 → \`@Component\` + 인스턴스 메서드로 전환
- \`@Value(\"\${masking.leak-markers:}\")\`로 yml CSV 주입 (Spring이 \`List<String>\` 자동 바인딩)
- 빈 리스트/공백 엔트리는 무시하고 default 마커(\`DEFAULT_LEAK_MARKERS\`)로 폴백 → yml 누락 시 기존 동작 유지
- \`GeminiClient\`, \`OpenRouterMaskingClient\` 생성자 주입으로 변경
- 외부 설정 케이스 회귀 테스트 3건 추가 (커스텀 마커, 빈 리스트, 공백 엔트리)

### be-config
- \`application-{dev,prod}.yml\`에 \`masking.leak-markers\` 항목 추가
- 머지된 PR: hufscheer/be-config#18 (이미 main 반영, 본 PR에서 서브모듈 포인터 bump)

## 테스트
- [x] \`./gradlew clean test --tests \"com.sports.server.command.cheertalk.infra.*\"\` BUILD SUCCESSFUL
- [x] \`MaskingOutputSanitizerTest.ExternalConfig\`: 커스텀 마커가 default를 대체하는지, 빈 리스트일 때 default가 살아있는지 검증
- [x] 기존 회귀 케이스(일본어 오인식 누수 등) 모두 통과

## 영향 API
없음. 출력단 sanitizer 내부 리팩터링.

## 프론트 참고
없음.