### PR TITLE
이미 주장이 존재하는 경우 주장 변경 불가능 오류 해결

### DIFF
--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -109,7 +109,6 @@ public class GameTeam extends BaseEntity<GameTeam> {
 
     public void changePlayerToCaptain(final LineupPlayer lineupPlayer) {
         validateLineupPlayer(lineupPlayer);
-        isCaptainExists(lineupPlayer);
         lineupPlayer.changePlayerToCaptain();
     }
 
@@ -124,15 +123,6 @@ public class GameTeam extends BaseEntity<GameTeam> {
 
         if (!exists) {
             throw new BadRequestException(ExceptionMessages.GAME_TEAM_PLAYER_NOT_IN_TEAM);
-        }
-    }
-
-    private void isCaptainExists(final LineupPlayer lineupPlayer) {
-        boolean captainExists = lineupPlayers.stream()
-                .anyMatch(lp -> lp.isCaptain() && !lp.equals(lineupPlayer));
-
-        if (captainExists) {
-            throw new BadRequestException(ExceptionMessages.GAME_TEAM_CAPTAIN_ALREADY_EXISTS);
         }
     }
 

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -109,7 +109,12 @@ public class GameTeam extends BaseEntity<GameTeam> {
 
     public void changePlayerToCaptain(final LineupPlayer lineupPlayer) {
         validateLineupPlayer(lineupPlayer);
-        lineupPlayer.changePlayerToCaptain();
+        lineupPlayers.stream()
+                .filter(lp -> lp.isCaptain() && !lp.equals(lineupPlayer))
+                .forEach(LineupPlayer::revokeCaptainFromPlayer);
+        if (!lineupPlayer.isCaptain()) {
+            lineupPlayer.changePlayerToCaptain();
+        }
     }
 
     public void revokeCaptainFromPlayer(final LineupPlayer lineupPlayer) {

--- a/src/main/java/com/sports/server/command/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/command/game/presentation/GameController.java
@@ -78,7 +78,7 @@ public class GameController {
         gameService.deleteGameTeam(gameTeamId, member);
     }
 
-    @PatchMapping("/games/{gameId}/lineup-players/{lineupPlayerId}/captain/register")
+    @PutMapping("/games/{gameId}/lineup-players/{lineupPlayerId}/captain/register")
     @ResponseStatus(HttpStatus.OK)
     public void changePlayerToCaptain(@PathVariable final Long gameId,
                                       @PathVariable final Long lineupPlayerId) {

--- a/src/main/java/com/sports/server/common/exception/ExceptionMessages.java
+++ b/src/main/java/com/sports/server/common/exception/ExceptionMessages.java
@@ -35,7 +35,6 @@ public class ExceptionMessages {
     public static final String GAME_TEAM_INVALID_CHEER_COUNT_RANGE = "잘못된 범위의 응원 요청 횟수입니다.";
     public static final String GAME_TEAM_CHEER_COUNT_LIMIT_EXCEEDED = "총 응원 횟수가 한계에 도달했습니다.";
     public static final String GAME_TEAM_PLAYER_NOT_IN_TEAM = "해당 게임팀에 속하지 않는 선수입니다.";
-    public static final String GAME_TEAM_CAPTAIN_ALREADY_EXISTS = "이미 등록된 주장이 존재합니다.";
 
     // LineupPlayer 관련
     public static final String LINEUP_PLAYER_ALREADY_STARTER = "이미 선발로 등록된 선수입니다.";

--- a/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
@@ -282,7 +282,7 @@ public class GameAcceptanceTest extends AcceptanceTest {
         RestAssured.given().log().all()
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .patch("/games/{gameId}/lineup-players/{lineupPlayerId}/captain/register", gameId,
+                .put("/games/{gameId}/lineup-players/{lineupPlayerId}/captain/register", gameId,
                         lineupPlayerId)
                 .then().log().all()
                 .extract();

--- a/src/test/java/com/sports/server/command/game/domain/GameTeamTest.java
+++ b/src/test/java/com/sports/server/command/game/domain/GameTeamTest.java
@@ -1,6 +1,7 @@
 package com.sports.server.command.game.domain;
 
 import static com.sports.server.support.fixture.FixtureMonkeyUtils.entityBuilder;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.sports.server.common.exception.CustomException;
@@ -39,17 +40,17 @@ public class GameTeamTest {
     }
 
     @Test
-    void 주장을_변경할_때_이미_주장이_존재하는_경우_예외를_던진다() {
+    void 이미_주장이_존재해도_새로운_선수를_주장으로_등록할_수_있다() {
         // given
         LineupPlayer firstLineupPlayer = gameTeam.getLineupPlayers().get(0);
         LineupPlayer secondLineupPlayer = gameTeam.getLineupPlayers().get(1);
         gameTeam.changePlayerToCaptain(firstLineupPlayer);
 
-        // when & then
-        assertThatThrownBy(() -> gameTeam.changePlayerToCaptain(secondLineupPlayer))
-                .isInstanceOf(CustomException.class)
-                .hasMessage("이미 등록된 주장이 존재합니다.");
+        // when
+        gameTeam.changePlayerToCaptain(secondLineupPlayer);
 
+        // then
+        assertThat(secondLineupPlayer.isCaptain()).isTrue();
     }
 }
 

--- a/src/test/java/com/sports/server/command/game/domain/GameTeamTest.java
+++ b/src/test/java/com/sports/server/command/game/domain/GameTeamTest.java
@@ -40,7 +40,7 @@ public class GameTeamTest {
     }
 
     @Test
-    void 이미_주장이_존재해도_새로운_선수를_주장으로_등록할_수_있다() {
+    void 새로운_주장을_등록하면_기존_주장은_자동으로_해제된다() {
         // given
         LineupPlayer firstLineupPlayer = gameTeam.getLineupPlayers().get(0);
         LineupPlayer secondLineupPlayer = gameTeam.getLineupPlayers().get(1);
@@ -50,7 +50,21 @@ public class GameTeamTest {
         gameTeam.changePlayerToCaptain(secondLineupPlayer);
 
         // then
+        assertThat(firstLineupPlayer.isCaptain()).isFalse();
         assertThat(secondLineupPlayer.isCaptain()).isTrue();
+    }
+
+    @Test
+    void 이미_주장인_선수를_다시_주장으로_등록해도_예외가_발생하지_않는다() {
+        // given
+        LineupPlayer lineupPlayer = gameTeam.getLineupPlayers().get(0);
+        gameTeam.changePlayerToCaptain(lineupPlayer);
+
+        // when
+        gameTeam.changePlayerToCaptain(lineupPlayer);
+
+        // then
+        assertThat(lineupPlayer.isCaptain()).isTrue();
     }
 }
 

--- a/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
+++ b/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
@@ -282,7 +282,7 @@ public class GameControllerTest extends DocumentationTest {
 
         //when
         ResultActions result = mockMvc.perform(
-                patch("/games/{gameId}/lineup-players/{lineupPlayerId}/captain/register", gameId,
+                put("/games/{gameId}/lineup-players/{lineupPlayerId}/captain/register", gameId,
                         lineupPlayerId)
                         .contentType(MediaType.APPLICATION_JSON)
         );


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #620 

## 📝 구현 내용
- 기존에는 해당 API 를 주장 등록 용도로만 쓸 것으로 생각해서, 이미 주장이 등록된 경우에는 예외를 던지도록 했어요.
- 수정에도 사용이 되면서, 아예 멱등성을 보장할 수 있도록 중복 검사를 제거하고 PUT mapping 으로 바꿨어요.