### PR TITLE
[FIX] 응원톡 마스킹 LLM 호출 비용 절감 — 1차 필터 + 결과 캐시

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     // comment - bad word filter
     implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
 
+    // local cache
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 

--- a/src/main/java/com/sports/server/command/cheertalk/infra/CachingMaskingClient.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/CachingMaskingClient.java
@@ -1,0 +1,60 @@
+package com.sports.server.command.cheertalk.infra;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.sports.server.command.cheertalk.application.MaskingClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * OpenRouter 마스킹 호출 비용을 줄이기 위한 데코레이터.
+ * 1) preFilter로 명백히 정상인 메시지는 LLM 스킵
+ * 2) LLM이 한 번 처리한 메시지는 결과를 캐싱하여 도배 시 동일 호출 차단
+ */
+@Component
+@Primary
+@ConditionalOnProperty(name = "masking.provider", havingValue = "openrouter")
+public class CachingMaskingClient implements MaskingClient {
+
+    private final OpenRouterMaskingClient delegate;
+    private final MaskingPreFilter preFilter;
+    private final Cache<String, String> cache;
+
+    public CachingMaskingClient(
+            OpenRouterMaskingClient delegate,
+            MaskingPreFilter preFilter,
+            @Value("${masking.cache.ttl-minutes:5}") long ttlMinutes,
+            @Value("${masking.cache.max-size:10000}") long maxSize
+    ) {
+        this.delegate = delegate;
+        this.preFilter = preFilter;
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(maxSize)
+                .expireAfterWrite(Duration.ofMinutes(ttlMinutes))
+                .build();
+    }
+
+    @Override
+    public String mask(String content) {
+        if (content == null) {
+            return null;
+        }
+        if (preFilter.canSkip(content)) {
+            return content;
+        }
+        String key = content.strip();
+        String cached = cache.getIfPresent(key);
+        if (cached != null) {
+            return cached;
+        }
+        String masked = delegate.mask(content);
+        if (masked != null) {
+            cache.put(key, masked);
+        }
+        return masked;
+    }
+}

--- a/src/main/java/com/sports/server/command/cheertalk/infra/CachingMaskingClient.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/CachingMaskingClient.java
@@ -51,10 +51,11 @@ public class CachingMaskingClient implements MaskingClient {
         if (cached != null) {
             return cached;
         }
-        String masked = delegate.mask(content);
-        if (masked != null) {
-            cache.put(key, masked);
+        String masked = delegate.mask(key);
+        if (masked == null) {
+            return content;
         }
+        cache.put(key, masked);
         return masked;
     }
 }

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingPreFilter.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingPreFilter.java
@@ -1,0 +1,72 @@
+package com.sports.server.command.cheertalk.infra;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * LLM 마스킹 호출 전에 명백히 정상인 메시지를 걸러낸다.
+ * 응원톡 도배의 상당수는 추천 문구나 짧은 응원 표현이라 LLM에 보낼 필요가 없다.
+ *
+ * 안전 원칙: 한국어 욕설 가능성이 0인 케이스만 스킵한다.
+ * 비속어 초성(ㅅㅂ 등)은 자모만으로 구성될 수 있으므로 자모 단독 메시지는 LLM에 위임한다.
+ */
+@Component
+public class MaskingPreFilter {
+
+    /**
+     * 프론트(`apps/spectator/.../cheer-talk-form.tsx`)의 RECOMMENDED_MESSAGES와 정확히 일치해야 한다.
+     * 프론트에서 추천 문구를 변경하면 이 리스트도 함께 갱신해야 한다.
+     */
+    private static final Set<String> RECOMMENDED_MESSAGES = Set.of(
+            "가즈아🔥",   // 가즈아🔥
+            "나이스👍",   // 나이스👍
+            "까비😭️" // 까비😭️
+    );
+
+    /**
+     * 응원/긍정 초성 — yml `[절대 마스킹 금지]` 항목 기반 정확 매치.
+     */
+    private static final Set<String> POSITIVE_CONSONANTS = Set.of(
+            "ㅍㅇㅌ", "ㅎㅇㅌ", "ㅎㅇ",
+            "ㄱㄱ", "ㄱㅅ",
+            "ㅊㅋ", "ㄷㄷ", "ㄹㅇ", "ㅇㅈ",
+            "ㄴㄴ", "ㅇㅇ"
+    );
+
+    public boolean canSkip(String content) {
+        if (content == null) {
+            return true;
+        }
+        String trimmed = content.strip();
+        if (trimmed.isEmpty()) {
+            return true;
+        }
+        if (RECOMMENDED_MESSAGES.contains(trimmed)) {
+            return true;
+        }
+        if (POSITIVE_CONSONANTS.contains(trimmed)) {
+            return true;
+        }
+        return !containsAnyHangul(trimmed);
+    }
+
+    private boolean containsAnyHangul(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (isHangul(c)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isHangul(char c) {
+        if (c >= 0xAC00 && c <= 0xD7A3) return true;   // 한글 음절
+        if (c >= 0x1100 && c <= 0x11FF) return true;   // 한글 자모
+        if (c >= 0x3130 && c <= 0x318F) return true;   // 한글 호환 자모
+        if (c >= 0xA960 && c <= 0xA97F) return true;   // 한글 자모 확장-A
+        if (c >= 0xD7B0 && c <= 0xD7FF) return true;   // 한글 자모 확장-B
+        return false;
+    }
+}

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingPreFilter.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingPreFilter.java
@@ -2,7 +2,9 @@ package com.sports.server.command.cheertalk.infra;
 
 import org.springframework.stereotype.Component;
 
+import java.text.Normalizer;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * LLM 마스킹 호출 전에 명백히 정상인 메시지를 걸러낸다.
@@ -22,7 +24,7 @@ public class MaskingPreFilter {
             "가즈아🔥",   // 가즈아🔥
             "나이스👍",   // 나이스👍
             "까비😭️" // 까비😭️
-    );
+    ).stream().map(MaskingPreFilter::nfc).collect(Collectors.toUnmodifiableSet());
 
     /**
      * 응원/긍정 초성 — yml `[절대 마스킹 금지]` 항목 기반 정확 매치.
@@ -32,13 +34,13 @@ public class MaskingPreFilter {
             "ㄱㄱ", "ㄱㅅ",
             "ㅊㅋ", "ㄷㄷ", "ㄹㅇ", "ㅇㅈ",
             "ㄴㄴ", "ㅇㅇ"
-    );
+    ).stream().map(MaskingPreFilter::nfc).collect(Collectors.toUnmodifiableSet());
 
     public boolean canSkip(String content) {
         if (content == null) {
             return true;
         }
-        String trimmed = content.strip();
+        String trimmed = nfc(content).strip();
         if (trimmed.isEmpty()) {
             return true;
         }
@@ -49,6 +51,10 @@ public class MaskingPreFilter {
             return true;
         }
         return !containsAnyHangul(trimmed);
+    }
+
+    private static String nfc(String s) {
+        return Normalizer.normalize(s, Normalizer.Form.NFC);
     }
 
     private boolean containsAnyHangul(String s) {

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingPreFilter.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingPreFilter.java
@@ -1,78 +1,71 @@
 package com.sports.server.command.cheertalk.infra;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.text.Normalizer;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * LLM 마스킹 호출 전에 명백히 정상인 메시지를 걸러낸다.
- * 응원톡 도배의 상당수는 추천 문구나 짧은 응원 표현이라 LLM에 보낼 필요가 없다.
- *
- * 안전 원칙: 한국어 욕설 가능성이 0인 케이스만 스킵한다.
- * 비속어 초성(ㅅㅂ 등)은 자모만으로 구성될 수 있으므로 자모 단독 메시지는 LLM에 위임한다.
+ * 자모 단독 메시지는 비속어 초성일 수 있으므로 화이트리스트에 등록된 케이스만 스킵한다.
  */
 @Component
 public class MaskingPreFilter {
 
-    /**
-     * 프론트(`apps/spectator/.../cheer-talk-form.tsx`)의 RECOMMENDED_MESSAGES와 정확히 일치해야 한다.
-     * 프론트에서 추천 문구를 변경하면 이 리스트도 함께 갱신해야 한다.
-     */
-    private static final Set<String> RECOMMENDED_MESSAGES = Set.of(
-            "가즈아🔥",   // 가즈아🔥
-            "나이스👍",   // 나이스👍
-            "까비😭️" // 까비😭️
-    ).stream().map(MaskingPreFilter::nfc).collect(Collectors.toUnmodifiableSet());
+    private final Set<String> recommendedMessages;
+    private final Set<String> positiveConsonants;
 
-    /**
-     * 응원/긍정 초성 — yml `[절대 마스킹 금지]` 항목 기반 정확 매치.
-     */
-    private static final Set<String> POSITIVE_CONSONANTS = Set.of(
-            "ㅍㅇㅌ", "ㅎㅇㅌ", "ㅎㅇ",
-            "ㄱㄱ", "ㄱㅅ",
-            "ㅊㅋ", "ㄷㄷ", "ㄹㅇ", "ㅇㅈ",
-            "ㄴㄴ", "ㅇㅇ"
-    ).stream().map(MaskingPreFilter::nfc).collect(Collectors.toUnmodifiableSet());
+    public MaskingPreFilter(
+            @Value("${masking.recommended-messages:}") List<String> recommendedMessages,
+            @Value("${masking.positive-consonants:}") List<String> positiveConsonants
+    ) {
+        this.recommendedMessages = toNormalizedSet(recommendedMessages);
+        this.positiveConsonants = toNormalizedSet(positiveConsonants);
+    }
 
     public boolean canSkip(String content) {
         if (content == null) {
             return true;
         }
-        String trimmed = nfc(content).strip();
+        String trimmed = Normalizer.normalize(content, Normalizer.Form.NFC).strip();
         if (trimmed.isEmpty()) {
             return true;
         }
-        if (RECOMMENDED_MESSAGES.contains(trimmed)) {
+        if (recommendedMessages.contains(trimmed)) {
             return true;
         }
-        if (POSITIVE_CONSONANTS.contains(trimmed)) {
+        if (positiveConsonants.contains(trimmed)) {
             return true;
         }
-        return !containsAnyHangul(trimmed);
+        return !containsAnyKorean(trimmed);
     }
 
-    private static String nfc(String s) {
-        return Normalizer.normalize(s, Normalizer.Form.NFC);
+    private static Set<String> toNormalizedSet(List<String> values) {
+        return values.stream()
+                .map(String::strip)
+                .filter(s -> !s.isEmpty())
+                .map(s -> Normalizer.normalize(s, Normalizer.Form.NFC))
+                .collect(Collectors.toUnmodifiableSet());
     }
 
-    private boolean containsAnyHangul(String s) {
+    private boolean containsAnyKorean(String s) {
         for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            if (isHangul(c)) {
+            if (isKorean(s.charAt(i))) {
                 return true;
             }
         }
         return false;
     }
 
-    private boolean isHangul(char c) {
-        if (c >= 0xAC00 && c <= 0xD7A3) return true;   // 한글 음절
-        if (c >= 0x1100 && c <= 0x11FF) return true;   // 한글 자모
-        if (c >= 0x3130 && c <= 0x318F) return true;   // 한글 호환 자모
-        if (c >= 0xA960 && c <= 0xA97F) return true;   // 한글 자모 확장-A
-        if (c >= 0xD7B0 && c <= 0xD7FF) return true;   // 한글 자모 확장-B
+    private boolean isKorean(char c) {
+        if (c >= 0xAC00 && c <= 0xD7A3) return true;
+        if (c >= 0x1100 && c <= 0x11FF) return true;
+        if (c >= 0x3130 && c <= 0x318F) return true;
+        if (c >= 0xA960 && c <= 0xA97F) return true;
+        if (c >= 0xD7B0 && c <= 0xD7FF) return true;
         return false;
     }
 }

--- a/src/main/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClient.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClient.java
@@ -49,12 +49,12 @@ public class OpenRouterMaskingClient implements MaskingClient {
         try {
             OpenRouterChatResponse response = chatCaller.call(body, REQUEST_TIMEOUT);
             if (response == null) {
-                return content;
+                return null;
             }
             return sanitizer.sanitize(content, response.getText());
         } catch (Exception e) {
             log.error("OpenRouter masking failed: {}", e.getMessage());
-            return content;
+            return null;
         }
     }
 }

--- a/src/test/java/com/sports/server/command/cheertalk/infra/CachingMaskingClientTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/CachingMaskingClientTest.java
@@ -1,0 +1,80 @@
+package com.sports.server.command.cheertalk.infra;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CachingMaskingClientTest {
+
+    private OpenRouterMaskingClient delegate;
+    private CachingMaskingClient client;
+
+    @BeforeEach
+    void setUp() {
+        delegate = mock(OpenRouterMaskingClient.class);
+        client = new CachingMaskingClient(delegate, new MaskingPreFilter(), 5L, 100L);
+    }
+
+    @Test
+    @DisplayName("preFilter가 통과시키는 메시지는 delegate를 호출하지 않고 원문을 반환한다")
+    void preFilter_통과시_delegate_미호출() {
+        String result = client.mask("ㄱㄱ");
+
+        assertThat(result).isEqualTo("ㄱㄱ");
+        verify(delegate, never()).mask(any());
+    }
+
+    @Test
+    @DisplayName("같은 메시지로 반복 호출하면 delegate는 한 번만 호출되고 캐시 결과를 반환한다")
+    void 동일_메시지_캐시_적중() {
+        when(delegate.mask("씨발 잘한다")).thenReturn("** 잘한다");
+
+        String first = client.mask("씨발 잘한다");
+        String second = client.mask("씨발 잘한다");
+
+        assertThat(first).isEqualTo("** 잘한다");
+        assertThat(second).isEqualTo("** 잘한다");
+        verify(delegate, times(1)).mask("씨발 잘한다");
+    }
+
+    @Test
+    @DisplayName("앞뒤 공백만 다른 메시지는 같은 키로 캐시 적중한다")
+    void 공백_차이_캐시_적중() {
+        when(delegate.mask("씨발 잘한다")).thenReturn("** 잘한다");
+
+        client.mask("씨발 잘한다");
+        client.mask("  씨발 잘한다  ");
+
+        verify(delegate, times(1)).mask(any());
+    }
+
+    @Test
+    @DisplayName("delegate가 null을 반환하면 캐시에 저장하지 않아 다음 호출도 delegate로 위임한다")
+    void null_결과는_캐시_미저장() {
+        when(delegate.mask("일시오류")).thenReturn(null);
+
+        String first = client.mask("일시오류");
+        String second = client.mask("일시오류");
+
+        assertThat(first).isNull();
+        assertThat(second).isNull();
+        verify(delegate, times(2)).mask("일시오류");
+    }
+
+    @Test
+    @DisplayName("null 입력은 delegate 호출 없이 null을 반환한다")
+    void null_입력() {
+        String result = client.mask(null);
+
+        assertThat(result).isNull();
+        verify(delegate, never()).mask(any());
+    }
+}

--- a/src/test/java/com/sports/server/command/cheertalk/infra/CachingMaskingClientTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/CachingMaskingClientTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -20,7 +22,11 @@ class CachingMaskingClientTest {
     @BeforeEach
     void setUp() {
         delegate = mock(OpenRouterMaskingClient.class);
-        client = new CachingMaskingClient(delegate, new MaskingPreFilter(), 5L, 100L);
+        MaskingPreFilter preFilter = new MaskingPreFilter(
+                List.of("가즈아🔥", "나이스👍", "까비😭️"),
+                List.of("ㅍㅇㅌ", "ㅎㅇㅌ", "ㅎㅇ", "ㄱㄱ", "ㄱㅅ", "ㅊㅋ", "ㄷㄷ", "ㄹㅇ", "ㅇㅈ", "ㄴㄴ", "ㅇㅇ")
+        );
+        client = new CachingMaskingClient(delegate, preFilter, 5L, 100L);
     }
 
     @Test

--- a/src/test/java/com/sports/server/command/cheertalk/infra/CachingMaskingClientTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/CachingMaskingClientTest.java
@@ -57,15 +57,15 @@ class CachingMaskingClientTest {
     }
 
     @Test
-    @DisplayName("delegate가 null을 반환하면 캐시에 저장하지 않아 다음 호출도 delegate로 위임한다")
-    void null_결과는_캐시_미저장() {
+    @DisplayName("delegate가 null(=일시 오류)을 반환하면 원문을 그대로 반환하되 캐시에는 저장하지 않는다")
+    void null_결과는_원문_반환_및_캐시_미저장() {
         when(delegate.mask("일시오류")).thenReturn(null);
 
         String first = client.mask("일시오류");
         String second = client.mask("일시오류");
 
-        assertThat(first).isNull();
-        assertThat(second).isNull();
+        assertThat(first).isEqualTo("일시오류");
+        assertThat(second).isEqualTo("일시오류");
         verify(delegate, times(2)).mask("일시오류");
     }
 

--- a/src/test/java/com/sports/server/command/cheertalk/infra/MaskingPreFilterTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/MaskingPreFilterTest.java
@@ -1,0 +1,56 @@
+package com.sports.server.command.cheertalk.infra;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MaskingPreFilterTest {
+
+    private final MaskingPreFilter filter = new MaskingPreFilter();
+
+    @Test
+    @DisplayName("null이거나 공백만 있으면 LLM을 스킵한다")
+    void null_또는_공백_스킵() {
+        assertThat(filter.canSkip(null)).isTrue();
+        assertThat(filter.canSkip("")).isTrue();
+        assertThat(filter.canSkip("   ")).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"가즈아🔥", "나이스👍", "까비😭️"})
+    @DisplayName("프론트 추천 문구는 정확 매치 시 LLM을 스킵한다")
+    void 추천_문구_정확_매치_스킵(String message) {
+        assertThat(filter.canSkip(message)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ㅍㅇㅌ", "ㅎㅇㅌ", "ㅎㅇ", "ㄱㄱ", "ㄱㅅ", "ㅊㅋ", "ㄷㄷ", "ㄹㅇ", "ㅇㅈ", "ㄴㄴ", "ㅇㅇ"})
+    @DisplayName("응원/긍정 초성은 LLM을 스킵한다")
+    void 긍정_초성_스킵(String consonant) {
+        assertThat(filter.canSkip(consonant)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Yes!!", "GG", "1234", "🔥🔥🔥", "👍", "wow", "!!!"})
+    @DisplayName("한글이 전혀 없는 메시지는 LLM을 스킵한다")
+    void 한글_없으면_스킵(String message) {
+        assertThat(filter.canSkip(message)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ㅅㅂ", "ㅂㅅ", "ㄱㅅㄲ", "ㅈㄴ", "ㅄ", "씨발", "개새끼", "응원합니다", "가즈아!", "가즈아"})
+    @DisplayName("욕설 의심 자모와 한글 음절을 포함한 메시지는 LLM에 위임한다")
+    void 욕설_의심은_LLM_위임(String message) {
+        assertThat(filter.canSkip(message)).isFalse();
+    }
+
+    @Test
+    @DisplayName("앞뒤 공백은 무시하고 정확 매치를 판단한다")
+    void 공백_무시() {
+        assertThat(filter.canSkip("  가즈아🔥  ")).isTrue();
+        assertThat(filter.canSkip(" ㄱㄱ ")).isTrue();
+    }
+}

--- a/src/test/java/com/sports/server/command/cheertalk/infra/MaskingPreFilterTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/MaskingPreFilterTest.java
@@ -5,11 +5,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MaskingPreFilterTest {
 
-    private final MaskingPreFilter filter = new MaskingPreFilter();
+    private final MaskingPreFilter filter = new MaskingPreFilter(
+            List.of("가즈아🔥", "나이스👍", "까비😭️"),
+            List.of("ㅍㅇㅌ", "ㅎㅇㅌ", "ㅎㅇ", "ㄱㄱ", "ㄱㅅ", "ㅊㅋ", "ㄷㄷ", "ㄹㅇ", "ㅇㅈ", "ㄴㄴ", "ㅇㅇ")
+    );
 
     @Test
     @DisplayName("null이거나 공백만 있으면 LLM을 스킵한다")

--- a/src/test/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClientTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClientTest.java
@@ -66,13 +66,13 @@ class OpenRouterMaskingClientTest {
     }
 
     @Test
-    @DisplayName("응답이 null이면 원문을 반환한다")
-    void 응답_null이면_원문() {
+    @DisplayName("응답이 null이면 null을 반환한다(상위 레이어가 fallback 결정)")
+    void 응답_null이면_null() {
         when(chatCaller.call(any(), any(Duration.class))).thenReturn(null);
 
         String result = client.mask("그대로");
 
-        assertThat(result).isEqualTo("그대로");
+        assertThat(result).isNull();
     }
 
     @Test
@@ -87,14 +87,14 @@ class OpenRouterMaskingClientTest {
     }
 
     @Test
-    @DisplayName("호출이 예외를 던지면 원문을 반환한다")
-    void 예외_발생시_원문() {
+    @DisplayName("호출이 예외를 던지면 null을 반환한다(상위 레이어가 fallback 결정)")
+    void 예외_발생시_null() {
         when(chatCaller.call(any(), any(Duration.class)))
                 .thenThrow(new RuntimeException("network error"));
 
         String result = client.mask("그대로");
 
-        assertThat(result).isEqualTo("그대로");
+        assertThat(result).isNull();
     }
 
     @Test


### PR DESCRIPTION
## 이슈
closes #623

## 변경 내용
- `MaskingPreFilter` 추가: 명백히 정상인 메시지는 LLM 호출 전에 걸러낸다
  - 프론트 추천 문구 정확 매치 (`가즈아🔥`, `나이스👍`, `까비😭️`)
  - 응원/긍정 초성 정확 매치 (`ㅍㅇㅌ`, `ㄱㄱ`, `ㄱㅅ`, `ㅊㅋ`, `ㄷㄷ`, `ㄹㅇ`, `ㅇㅈ`, `ㄴㄴ`, `ㅇㅇ`, `ㅎㅇ`, `ㅎㅇㅌ`)
  - 한글이 전혀 포함되지 않은 메시지 (영문/숫자/이모지/구두점만)
- `CachingMaskingClient` 추가: 마스킹 결과를 LRU 캐싱하여 도배 시 동일 호출 차단
  - Caffeine, TTL 5분, 최대 10,000 엔트리
  - 키는 `content.strip()` — 앞뒤 공백 차이로 인한 캐시 미스 방지
  - delegate가 `null`을 반환하면 캐시에 저장하지 않음 (일시 오류 보호)
- `masking.provider=openrouter` 일 때만 활성화. `gemini` 경로는 영향 없음
- `caffeine` 의존성 추가

## 테스트
- `MaskingPreFilterTest` — 추천 문구 매치, 응원 초성, 한글 미포함 메시지 스킵, 욕설/한글 음절 LLM 위임 검증
- `CachingMaskingClientTest` — preFilter 통과 시 delegate 미호출, 동일 메시지 캐시 적중, 공백 차이 정규화, `null` 결과 미캐싱

## 비고
- 안전 우선 정책: 욕설은 정규식으로 직접 마스킹하지 않고 LLM에 위임 (false positive 회피)
- 프론트(`apps/spectator/.../cheer-talk-form.tsx`)의 `RECOMMENDED_MESSAGES`가 변경되면 `MaskingPreFilter.RECOMMENDED_MESSAGES`도 함께 갱신 필요