### PR TITLE
[FIX] AiSeedService LazyInitializationException 해결

### DIFF
--- a/src/main/java/com/sports/server/command/cheertalk/application/AiSeedService.java
+++ b/src/main/java/com/sports/server/command/cheertalk/application/AiSeedService.java
@@ -6,11 +6,12 @@ import com.sports.server.command.cheertalk.domain.CheerTalkCreateEvent;
 import com.sports.server.command.cheertalk.domain.CheerTalkRepository;
 import com.sports.server.command.cheertalk.infra.AiSeedMessageGenerator;
 import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.GameRepository;
 import com.sports.server.command.game.domain.GameState;
 import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.game.domain.GameTeamRepository;
 import com.sports.server.command.league.domain.SportType;
-import com.sports.server.common.application.EntityUtils;
+import com.sports.server.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,47 +36,39 @@ public class AiSeedService {
 
     private final CheerTalkRepository cheerTalkRepository;
     private final GameTeamRepository gameTeamRepository;
-    private final EntityUtils entityUtils;
+    private final GameRepository gameRepository;
     private final AiSeedMessageGenerator messageGenerator;
     private final ApplicationEventPublisher eventPublisher;
     private final TransactionTemplate transactionTemplate;
 
     public void publish(Long gameId, AiSeedTriggerType triggerType,
                         Long scoringGameTeamId, String scorerName) {
-        record SeedContext(Long gameTeamId, String teamName) {}
+        Game game = gameRepository.findByIdWithLeague(gameId)
+                .orElseThrow(() -> new NotFoundException("Game을(를) 찾을 수 없습니다"));
 
-        SeedContext context = transactionTemplate.execute(status -> {
-            Game game = entityUtils.getEntity(gameId, Game.class);
-
-            if (!canPublish(game)) {
-                return null;
-            }
-
-            List<GameTeam> gameTeams = gameTeamRepository.findAllByGameIdForUpdateOrderByAsc(gameId);
-            List<Long> gameTeamIds = gameTeams.stream().map(GameTeam::getId).toList();
-
-            if (!isReadyForNextSeed(gameTeamIds, triggerType)) {
-                return null;
-            }
-
-            GameTeam selectedTeam = selectTeam(triggerType, scoringGameTeamId, gameTeams);
-            return new SeedContext(selectedTeam.getId(), selectedTeam.getTeam().getName());
-        });
-
-        if (context == null) {
+        if (!canPublish(game)) {
             return;
         }
 
-        String message = messageGenerator.generate(triggerType, context.teamName(), scorerName);
+        List<GameTeam> gameTeams = gameTeamRepository.findAllByGameIdWithTeamOrderByAsc(gameId);
+        List<Long> gameTeamIds = gameTeams.stream().map(GameTeam::getId).toList();
+
+        if (!isReadyForNextSeed(gameTeamIds, triggerType)) {
+            return;
+        }
+
+        GameTeam selectedTeam = selectTeam(triggerType, scoringGameTeamId, gameTeams);
+        String teamName = selectedTeam.getTeam().getName();
+        String message = messageGenerator.generate(triggerType, teamName, scorerName);
 
         transactionTemplate.executeWithoutResult(status -> {
-            CheerTalk aiSeed = CheerTalk.createAiSeed(message, context.gameTeamId());
+            CheerTalk aiSeed = CheerTalk.createAiSeed(message, selectedTeam.getId());
             cheerTalkRepository.save(aiSeed);
             eventPublisher.publishEvent(new CheerTalkCreateEvent(aiSeed, gameId));
         });
 
         log.info("AI Seed 발화: gameId={}, trigger={}, team={}, message={}",
-                gameId, triggerType, context.teamName(), message);
+                gameId, triggerType, teamName, message);
     }
 
 private boolean canPublish(Game game) {

--- a/src/main/java/com/sports/server/command/cheertalk/application/AiSeedService.java
+++ b/src/main/java/com/sports/server/command/cheertalk/application/AiSeedService.java
@@ -42,31 +42,40 @@ public class AiSeedService {
 
     public void publish(Long gameId, AiSeedTriggerType triggerType,
                         Long scoringGameTeamId, String scorerName) {
-        Game game = entityUtils.getEntity(gameId, Game.class);
+        record SeedContext(Long gameTeamId, String teamName) {}
 
-        if (!canPublish(game)) {
+        SeedContext context = transactionTemplate.execute(status -> {
+            Game game = entityUtils.getEntity(gameId, Game.class);
+
+            if (!canPublish(game)) {
+                return null;
+            }
+
+            List<GameTeam> gameTeams = gameTeamRepository.findAllByGameIdForUpdateOrderByAsc(gameId);
+            List<Long> gameTeamIds = gameTeams.stream().map(GameTeam::getId).toList();
+
+            if (!isReadyForNextSeed(gameTeamIds, triggerType)) {
+                return null;
+            }
+
+            GameTeam selectedTeam = selectTeam(triggerType, scoringGameTeamId, gameTeams);
+            return new SeedContext(selectedTeam.getId(), selectedTeam.getTeam().getName());
+        });
+
+        if (context == null) {
             return;
         }
 
-        List<GameTeam> gameTeams = gameTeamRepository.findAllByGameIdForUpdateOrderByAsc(gameId);
-        List<Long> gameTeamIds = gameTeams.stream().map(GameTeam::getId).toList();
-
-        if (!isReadyForNextSeed(gameTeamIds, triggerType)) {
-            return;
-        }
-
-        GameTeam selectedTeam = selectTeam(triggerType, scoringGameTeamId, gameTeams);
-        String teamName = selectedTeam.getTeam().getName();
-        String message = messageGenerator.generate(triggerType, teamName, scorerName);
+        String message = messageGenerator.generate(triggerType, context.teamName(), scorerName);
 
         transactionTemplate.executeWithoutResult(status -> {
-            CheerTalk aiSeed = CheerTalk.createAiSeed(message, selectedTeam.getId());
+            CheerTalk aiSeed = CheerTalk.createAiSeed(message, context.gameTeamId());
             cheerTalkRepository.save(aiSeed);
             eventPublisher.publishEvent(new CheerTalkCreateEvent(aiSeed, gameId));
         });
 
         log.info("AI Seed 발화: gameId={}, trigger={}, team={}, message={}",
-                gameId, triggerType, teamName, message);
+                gameId, triggerType, context.teamName(), message);
     }
 
 private boolean canPublish(Game game) {

--- a/src/main/java/com/sports/server/command/game/domain/GameRepository.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameRepository.java
@@ -39,4 +39,7 @@ public interface GameRepository extends Repository<Game, Long> {
            "AND g.startTime BETWEEN :from AND :to")
     List<Game> findScheduledSoccerGamesBetween(@Param("from") LocalDateTime from,
                                                @Param("to") LocalDateTime to);
+
+    @Query("SELECT g FROM Game g JOIN FETCH g.league WHERE g.id = :id")
+    Optional<Game> findByIdWithLeague(@Param("id") Long id);
 }

--- a/src/main/java/com/sports/server/command/game/domain/GameTeamRepository.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeamRepository.java
@@ -14,6 +14,9 @@ public interface GameTeamRepository extends Repository<GameTeam, Long> {
     @Query("SELECT gt FROM GameTeam gt WHERE gt.game.id = :gameId ORDER BY gt.id ASC")
     List<GameTeam> findAllByGameIdForUpdateOrderByAsc(Long gameId);
 
+    @Query("SELECT gt FROM GameTeam gt JOIN FETCH gt.team WHERE gt.game.id = :gameId ORDER BY gt.id ASC")
+    List<GameTeam> findAllByGameIdWithTeamOrderByAsc(@Param("gameId") Long gameId);
+
     @Modifying
     @Query("UPDATE GameTeam t SET t.cheerCount = t.cheerCount + :cheerCount WHERE t.id = :gameTeamId")
     void updateCheerCount(@Param("gameTeamId") Long gameTeamId, @Param("cheerCount") int cheerCount);

--- a/src/test/java/com/sports/server/command/cheertalk/application/AiSeedServiceTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/application/AiSeedServiceTest.java
@@ -6,12 +6,12 @@ import com.sports.server.command.cheertalk.domain.CheerTalkRepository;
 import com.sports.server.command.cheertalk.infra.AiSeedMessageGenerator;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.GameState;
+import com.sports.server.command.game.domain.GameRepository;
 import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.game.domain.GameTeamRepository;
 import com.sports.server.command.league.domain.League;
 import com.sports.server.command.league.domain.SportType;
 import com.sports.server.command.team.domain.Team;
-import com.sports.server.common.application.EntityUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -31,7 +31,7 @@ class AiSeedServiceTest {
 
     private CheerTalkRepository cheerTalkRepository;
     private GameTeamRepository gameTeamRepository;
-    private EntityUtils entityUtils;
+    private GameRepository gameRepository;
     private AiSeedMessageGenerator messageGenerator;
     private ApplicationEventPublisher eventPublisher;
     private TransactionTemplate transactionTemplate;
@@ -46,7 +46,7 @@ class AiSeedServiceTest {
     void setUp() {
         cheerTalkRepository = mock(CheerTalkRepository.class);
         gameTeamRepository = mock(GameTeamRepository.class);
-        entityUtils = mock(EntityUtils.class);
+        gameRepository = mock(GameRepository.class);
         messageGenerator = mock(AiSeedMessageGenerator.class);
         eventPublisher = mock(ApplicationEventPublisher.class);
         transactionTemplate = mock(TransactionTemplate.class);
@@ -57,7 +57,7 @@ class AiSeedServiceTest {
         }).when(transactionTemplate).executeWithoutResult(any());
 
         aiSeedService = new AiSeedService(
-                cheerTalkRepository, gameTeamRepository, entityUtils,
+                cheerTalkRepository, gameTeamRepository, gameRepository,
                 messageGenerator, eventPublisher, transactionTemplate
         );
 
@@ -74,7 +74,7 @@ class AiSeedServiceTest {
         @Test
         @DisplayName("축구가 아닌 경기는 발화하지 않는다")
         void 축구_아닌_경기_스킵() {
-            when(entityUtils.getEntity(1L, Game.class)).thenReturn(basketballGame);
+            when(gameRepository.findByIdWithLeague(1L)).thenReturn(Optional.of(basketballGame));
 
             aiSeedService.publish(1L, AiSeedTriggerType.GOAL, 1L, "민준");
 
@@ -84,7 +84,7 @@ class AiSeedServiceTest {
         @Test
         @DisplayName("종료된 경기는 발화하지 않는다")
         void 종료된_경기_스킵() {
-            when(entityUtils.getEntity(1L, Game.class)).thenReturn(finishedGame);
+            when(gameRepository.findByIdWithLeague(1L)).thenReturn(Optional.of(finishedGame));
 
             aiSeedService.publish(1L, AiSeedTriggerType.GOAL, 1L, "민준");
 
@@ -94,8 +94,8 @@ class AiSeedServiceTest {
         @Test
         @DisplayName("경기당 5회 초과 시 발화하지 않는다")
         void 최대_횟수_초과_스킵() {
-            when(entityUtils.getEntity(1L, Game.class)).thenReturn(soccerGame);
-            when(gameTeamRepository.findAllByGameIdForUpdateOrderByAsc(1L)).thenReturn(gameTeams);
+            when(gameRepository.findByIdWithLeague(1L)).thenReturn(Optional.of(soccerGame));
+            when(gameTeamRepository.findAllByGameIdWithTeamOrderByAsc(1L)).thenReturn(gameTeams);
             when(cheerTalkRepository.countAiSeedsByGameTeamIds(anyList())).thenReturn(5L);
 
             aiSeedService.publish(1L, AiSeedTriggerType.GOAL, 1L, "민준");
@@ -106,8 +106,8 @@ class AiSeedServiceTest {
         @Test
         @DisplayName("마지막 AI seed 후 3분 이내면 발화하지 않는다")
         void 간격_부족_스킵() {
-            when(entityUtils.getEntity(1L, Game.class)).thenReturn(soccerGame);
-            when(gameTeamRepository.findAllByGameIdForUpdateOrderByAsc(1L)).thenReturn(gameTeams);
+            when(gameRepository.findByIdWithLeague(1L)).thenReturn(Optional.of(soccerGame));
+            when(gameTeamRepository.findAllByGameIdWithTeamOrderByAsc(1L)).thenReturn(gameTeams);
             when(cheerTalkRepository.countAiSeedsByGameTeamIds(anyList())).thenReturn(1L);
 
             CheerTalk recentSeed = mock(CheerTalk.class);
@@ -122,8 +122,8 @@ class AiSeedServiceTest {
         @Test
         @DisplayName("SCHEDULED 트리거에서 최근 2분 내 유저 발화가 있으면 발화하지 않는다")
         void 유저_발화_있으면_SCHEDULED_스킵() {
-            when(entityUtils.getEntity(1L, Game.class)).thenReturn(soccerGame);
-            when(gameTeamRepository.findAllByGameIdForUpdateOrderByAsc(1L)).thenReturn(gameTeams);
+            when(gameRepository.findByIdWithLeague(1L)).thenReturn(Optional.of(soccerGame));
+            when(gameTeamRepository.findAllByGameIdWithTeamOrderByAsc(1L)).thenReturn(gameTeams);
             when(cheerTalkRepository.countAiSeedsByGameTeamIds(anyList())).thenReturn(0L);
             when(cheerTalkRepository.findLastAiSeed(anyList())).thenReturn(Optional.empty());
             when(cheerTalkRepository.existsUserCheerTalkAfter(anyList(), any(LocalDateTime.class)))
@@ -142,8 +142,8 @@ class AiSeedServiceTest {
         @Test
         @DisplayName("GOAL 트리거는 유저 발화 여부와 무관하게 발화한다")
         void GOAL_무조건_발화() {
-            when(entityUtils.getEntity(1L, Game.class)).thenReturn(soccerGame);
-            when(gameTeamRepository.findAllByGameIdForUpdateOrderByAsc(1L)).thenReturn(gameTeams);
+            when(gameRepository.findByIdWithLeague(1L)).thenReturn(Optional.of(soccerGame));
+            when(gameTeamRepository.findAllByGameIdWithTeamOrderByAsc(1L)).thenReturn(gameTeams);
             when(cheerTalkRepository.countAiSeedsByGameTeamIds(anyList())).thenReturn(0L);
             when(cheerTalkRepository.findLastAiSeed(anyList())).thenReturn(Optional.empty());
             when(cheerTalkRepository.existsUserCheerTalkAfter(anyList(), any(LocalDateTime.class)))
@@ -159,8 +159,8 @@ class AiSeedServiceTest {
         @Test
         @DisplayName("조건 충족 시 CheerTalk을 저장하고 이벤트를 발행한다")
         void 정상_발화() {
-            when(entityUtils.getEntity(1L, Game.class)).thenReturn(soccerGame);
-            when(gameTeamRepository.findAllByGameIdForUpdateOrderByAsc(1L)).thenReturn(gameTeams);
+            when(gameRepository.findByIdWithLeague(1L)).thenReturn(Optional.of(soccerGame));
+            when(gameTeamRepository.findAllByGameIdWithTeamOrderByAsc(1L)).thenReturn(gameTeams);
             when(cheerTalkRepository.countAiSeedsByGameTeamIds(anyList())).thenReturn(0L);
             when(cheerTalkRepository.findLastAiSeed(anyList())).thenReturn(Optional.empty());
             when(cheerTalkRepository.existsUserCheerTalkAfter(anyList(), any(LocalDateTime.class)))


### PR DESCRIPTION
## 🌍 이슈 번호
- closed #632 

## 변경 사항                                                                                                                                                              
  - `AiSeedService.publish()`의 `LazyInitializationException` 수정                                                                                                        
                                                                                                                                                                            
  ## 원인                                                                                                                                                                   
  - 트랜잭션 밖에서 `game.getLeague().getSportType()`, `selectedTeam.getTeam().getName()` 프록시 접근                                                                       
                                                                                                                                                                            
  ## 해결
  - `transactionTemplate` 안에서 필요한 값을 미리 추출 (`SeedContext` record 활용)                                                                                          
  - LLM 호출은 트랜잭션 밖 유지