### PR TITLE
fix: 게임 정보 수정 API가 진행 상태(state/quarter)를 덮어쓰지 않도록 분리

### DIFF
--- a/src/main/java/com/sports/server/command/game/application/GameService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameService.java
@@ -85,17 +85,11 @@ public class GameService {
         league.validateRoundWithinLimit(request.round());
 
         Game game = entityUtils.getEntity(gameId, Game.class);
-        GameState state = GameState.from(request.state());
 
         game.updateName(request.name());
         game.updateStartTime(request.startTime());
         game.updateVideoId(request.videoId());
-        if (StringUtils.hasText(request.quarter())) {
-            game.updateGameQuarter(QuarterResolver.resolve(request.quarter()));
-        }
-        game.updateState(state);
         game.updateRound(Round.from(request.round()));
-        game.updateResult();
     }
 
     @Transactional

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -53,6 +53,15 @@ public class GameStatusScheduler {
         updateLeagueStatisticsForFinalGames(List.of(game));
     }
 
+    public void rollbackLeagueStatisticsIfNeeded(Game game) {
+        if (Round.FINAL != game.getRound() || game.getLeague() == null) {
+            return;
+        }
+        leagueStatisticsService.rollbackLeagueStatisticForFinalGame(game.getId());
+        leagueTopScorerService.clearTopScorersForLeague(game.getLeague().getId());
+        leagueService.updateTotalCheerCountsAndTotalTalkCount(game.getLeague().getId());
+    }
+
     public void manualUpdateLeagueStatisticsForFinalGames(List<Long> gameIds) {
         List<Game> games = gameService.determineResultsAndGet(gameIds);
         updateLeagueStatisticsForFinalGames(games);

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -46,6 +46,13 @@ public class GameStatusScheduler {
         manualUpdateLeagueStatisticsForFinalGames(List.of(gameId));
     }
 
+    public void updateLeagueStatisticsIfNeeded(Game game) {
+        if (GameState.FINISHED != game.getState() || Round.FINAL != game.getRound()) {
+            return;
+        }
+        updateLeagueStatisticsForFinalGames(List.of(game));
+    }
+
     public void manualUpdateLeagueStatisticsForFinalGames(List<Long> gameIds) {
         List<Game> games = gameService.determineResultsAndGet(gameIds);
         updateLeagueStatisticsForFinalGames(games);

--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -272,6 +272,10 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
         determineResult();
     }
 
+    public void resetResult() {
+        gameTeams.forEach(GameTeam::clearResult);
+    }
+
     private static void markAsDraw(GameTeam team1, GameTeam team2) {
         team1.markAsDraw();
         team2.markAsDraw();

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -142,4 +142,8 @@ public class GameTeam extends BaseEntity<GameTeam> {
     public void markAsDraw() {
         this.result = GameResult.DRAW;
     }
+
+    public void clearResult() {
+        this.result = null;
+    }
 }

--- a/src/main/java/com/sports/server/command/game/dto/GameRequest.java
+++ b/src/main/java/com/sports/server/command/game/dto/GameRequest.java
@@ -59,8 +59,6 @@ public class GameRequest {
     public record Update(
             String name,
             int round,
-            String quarter,
-            String state,
             LocalDateTime startTime,
             String videoId
     ) {

--- a/src/main/java/com/sports/server/command/game/presentation/GameController.java
+++ b/src/main/java/com/sports/server/command/game/presentation/GameController.java
@@ -5,10 +5,8 @@ import com.sports.server.command.game.application.GameService;
 import com.sports.server.command.game.application.GameStatusScheduler;
 import com.sports.server.command.game.application.GameTeamService;
 import com.sports.server.command.game.application.LineupPlayerService;
-import com.sports.server.command.game.domain.GameState;
 import com.sports.server.command.game.dto.CheerCountUpdateRequest;
 import com.sports.server.command.game.dto.GameRequest;
-import com.sports.server.command.league.domain.Round;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.common.util.VisitorIdResolver;
 import jakarta.servlet.http.HttpServletRequest;
@@ -70,8 +68,6 @@ public class GameController {
     public void updateGame(@PathVariable final Long leagueId, @PathVariable final Long gameId,
                            @RequestBody final GameRequest.Update request, final Member member) {
         gameService.updateGame(leagueId, gameId, request, member);
-        gameStatusScheduler.updateLeagueStatisticsIfNeeded(
-                gameId, GameState.from(request.state()), Round.from(request.round()));
     }
 
     @DeleteMapping("/leagues/{leagueId}/{gameId}")

--- a/src/main/java/com/sports/server/command/league/application/LeagueStatisticsService.java
+++ b/src/main/java/com/sports/server/command/league/application/LeagueStatisticsService.java
@@ -97,4 +97,27 @@ public class LeagueStatisticsService {
         leagueTeamRepository.findByLeagueAndTeam(league, team)
                 .ifPresent(leagueTeam -> leagueTeam.updateRanking(ranking));
     }
+
+    @Transactional
+    public void rollbackLeagueStatisticForFinalGame(Long finalGameId) {
+        Game finalGame = entityUtils.getEntity(finalGameId, Game.class);
+        League league = finalGame.getLeague();
+        LeagueStatistics leagueStatistics = leagueStatisticsRepository.findByLeagueId(league.getId());
+        if (leagueStatistics == null) {
+            return;
+        }
+        Team firstWinner = leagueStatistics.getFirstWinnerTeam();
+        Team secondWinner = leagueStatistics.getSecondWinnerTeam();
+        leagueStatistics.clearFinalSnapshot();
+        resetLeagueTeamRanking(league, firstWinner);
+        resetLeagueTeamRanking(league, secondWinner);
+    }
+
+    private void resetLeagueTeamRanking(League league, Team team) {
+        if (team == null) {
+            return;
+        }
+        leagueTeamRepository.findByLeagueAndTeam(league, team)
+                .ifPresent(leagueTeam -> leagueTeam.updateRanking(0));
+    }
 }

--- a/src/main/java/com/sports/server/command/league/application/LeagueTopScorerService.java
+++ b/src/main/java/com/sports/server/command/league/application/LeagueTopScorerService.java
@@ -65,4 +65,8 @@ public class LeagueTopScorerService {
 
         leagueTopScorerRepository.saveAll(topScorersToBeSaved);
     }
+
+    public void clearTopScorersForLeague(Long leagueId) {
+        leagueTopScorerRepository.deleteByLeagueId(leagueId);
+    }
 }

--- a/src/main/java/com/sports/server/command/league/domain/LeagueStatistics.java
+++ b/src/main/java/com/sports/server/command/league/domain/LeagueStatistics.java
@@ -58,4 +58,11 @@ public class LeagueStatistics extends BaseEntity<LeagueStatistics> {
     public void updateMostCheerTalksTeam(Team mostCheerTalksTeam) {
         this.mostCheerTalksTeam = mostCheerTalksTeam;
     }
+
+    public void clearFinalSnapshot() {
+        this.firstWinnerTeam = null;
+        this.secondWinnerTeam = null;
+        this.mostCheeredTeam = null;
+        this.mostCheerTalksTeam = null;
+    }
 }

--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -3,7 +3,6 @@ package com.sports.server.command.timeline.application;
 import com.sports.server.command.game.application.GameStatusScheduler;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.GameRepository;
-import com.sports.server.command.game.domain.GameState;
 import com.sports.server.command.league.domain.Quarter;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.timeline.domain.GameProgressTimeline;
@@ -61,8 +60,7 @@ public class TimelineService {
 
         if (timeline instanceof GameProgressTimeline progress
                 && progress.getGameProgressType() == GameProgressType.GAME_END) {
-            gameStatusScheduler.updateLeagueStatisticsIfNeeded(
-                    gameId, GameState.FINISHED, game.getRound());
+            gameStatusScheduler.updateLeagueStatisticsIfNeeded(game);
         }
 
         eventPublisher.publishEvent(new TimelineCreatedEvent(

--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -1,7 +1,9 @@
 package com.sports.server.command.timeline.application;
 
+import com.sports.server.command.game.application.GameStatusScheduler;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.GameRepository;
+import com.sports.server.command.game.domain.GameState;
 import com.sports.server.command.league.domain.Quarter;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.timeline.domain.GameProgressTimeline;
@@ -35,6 +37,7 @@ public class TimelineService {
     private final TimelineMapper timelineMapper;
     private final EntityUtils entityUtils;
     private final ApplicationEventPublisher eventPublisher;
+    private final GameStatusScheduler gameStatusScheduler;
 
     @Transactional
     public void register(Member manager, Long gameId, TimelineRequest request) {
@@ -55,6 +58,12 @@ public class TimelineService {
         Timeline timeline = timelineMapper.toEntity(game, request);
         timeline.apply();
         timelineRepository.save(timeline);
+
+        if (timeline instanceof GameProgressTimeline progress
+                && progress.getGameProgressType() == GameProgressType.GAME_END) {
+            gameStatusScheduler.updateLeagueStatisticsIfNeeded(
+                    gameId, GameState.FINISHED, game.getRound());
+        }
 
         eventPublisher.publishEvent(new TimelineCreatedEvent(
                 timeline.getId(), gameId, timeline.getType()));

--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -132,8 +132,14 @@ public class TimelineService {
         PermissionValidator.checkPermission(game, manager);
 
         Timeline timeline = getLastTimeline(timelineId, game);
+        boolean isGameEnd = timeline instanceof GameProgressTimeline progress
+                && progress.getGameProgressType() == GameProgressType.GAME_END;
         timeline.rollback();
         timelineRepository.delete(timeline);
+
+        if (isGameEnd) {
+            gameStatusScheduler.rollbackLeagueStatisticsIfNeeded(game);
+        }
     }
 
     private Game getGameForUpdate(Long id) {

--- a/src/main/java/com/sports/server/command/timeline/domain/GameProgressTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/GameProgressTimeline.java
@@ -84,6 +84,7 @@ public class GameProgressTimeline extends Timeline {
 
         if (gameProgressType == GameProgressType.GAME_END) {
             game.updateState(GameState.PLAYING);
+            game.resetResult();
         }
     }
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/GameProgressTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/GameProgressTimeline.java
@@ -68,6 +68,7 @@ public class GameProgressTimeline extends Timeline {
 
         if (gameProgressType == GameProgressType.GAME_END) {
             game.end();
+            game.updateResult();
         }
     }
 

--- a/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
@@ -218,6 +218,17 @@ public class GameAcceptanceTest extends AcceptanceTest {
 
         configureMockJwtForEmail(MOCK_EMAIL);
 
+        // 수정 전 진행 상태(state/quarter) 기록 — PUT으로 변경되지 않아야 함
+        ExtractableResponse<Response> beforeResponse = RestAssured.given().log().all()
+                .when()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .get("/games/{gameId}", gameId)
+                .then().log().all()
+                .extract();
+        GameDetailResponse beforeGame = toResponse(beforeResponse, GameDetailResponse.class);
+        String stateBefore = beforeGame.state();
+        String quarterBefore = beforeGame.gameQuarter().key();
+
         // when
         ExtractableResponse<Response> putResponse = RestAssured.given().log().all()
                 .cookie(COOKIE_NAME, mockToken)
@@ -235,16 +246,16 @@ public class GameAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .extract();
 
-        // then
+        // then: 정보(name/round/startTime/videoId)는 수정되고, 진행 상태(state/quarter)는 timeline 전용이라 불변
         GameDetailResponse updatedGame = toResponse(getResponse, GameDetailResponse.class);
         assertAll(
                 () -> assertThat(putResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(updatedGame.gameQuarter().key()).isEqualTo(quarter),
                 () -> assertThat(updatedGame.round()).isEqualTo(round),
                 () -> assertThat(updatedGame.gameName()).isEqualTo(name),
                 () -> assertThat(updatedGame.startTime()).isEqualTo(fixedLocalDateTime),
-                () -> assertThat(updatedGame.state()).isEqualTo(state),
-                () -> assertThat(updatedGame.videoId()).isEqualTo(videoId)
+                () -> assertThat(updatedGame.videoId()).isEqualTo(videoId),
+                () -> assertThat(updatedGame.gameQuarter().key()).isEqualTo(quarterBefore),
+                () -> assertThat(updatedGame.state()).isEqualTo(stateBefore)
         );
     }
 

--- a/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
@@ -210,11 +210,9 @@ public class GameAcceptanceTest extends AcceptanceTest {
         Long gameId = 1L;
         String name = "경기 이름";
         int round = 16;
-        String quarter = "SECOND_HALF";
-        String state = "PLAYING";
         LocalDateTime fixedLocalDateTime = LocalDateTime.of(2024, 9, 11, 12, 0, 0);
         String videoId = "videoId";
-        GameRequest.Update request = new GameRequest.Update(name, round, quarter, state, fixedLocalDateTime, videoId);
+        GameRequest.Update request = new GameRequest.Update(name, round, fixedLocalDateTime, videoId);
 
         configureMockJwtForEmail(MOCK_EMAIL);
 

--- a/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
@@ -193,39 +193,38 @@ public class GameServiceTest extends ServiceTest {
         }
 
         @Test
-        void 정상적으로_게임이_수정된다() {
+        void 게임_정보가_수정된다() {
             // when
             gameService.updateGame(leagueId, gameId, updateDto, manager);
 
             // then
             Game game = entityUtils.getEntity(gameId, Game.class);
-            assertAll(() -> assertThat(game.getGameQuarter()).isEqualTo(updateDto.quarter()),
+            assertAll(
                     () -> assertThat(game.getRound()).isEqualTo(Round.from(updateDto.round())),
                     () -> assertThat(game.getName()).isEqualTo(updateDto.name()),
                     () -> assertThat(game.getStartTime()).isEqualTo(updateDto.startTime()),
-                    () -> assertThat(game.getState()).isEqualTo(GameState.from(updateDto.state())),
                     () -> assertThat(game.getVideoId()).isEqualTo(updateDto.videoId()));
         }
 
         @Test
-        void 게임을_직접_종료하면_결과가_저장된다() {
+        void 게임_정보_수정으로_state와_quarter는_변경되지_않는다() {
             // given
-            GameRequest.Update finishRequest = new GameRequest.Update(
+            Game before = entityUtils.getEntity(gameId, Game.class);
+            String quarterBefore = before.getGameQuarter();
+            GameState stateBefore = before.getState();
+
+            GameRequest.Update finishAttempt = new GameRequest.Update(
                     nameOfGame, 4, "경기 종료", "FINISHED", LocalDateTime.of(2024, 9, 11, 12, 0, 0), "videoId"
             );
 
             // when
-            gameService.updateGame(leagueId, gameId, finishRequest, manager);
+            gameService.updateGame(leagueId, gameId, finishAttempt, manager);
 
-            // then
-            Game game = entityUtils.getEntity(gameId, Game.class);
-            GameTeam firstGameTeam = entityUtils.getEntity(1L, GameTeam.class);
-            GameTeam secondGameTeam = entityUtils.getEntity(2L, GameTeam.class);
-
+            // then: 진행 상태(state/quarter)는 timeline 전용. 정보 수정 API로는 변경 불가.
+            Game after = entityUtils.getEntity(gameId, Game.class);
             assertAll(
-                    () -> assertThat(game.getState()).isEqualTo(GameState.FINISHED),
-                    () -> assertThat(firstGameTeam.getResult()).isEqualTo(GameResult.LOSE),
-                    () -> assertThat(secondGameTeam.getResult()).isEqualTo(GameResult.WIN)
+                    () -> assertThat(after.getState()).isEqualTo(stateBefore),
+                    () -> assertThat(after.getGameQuarter()).isEqualTo(quarterBefore)
             );
         }
 

--- a/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
@@ -186,7 +186,7 @@ public class GameServiceTest extends ServiceTest {
         @BeforeEach
         void setUp() {
             LocalDateTime fixedLocalDateTime = LocalDateTime.of(2024, 9, 11, 12, 0, 0);
-            updateDto = new GameRequest.Update(nameOfGame, 8, "SECOND_HALF", "PLAYING", fixedLocalDateTime, "videoId");
+            updateDto = new GameRequest.Update(nameOfGame, 8, fixedLocalDateTime, "videoId");
             leagueId = 1L;
             gameId = 1L;
             manager = entityUtils.getEntity(1L, Member.class);
@@ -214,7 +214,7 @@ public class GameServiceTest extends ServiceTest {
             GameState stateBefore = before.getState();
 
             GameRequest.Update finishAttempt = new GameRequest.Update(
-                    nameOfGame, 4, "경기 종료", "FINISHED", LocalDateTime.of(2024, 9, 11, 12, 0, 0), "videoId"
+                    nameOfGame, 4, LocalDateTime.of(2024, 9, 11, 12, 0, 0), "videoId"
             );
 
             // when

--- a/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
+++ b/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
@@ -174,7 +174,7 @@ public class GameControllerTest extends DocumentationTest {
         Long leagueId = 1L;
         Long gameId = 1L;
         GameRequest.Update requestDto = new GameRequest.Update(
-                "게임 이름", 16, "FIRST_HALF", "PLAYING", LocalDateTime.of(2024, 9, 11, 12, 0, 0), "videoId"
+                "게임 이름", 16, LocalDateTime.of(2024, 9, 11, 12, 0, 0), "videoId"
         );
 
         // when
@@ -194,8 +194,6 @@ public class GameControllerTest extends DocumentationTest {
                                 fieldWithPath("name").type(JsonFieldType.STRING).description("변경할 경기의 이름"),
                                 fieldWithPath("round").type(JsonFieldType.NUMBER)
                                         .description("변경할 경기의 라운드 ex. 16강->16, 결승->2"),
-                                fieldWithPath("quarter").type(JsonFieldType.STRING).description("쿼터"),
-                                fieldWithPath("state").type(JsonFieldType.STRING).description("경기의 상태 (SCHEDULED, PLAYING, FINISHED)"),
                                 fieldWithPath("startTime").type(JsonFieldType.STRING).description("경기 시작 날짜 및 시각"),
                                 fieldWithPath("videoId").type(JsonFieldType.STRING)
                                         .description("경기 영상 링크")

--- a/src/test/java/com/sports/server/command/league/application/LeagueStatisticsServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueStatisticsServiceTest.java
@@ -122,4 +122,46 @@ public class LeagueStatisticsServiceTest extends ServiceTest {
             assertThat(statistics).isNotNull();
         }
     }
+
+    @Nested
+    @DisplayName("최종 게임으로부터 리그 통계를 롤백할 때")
+    class RollbackLeagueStatisticForFinalGameTest {
+
+        @Test
+        void 우승_준우승_최다_응원_최다_대화팀_정보가_초기화되고_랭킹이_복구된다() {
+            // given
+            Long finalGameId = 1L;
+            Game finalGame = entityUtils.getEntity(finalGameId, Game.class);
+            League league = finalGame.getLeague();
+            leagueStatisticsService.updateLeagueStatisticFromFinalGame(finalGameId);
+
+            LeagueStatistics applied = leagueStatisticsRepository.findByLeagueId(league.getId());
+            Team firstWinnerBefore = applied.getFirstWinnerTeam();
+            Team secondWinnerBefore = applied.getSecondWinnerTeam();
+
+            // when
+            leagueStatisticsService.rollbackLeagueStatisticForFinalGame(finalGameId);
+
+            // then
+            LeagueStatistics rolledBack = leagueStatisticsRepository.findByLeagueId(league.getId());
+            assertThat(rolledBack.getFirstWinnerTeam()).isNull();
+            assertThat(rolledBack.getSecondWinnerTeam()).isNull();
+            assertThat(rolledBack.getMostCheeredTeam()).isNull();
+            assertThat(rolledBack.getMostCheerTalksTeam()).isNull();
+
+            LeagueTeam firstWinnerLeagueTeam = leagueTeamRepository.findByLeagueAndTeam(league, firstWinnerBefore).orElseThrow();
+            LeagueTeam secondWinnerLeagueTeam = leagueTeamRepository.findByLeagueAndTeam(league, secondWinnerBefore).orElseThrow();
+            assertThat(firstWinnerLeagueTeam.getRanking()).isZero();
+            assertThat(secondWinnerLeagueTeam.getRanking()).isZero();
+        }
+
+        @Test
+        void 통계가_없으면_조용히_종료된다() {
+            // given - apply 호출 없이 곧바로 rollback
+            Long finalGameId = 1L;
+
+            // when & then - 예외 없이 실행
+            leagueStatisticsService.rollbackLeagueStatisticForFinalGame(finalGameId);
+        }
+    }
 }

--- a/src/test/java/com/sports/server/command/timeline/domain/GameProgressTimelineTest.java
+++ b/src/test/java/com/sports/server/command/timeline/domain/GameProgressTimelineTest.java
@@ -6,7 +6,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.GameResult;
 import com.sports.server.command.game.domain.GameState;
+import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.league.domain.CommonQuarter;
 import com.sports.server.command.league.domain.League;
 import com.sports.server.command.league.domain.SoccerQuarter;
@@ -241,6 +243,50 @@ class GameProgressTimelineTest {
             assertAll(
                     () -> assertThat(game.getGameQuarter()).isEqualTo(SoccerQuarter.SECOND_HALF.name()),
                     () -> assertThat(game.getState()).isEqualTo(GameState.PLAYING)
+            );
+        }
+
+        @Test
+        void 경기_종료_롤백_시_GameTeam의_결과가_초기화된다() {
+            // given: 점수 차이가 있는 두 팀이 참여한 경기 — apply 시 WIN/LOSE 결과가 확정됨
+            GameTeam winningTeam = entityBuilder(GameTeam.class)
+                    .set("id", 1L)
+                    .set("game", game)
+                    .set("score", 3)
+                    .set("pkScore", 0)
+                    .set("result", null)
+                    .sample();
+            GameTeam losingTeam = entityBuilder(GameTeam.class)
+                    .set("id", 2L)
+                    .set("game", game)
+                    .set("score", 1)
+                    .set("pkScore", 0)
+                    .set("result", null)
+                    .sample();
+            game.addGameTeam(winningTeam);
+            game.addGameTeam(losingTeam);
+
+            전반전_시작_타임라인_생성(game).apply();
+            전반전_종료_타임라인_생성(game).apply();
+            후반전_시작_타임라인_생성(game).apply();
+            후반전_종료_타임라인_생성(game).apply();
+
+            GameProgressTimeline timeline = 경기_종료_타임라인_생성(game);
+            timeline.apply();
+
+            assertAll(
+                    () -> assertThat(winningTeam.getResult()).isEqualTo(GameResult.WIN),
+                    () -> assertThat(losingTeam.getResult()).isEqualTo(GameResult.LOSE)
+            );
+
+            // when
+            timeline.rollback();
+
+            // then
+            assertAll(
+                    () -> assertThat(game.getState()).isEqualTo(GameState.PLAYING),
+                    () -> assertThat(winningTeam.getResult()).isNull(),
+                    () -> assertThat(losingTeam.getResult()).isNull()
             );
         }
     }


### PR DESCRIPTION
## 이슈
closes #635

## 변경 내용
- `GameService.updateGame`이 매니저의 정보 수정 요청(name/round/startTime/videoId)만 처리하도록 변경. 진행 상태(state/quarter)와 result는 timeline 전용으로 분리.
  - 그동안 PUT `/leagues/{leagueId}/{gameId}` 호출 시 요청 바디의 stale한 state/quarter/round로 덮어써져, timeline으로 PLAYING 전환된 경기가 다시 SCHEDULED로 회귀하는 부정합이 발생.
- `GameController.updateGame`에서 컨트롤러 책임이던 `GameStatusScheduler.updateLeagueStatisticsIfNeeded` 호출 제거. (관련 import/필드 정리)
- `GameProgressTimeline.apply()`의 `GAME_END` 분기에서 `game.end()` + `game.updateResult()`를 함께 수행하여 도메인 책임으로 일원화.
- `TimelineService.register`에서 `GAME_END` 타임라인이 등록되는 순간 `GameStatusScheduler.updateLeagueStatisticsIfNeeded(gameId, FINISHED, round)`를 트리거하여 결승전 통계 갱신 흐름을 보존.

## 테스트
- 단위 (`GameServiceTest`)
  - `게임_정보가_수정된다`: 정보 필드 갱신 검증
  - `게임_정보_수정으로_state와_quarter는_변경되지_않는다`: PUT으로 강제 종료 시도해도 state/quarter 불변
- 인수 (`GameAcceptanceTest`)
  - `경기_정보를_수정한_후_다시_가져와_확인한다`: PUT 전후 state/quarter 동일성 + 정보 필드 반영 검증
- 회귀
  - `TimelineServiceTest`, `GameProgressTimelineTest` 통과 확인 (GAME_END 흐름에서 result/통계 트리거 보존)

## 영향 API
- `PUT /leagues/{leagueId}/{gameId}` — 응답/상태코드 동일. **요청 바디의 `state`/`quarter` 필드는 더 이상 반영되지 않음**(timeline 전용). name/round/startTime/videoId만 갱신.