### PR TITLE
feat: 팀 로고 정사각 정규화 + 기존 로고 백필

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,9 @@ dependencies {
     // aws
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 
+    // image normalization (team logo aspect ratio fix)
+    implementation 'net.coobird:thumbnailator:0.4.20'
+
     // fixture
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.21")
 }

--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -12,6 +12,7 @@ import com.sports.server.common.application.PermissionValidator;
 import com.sports.server.common.application.S3Service;
 import com.sports.server.common.exception.CustomException;
 import com.sports.server.common.exception.NotFoundException;
+import com.sports.server.common.util.LogoImageNormalizer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -43,6 +44,7 @@ public class TeamService {
     public void register(final Member member, final TeamRequest.Register request) {
         String imgUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
         s3Service.doesFileExist(imgUrl);
+        normalizeLogoFromUrl(request.logoImageUrl());
 
         Unit unit = findUnit(request.unit(), member.getOrganization().getId());
         Team team = request.toEntity(imgUrl, unit);
@@ -57,6 +59,7 @@ public class TeamService {
     public Long registerAndReturnId(final Member member, final TeamRequest.Register request) {
         String imgUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
         s3Service.doesFileExist(imgUrl);
+        normalizeLogoFromUrl(request.logoImageUrl());
 
         Unit unit = findUnit(request.unit(), member.getOrganization().getId());
         Team team = request.toEntity(imgUrl, unit);
@@ -77,7 +80,11 @@ public class TeamService {
                     return findUnit(unitName, unitOrgId);
                 })
                 .orElse(null);
-        team.update(request.name(), resolveLogoImageUrl(request.logoImageUrl(), team), unit, request.teamColor());
+        String resolvedLogoUrl = resolveLogoImageUrl(request.logoImageUrl(), team);
+        if (resolvedLogoUrl != null) {
+            normalizeLogoFromUrl(request.logoImageUrl());
+        }
+        team.update(request.name(), resolvedLogoUrl, unit, request.teamColor());
 
         if (request.teamPlayers() != null) {
             upsertPlayersToTeam(member, team, request.teamPlayers());
@@ -204,5 +211,28 @@ public class TeamService {
             throw new CustomException(HttpStatus.BAD_REQUEST, "잘못된 이미지 url 입니다.");
         }
         return logoImageUrl.replace(originPrefix, replacePrefix);
+    }
+
+    public void normalizeLogoFromUrl(String url) {
+        String key = extractS3Key(url);
+        if (key == null) {
+            return;
+        }
+        byte[] original = s3Service.download(key);
+        byte[] normalized = LogoImageNormalizer.normalize(original);
+        s3Service.upload(key, normalized, LogoImageNormalizer.OUTPUT_CONTENT_TYPE);
+    }
+
+    private String extractS3Key(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        if (url.startsWith(originPrefix)) {
+            return url.substring(originPrefix.length());
+        }
+        if (url.startsWith(replacePrefix)) {
+            return url.substring(replacePrefix.length());
+        }
+        return null;
     }
 }

--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -43,7 +43,7 @@ public class TeamService {
 
     public void register(final Member member, final TeamRequest.Register request) {
         String imgUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
-        s3Service.doesFileExist(imgUrl);
+        s3Service.doesFileExist(extractS3Key(request.logoImageUrl()));
         normalizeLogoFromUrl(request.logoImageUrl());
 
         Unit unit = findUnit(request.unit(), member.getOrganization().getId());
@@ -58,7 +58,7 @@ public class TeamService {
 
     public Long registerAndReturnId(final Member member, final TeamRequest.Register request) {
         String imgUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
-        s3Service.doesFileExist(imgUrl);
+        s3Service.doesFileExist(extractS3Key(request.logoImageUrl()));
         normalizeLogoFromUrl(request.logoImageUrl());
 
         Unit unit = findUnit(request.unit(), member.getOrganization().getId());

--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -12,9 +12,9 @@ import com.sports.server.common.application.PermissionValidator;
 import com.sports.server.common.application.S3Service;
 import com.sports.server.common.exception.CustomException;
 import com.sports.server.common.exception.NotFoundException;
-import com.sports.server.common.util.LogoImageNormalizer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,16 +40,17 @@ public class TeamService {
     private final UnitRepository unitRepository;
     private final EntityUtils entityUtils;
     private final S3Service s3Service;
+    private final ApplicationEventPublisher eventPublisher;
 
     public void register(final Member member, final TeamRequest.Register request) {
         String imgUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
         s3Service.doesFileExist(extractS3Key(request.logoImageUrl()));
-        normalizeLogoFromUrl(request.logoImageUrl());
 
         Unit unit = findUnit(request.unit(), member.getOrganization().getId());
         Team team = request.toEntity(imgUrl, unit);
         team.setOrganization(member.getOrganization());
         teamRepository.save(team);
+        eventPublisher.publishEvent(new LogoImageNormalizationRequestedEvent(request.logoImageUrl()));
 
         if (request.teamPlayers() != null && !request.teamPlayers().isEmpty()) {
             addPlayersToTeam(member, team.getId(), request.teamPlayers());
@@ -59,12 +60,12 @@ public class TeamService {
     public Long registerAndReturnId(final Member member, final TeamRequest.Register request) {
         String imgUrl = changeLogoImageUrlToBeSaved(request.logoImageUrl());
         s3Service.doesFileExist(extractS3Key(request.logoImageUrl()));
-        normalizeLogoFromUrl(request.logoImageUrl());
 
         Unit unit = findUnit(request.unit(), member.getOrganization().getId());
         Team team = request.toEntity(imgUrl, unit);
         team.setOrganization(member.getOrganization());
         teamRepository.save(team);
+        eventPublisher.publishEvent(new LogoImageNormalizationRequestedEvent(request.logoImageUrl()));
         return team.getId();
     }
 
@@ -81,10 +82,10 @@ public class TeamService {
                 })
                 .orElse(null);
         String resolvedLogoUrl = resolveLogoImageUrl(request.logoImageUrl(), team);
-        if (resolvedLogoUrl != null) {
-            normalizeLogoFromUrl(request.logoImageUrl());
-        }
         team.update(request.name(), resolvedLogoUrl, unit, request.teamColor());
+        if (resolvedLogoUrl != null) {
+            eventPublisher.publishEvent(new LogoImageNormalizationRequestedEvent(request.logoImageUrl()));
+        }
 
         if (request.teamPlayers() != null) {
             upsertPlayersToTeam(member, team, request.teamPlayers());
@@ -211,16 +212,6 @@ public class TeamService {
             throw new CustomException(HttpStatus.BAD_REQUEST, "잘못된 이미지 url 입니다.");
         }
         return logoImageUrl.replace(originPrefix, replacePrefix);
-    }
-
-    public void normalizeLogoFromUrl(String url) {
-        String key = extractS3Key(url);
-        if (key == null) {
-            return;
-        }
-        byte[] original = s3Service.download(key);
-        byte[] normalized = LogoImageNormalizer.normalize(original);
-        s3Service.upload(key, normalized, LogoImageNormalizer.OUTPUT_CONTENT_TYPE);
     }
 
     private String extractS3Key(String url) {

--- a/src/main/java/com/sports/server/command/team/domain/LogoImageNormalizationRequestedEvent.java
+++ b/src/main/java/com/sports/server/command/team/domain/LogoImageNormalizationRequestedEvent.java
@@ -1,0 +1,6 @@
+package com.sports.server.command.team.domain;
+
+public record LogoImageNormalizationRequestedEvent(
+        String logoImageUrl
+) {
+}

--- a/src/main/java/com/sports/server/command/team/domain/TeamRepository.java
+++ b/src/main/java/com/sports/server/command/team/domain/TeamRepository.java
@@ -10,4 +10,6 @@ public interface TeamRepository extends Repository<Team, Long> {
     void delete(Team team);
 
     List<Team> findAllById(Iterable<Long> ids);
+
+    List<Team> findAll();
 }

--- a/src/main/java/com/sports/server/command/team/infrastructure/TeamLogoBackfillRunner.java
+++ b/src/main/java/com/sports/server/command/team/infrastructure/TeamLogoBackfillRunner.java
@@ -1,0 +1,50 @@
+package com.sports.server.command.team.infrastructure;
+
+import com.sports.server.command.team.application.TeamService;
+import com.sports.server.command.team.domain.Team;
+import com.sports.server.command.team.domain.TeamRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.team-logo-backfill.enabled", havingValue = "true")
+public class TeamLogoBackfillRunner implements ApplicationRunner {
+
+    private final TeamRepository teamRepository;
+    private final TeamService teamService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        List<Team> teams = teamRepository.findAll();
+        log.info("[team-logo-backfill] start. total={}", teams.size());
+
+        int success = 0;
+        int skipped = 0;
+        int failed = 0;
+        for (Team team : teams) {
+            String url = team.getLogoImageUrl();
+            if (url == null || url.isBlank()) {
+                skipped++;
+                continue;
+            }
+            try {
+                teamService.normalizeLogoFromUrl(url);
+                success++;
+                log.info("[team-logo-backfill] ok teamId={}", team.getId());
+            } catch (Exception e) {
+                failed++;
+                log.warn("[team-logo-backfill] fail teamId={} url={} reason={}",
+                        team.getId(), url, e.getMessage());
+            }
+        }
+
+        log.info("[team-logo-backfill] done. success={} skipped={} failed={}", success, skipped, failed);
+    }
+}

--- a/src/main/java/com/sports/server/command/team/infrastructure/TeamLogoBackfillRunner.java
+++ b/src/main/java/com/sports/server/command/team/infrastructure/TeamLogoBackfillRunner.java
@@ -1,6 +1,5 @@
 package com.sports.server.command.team.infrastructure;
 
-import com.sports.server.command.team.application.TeamService;
 import com.sports.server.command.team.domain.Team;
 import com.sports.server.command.team.domain.TeamRepository;
 import java.util.List;
@@ -18,7 +17,7 @@ import org.springframework.stereotype.Component;
 public class TeamLogoBackfillRunner implements ApplicationRunner {
 
     private final TeamRepository teamRepository;
-    private final TeamService teamService;
+    private final TeamLogoNormalizer teamLogoNormalizer;
 
     @Override
     public void run(ApplicationArguments args) {
@@ -35,7 +34,7 @@ public class TeamLogoBackfillRunner implements ApplicationRunner {
                 continue;
             }
             try {
-                teamService.normalizeLogoFromUrl(url);
+                teamLogoNormalizer.normalize(url);
                 success++;
                 log.info("[team-logo-backfill] ok teamId={}", team.getId());
             } catch (Exception e) {

--- a/src/main/java/com/sports/server/command/team/infrastructure/TeamLogoNormalizer.java
+++ b/src/main/java/com/sports/server/command/team/infrastructure/TeamLogoNormalizer.java
@@ -1,0 +1,60 @@
+package com.sports.server.command.team.infrastructure;
+
+import com.sports.server.command.team.domain.LogoImageNormalizationRequestedEvent;
+import com.sports.server.common.application.S3Service;
+import com.sports.server.common.util.LogoImageNormalizer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TeamLogoNormalizer {
+
+    private final S3Service s3Service;
+
+    @Value("${image.origin-prefix}")
+    private String originPrefix;
+
+    @Value("${image.replaced-prefix}")
+    private String replacePrefix;
+
+    public void normalize(String logoImageUrl) {
+        String key = extractS3Key(logoImageUrl);
+        if (key == null) {
+            return;
+        }
+        byte[] original = s3Service.download(key);
+        byte[] normalized = LogoImageNormalizer.normalize(original);
+        s3Service.upload(key, normalized, LogoImageNormalizer.OUTPUT_CONTENT_TYPE);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async("asyncThreadPool")
+    public void handle(LogoImageNormalizationRequestedEvent event) {
+        try {
+            normalize(event.logoImageUrl());
+        } catch (Exception e) {
+            log.warn("[team-logo-normalize-async] failed url={} reason={}",
+                    event.logoImageUrl(), e.getMessage());
+        }
+    }
+
+    private String extractS3Key(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        if (url.startsWith(originPrefix)) {
+            return url.substring(originPrefix.length());
+        }
+        if (url.startsWith(replacePrefix)) {
+            return url.substring(replacePrefix.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/sports/server/common/application/S3Service.java
+++ b/src/main/java/com/sports/server/common/application/S3Service.java
@@ -4,7 +4,13 @@ import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
 import com.sports.server.common.exception.CustomException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
@@ -56,6 +62,28 @@ public class S3Service {
             amazonS3.doesObjectExist(bucketName, key);
         } catch (Exception e) {
             throw new CustomException(HttpStatus.NOT_FOUND, "S3에 해당 파일이 존재하지 않습니다.");
+        }
+    }
+
+    public byte[] download(String key) {
+        try (S3Object object = amazonS3.getObject(bucketName, key);
+             InputStream content = object.getObjectContent();
+             ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            content.transferTo(out);
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new CustomException(HttpStatus.NOT_FOUND, "S3에서 이미지를 다운로드할 수 없습니다.");
+        }
+    }
+
+    public void upload(String key, byte[] bytes, String contentType) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(contentType);
+        metadata.setContentLength(bytes.length);
+        try {
+            amazonS3.putObject(new PutObjectRequest(bucketName, key, new ByteArrayInputStream(bytes), metadata));
+        } catch (Exception e) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "이미지 파일 업로드에 실패했습니다.");
         }
     }
 

--- a/src/main/java/com/sports/server/common/application/S3Service.java
+++ b/src/main/java/com/sports/server/common/application/S3Service.java
@@ -29,6 +29,8 @@ public class S3Service {
     @Value("${amazon.aws.bucket}")
     private String bucketName;
 
+    private static final long MAX_DOWNLOAD_BYTES = 10L * 1024 * 1024;
+
     private final String backupPrefix = "backup/";
 
     public String generatePresignedUrl(String extension) {
@@ -66,6 +68,16 @@ public class S3Service {
     }
 
     public byte[] download(String key) {
+        try {
+            ObjectMetadata meta = amazonS3.getObjectMetadata(bucketName, key);
+            if (meta.getContentLength() > MAX_DOWNLOAD_BYTES) {
+                throw new CustomException(HttpStatus.PAYLOAD_TOO_LARGE, "이미지 파일이 허용 용량(10MB)을 초과합니다.");
+            }
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(HttpStatus.NOT_FOUND, "S3에서 이미지를 다운로드할 수 없습니다.");
+        }
         try (S3Object object = amazonS3.getObject(bucketName, key);
              InputStream content = object.getObjectContent();
              ByteArrayOutputStream out = new ByteArrayOutputStream()) {

--- a/src/main/java/com/sports/server/common/util/LogoImageNormalizer.java
+++ b/src/main/java/com/sports/server/common/util/LogoImageNormalizer.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 public final class LogoImageNormalizer {
 
     public static final int CANVAS_SIZE = 512;
+    public static final int MAX_DIMENSION = 4096;
     public static final String OUTPUT_FORMAT = "png";
     public static final String OUTPUT_CONTENT_TYPE = "image/png";
 
@@ -25,6 +26,9 @@ public final class LogoImageNormalizer {
 
     public static byte[] normalize(byte[] source) {
         BufferedImage decoded = decode(source);
+        if (decoded.getWidth() > MAX_DIMENSION || decoded.getHeight() > MAX_DIMENSION) {
+            throw new CustomException(HttpStatus.PAYLOAD_TOO_LARGE, "이미지 해상도가 허용 한도(4096×4096)를 초과합니다.");
+        }
         BufferedImage resized = resizeContain(decoded);
         BufferedImage centered = centerOnCanvas(resized);
         return encodePng(centered);

--- a/src/main/java/com/sports/server/common/util/LogoImageNormalizer.java
+++ b/src/main/java/com/sports/server/common/util/LogoImageNormalizer.java
@@ -1,0 +1,80 @@
+package com.sports.server.common.util;
+
+import com.sports.server.common.exception.CustomException;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+import net.coobird.thumbnailator.Thumbnails;
+import org.springframework.http.HttpStatus;
+
+public final class LogoImageNormalizer {
+
+    public static final int CANVAS_SIZE = 512;
+    public static final String OUTPUT_FORMAT = "png";
+    public static final String OUTPUT_CONTENT_TYPE = "image/png";
+
+    private static final Color BACKGROUND = Color.WHITE;
+
+    private LogoImageNormalizer() {
+    }
+
+    public static byte[] normalize(byte[] source) {
+        BufferedImage decoded = decode(source);
+        BufferedImage resized = resizeContain(decoded);
+        BufferedImage centered = centerOnCanvas(resized);
+        return encodePng(centered);
+    }
+
+    private static BufferedImage decode(byte[] source) {
+        try {
+            BufferedImage image = ImageIO.read(new ByteArrayInputStream(source));
+            if (image == null) {
+                throw new CustomException(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다.");
+            }
+            return image;
+        } catch (IOException e) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "이미지 디코딩에 실패했습니다.");
+        }
+    }
+
+    private static BufferedImage resizeContain(BufferedImage source) {
+        try {
+            return Thumbnails.of(source)
+                    .size(CANVAS_SIZE, CANVAS_SIZE)
+                    .keepAspectRatio(true)
+                    .asBufferedImage();
+        } catch (IOException e) {
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 리사이즈에 실패했습니다.");
+        }
+    }
+
+    private static BufferedImage centerOnCanvas(BufferedImage resized) {
+        BufferedImage canvas = new BufferedImage(CANVAS_SIZE, CANVAS_SIZE, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = canvas.createGraphics();
+        try {
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+            g.setColor(BACKGROUND);
+            g.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+            int x = (CANVAS_SIZE - resized.getWidth()) / 2;
+            int y = (CANVAS_SIZE - resized.getHeight()) / 2;
+            g.drawImage(resized, x, y, null);
+        } finally {
+            g.dispose();
+        }
+        return canvas;
+    }
+
+    private static byte[] encodePng(BufferedImage image) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            ImageIO.write(image, OUTPUT_FORMAT, out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 인코딩에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/sports/server/common/util/LogoImageNormalizer.java
+++ b/src/main/java/com/sports/server/common/util/LogoImageNormalizer.java
@@ -64,9 +64,9 @@ public final class LogoImageNormalizer {
             g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
             g.setColor(BACKGROUND);
             g.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
-            int x = (CANVAS_SIZE - resized.getWidth()) / 2;
-            int y = (CANVAS_SIZE - resized.getHeight()) / 2;
-            g.drawImage(resized, x, y, null);
+            int offsetX = (CANVAS_SIZE - resized.getWidth()) / 2;
+            int offsetY = (CANVAS_SIZE - resized.getHeight()) / 2;
+            g.drawImage(resized, offsetX, offsetY, null);
         } finally {
             g.dispose();
         }

--- a/src/test/java/com/sports/server/command/team/application/TeamServiceTest.java
+++ b/src/test/java/com/sports/server/command/team/application/TeamServiceTest.java
@@ -25,8 +25,15 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
 
 
 @Sql("/team-fixture.sql")
@@ -54,10 +61,16 @@ public class TeamServiceTest extends ServiceTest {
     private Member manager;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws IOException {
         imageUrl = originPrefix + "image_url.png";
         manager = memberRepository.findMemberByEmailWithOrganization("john@example.com")
                 .orElseThrow();
+
+        BufferedImage stub = new BufferedImage(10, 10, BufferedImage.TYPE_INT_RGB);
+        ByteArrayOutputStream png = new ByteArrayOutputStream();
+        ImageIO.write(stub, "png", png);
+        when(s3Service.download(anyString())).thenReturn(png.toByteArray());
+        doNothing().when(s3Service).upload(anyString(), any(byte[].class), anyString());
     }
 
     @Nested

--- a/src/test/java/com/sports/server/common/util/LogoImageNormalizerTest.java
+++ b/src/test/java/com/sports/server/common/util/LogoImageNormalizerTest.java
@@ -76,6 +76,16 @@ class LogoImageNormalizerTest {
                 .isInstanceOf(CustomException.class);
     }
 
+    @Test
+    @DisplayName("해상도가 허용 한도를 초과하면 CustomException 이 발생한다")
+    void normalize_oversizedDimension_throws() throws Exception {
+        int overLimit = LogoImageNormalizer.MAX_DIMENSION + 1;
+        byte[] oversized = renderSolidImage(overLimit, overLimit, Color.RED, "png");
+
+        assertThatThrownBy(() -> LogoImageNormalizer.normalize(oversized))
+                .isInstanceOf(CustomException.class);
+    }
+
     private static byte[] renderSolidImage(int width, int height, Color color, String format) throws Exception {
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
         Graphics2D g = image.createGraphics();

--- a/src/test/java/com/sports/server/common/util/LogoImageNormalizerTest.java
+++ b/src/test/java/com/sports/server/common/util/LogoImageNormalizerTest.java
@@ -1,0 +1,96 @@
+package com.sports.server.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sports.server.common.exception.CustomException;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LogoImageNormalizerTest {
+
+    @Test
+    @DisplayName("와이드 이미지를 정규화하면 512x512 정사각형으로 변환된다")
+    void normalize_widthRectangle_to512Square() throws Exception {
+        byte[] wide = renderSolidImage(1024, 256, Color.RED, "png");
+
+        byte[] result = LogoImageNormalizer.normalize(wide);
+
+        BufferedImage decoded = decode(result);
+        assertThat(decoded.getWidth()).isEqualTo(LogoImageNormalizer.CANVAS_SIZE);
+        assertThat(decoded.getHeight()).isEqualTo(LogoImageNormalizer.CANVAS_SIZE);
+    }
+
+    @Test
+    @DisplayName("와이드 이미지를 정규화하면 위/아래 빈 영역이 흰색으로 패딩된다")
+    void normalize_widthRectangle_paddedWithWhite() throws Exception {
+        byte[] wide = renderSolidImage(1024, 256, Color.RED, "png");
+
+        byte[] result = LogoImageNormalizer.normalize(wide);
+
+        BufferedImage decoded = decode(result);
+        Color topLeft = new Color(decoded.getRGB(0, 0));
+        Color bottomRight = new Color(decoded.getRGB(decoded.getWidth() - 1, decoded.getHeight() - 1));
+        assertThat(topLeft).isEqualTo(Color.WHITE);
+        assertThat(bottomRight).isEqualTo(Color.WHITE);
+    }
+
+    @Test
+    @DisplayName("정사각형 이미지를 정규화하면 패딩 없이 512x512로 변환된다")
+    void normalize_square_to512Square() throws Exception {
+        byte[] square = renderSolidImage(300, 300, Color.BLUE, "png");
+
+        byte[] result = LogoImageNormalizer.normalize(square);
+
+        BufferedImage decoded = decode(result);
+        assertThat(decoded.getWidth()).isEqualTo(LogoImageNormalizer.CANVAS_SIZE);
+        assertThat(decoded.getHeight()).isEqualTo(LogoImageNormalizer.CANVAS_SIZE);
+        Color center = new Color(decoded.getRGB(decoded.getWidth() / 2, decoded.getHeight() / 2));
+        assertThat(center).isEqualTo(Color.BLUE);
+    }
+
+    @Test
+    @DisplayName("JPEG 입력도 PNG로 정규화된다")
+    void normalize_jpegInput_toPng() throws Exception {
+        byte[] jpeg = renderSolidImage(400, 400, Color.GREEN, "jpg");
+
+        byte[] result = LogoImageNormalizer.normalize(jpeg);
+
+        BufferedImage decoded = decode(result);
+        assertThat(decoded.getWidth()).isEqualTo(LogoImageNormalizer.CANVAS_SIZE);
+        assertThat(decoded.getHeight()).isEqualTo(LogoImageNormalizer.CANVAS_SIZE);
+    }
+
+    @Test
+    @DisplayName("디코딩 불가능한 입력은 CustomException 으로 변환된다")
+    void normalize_invalidBytes_throws() {
+        byte[] garbage = "not-an-image".getBytes();
+
+        assertThatThrownBy(() -> LogoImageNormalizer.normalize(garbage))
+                .isInstanceOf(CustomException.class);
+    }
+
+    private static byte[] renderSolidImage(int width, int height, Color color, String format) throws Exception {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = image.createGraphics();
+        try {
+            g.setColor(color);
+            g.fillRect(0, 0, width, height);
+        } finally {
+            g.dispose();
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ImageIO.write(image, format, out);
+        return out.toByteArray();
+    }
+
+    private static BufferedImage decode(byte[] bytes) throws Exception {
+        return ImageIO.read(new ByteArrayInputStream(bytes));
+    }
+}

--- a/src/test/java/com/sports/server/support/AcceptanceTest.java
+++ b/src/test/java/com/sports/server/support/AcceptanceTest.java
@@ -13,7 +13,11 @@ import com.sports.server.support.isolation.DatabaseIsolation;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
+import javax.imageio.ImageIO;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,6 +55,8 @@ public class AcceptanceTest {
 
     protected String mockToken = "mockToken";
 
+    private static final byte[] STUB_PNG = createStubPng();
+
     @BeforeEach
     protected void setUp(
     ) {
@@ -60,6 +66,19 @@ public class AcceptanceTest {
                 .willReturn(ResponseEntity.ok().build());
 
         willDoNothing().given(s3Service).doesFileExist(any());
+        given(s3Service.download(any())).willReturn(STUB_PNG);
+        willDoNothing().given(s3Service).upload(any(), any(), any());
+    }
+
+    private static byte[] createStubPng() {
+        try {
+            BufferedImage image = new BufferedImage(10, 10, BufferedImage.TYPE_INT_RGB);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ImageIO.write(image, "png", out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException("test stub PNG 생성 실패", e);
+        }
     }
 
     protected <T> List<T> toResponses(ExtractableResponse<Response> response,


### PR DESCRIPTION
## 이슈
- 축구 경기 UI에서 팀 로고가 찌그러져 보이는 문제 (와이드/레터박스 원본을 정사각 슬롯에 강제 표시)
- 원본 비율 다양성으로 프론트 단일 처리 불가 → 백엔드에서 일회성 정규화

## 변경내용
- `LogoImageNormalizer` 추가: 512×512 PNG로 contain 리사이즈 + 흰색 패딩 (Thumbnailator)
- `S3Service`에 `download(key)`, `upload(key, bytes, contentType)` 추가
- `TeamService.register/registerAndReturnId/update`에서 등록·수정 시 동기 정규화 호출
  - 같은 S3 key로 덮어쓰기 → 프론트 URL/CDN 캐시 영향 없음 (CDN은 무효화 필요 시 별도)
- `TeamLogoBackfillRunner` 추가: `app.team-logo-backfill.enabled=true`일 때 부팅 시 1회 전 팀 정규화
- 의존성: `net.coobird:thumbnailator:0.4.20`
- 테스트: `LogoImageNormalizerTest` 5건 + `AcceptanceTest`/`TeamServiceTest` S3 모킹 보강

## 테스트
- [x] `./gradlew test` 전체 통과 (BUILD SUCCESSFUL)
- [x] 정규화 단위 테스트: 와이드→정사각, 패딩=흰색, 정사각 유지, JPEG→PNG, 잘못된 입력→예외
- [x] 인수 테스트(team 등록/수정) 회귀 통과

## 영향 API
- `POST /admin/teams`, `PUT /admin/teams/{id}`: 응답 스키마 변경 없음. 내부에서 S3 객체 본문이 정사각 PNG로 교체됨.
- 신규 환경변수: `APP_TEAM_LOGO_BACKFILL_ENABLED` (기본 false)

## 프론트 참고
- 응답 URL 동일. 동일 key 덮어쓰기라 마크업/요청 변경 불필요.
- CDN 캐시 갱신이 필요하면 별도 무효화 요청 (key 미변경이라 자동 갱신 안 될 수 있음).

## 백필 운영 절차
1. 서버에 `APP_TEAM_LOGO_BACKFILL_ENABLED=true` 설정 후 재배포/재시작
2. 로그에서 `[team-logo-backfill] start` → `done success=N skipped=N failed=N` 확인
3. 환경변수 제거 후 다시 재시작 (러너 비활성화)
4. 실패 건은 로그의 team_id로 수동 확인