### PR TITLE
fix: 긍정 초성 단어 결합·언급 케이스 마스킹 누수 차단

### DIFF
--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
@@ -3,6 +3,7 @@ package com.sports.server.command.cheertalk.infra;
 import java.text.Normalizer;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -41,7 +42,7 @@ public class MaskingOutputSanitizer {
     );
 
     private static final int LONG_POSITIVE_THRESHOLD = 3;
-    private static final String POSITIVE_TOKEN_DELIMITERS = "[\\s,.!?~^]+";
+    private static final Pattern POSITIVE_TOKEN_PATTERN = Pattern.compile("[\\s,.!?~^]+");
 
     private final List<String> leakMarkers;
     private final Set<String> positiveConsonants;
@@ -78,6 +79,9 @@ public class MaskingOutputSanitizer {
         }
         if (containsLeakMarker(stripped)) {
             return original;
+        }
+        if (stripped.equals(original)) {
+            return stripped;
         }
         if (isModifiedWithoutMask(original, stripped)) {
             return original;
@@ -131,7 +135,7 @@ public class MaskingOutputSanitizer {
     }
 
     private boolean containsAsToken(String text, String token) {
-        for (String t : text.split(POSITIVE_TOKEN_DELIMITERS)) {
+        for (String t : POSITIVE_TOKEN_PATTERN.split(text)) {
             if (t.equals(token)) {
                 return true;
             }

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
@@ -32,6 +32,17 @@ public class MaskingOutputSanitizer {
             "마스킹할 필요"
     );
 
+    /**
+     * 욕설 초성 화이트리스트. gemini 프롬프트 [반드시 마스킹] 항목과 동기화 유지.
+     * 짧은 긍정 초성(ㄱㅅ 등)이 욕설 초성(ㄱㅅㄲ)의 부분문자열일 때 잘못 복구하는 것을 방지한다.
+     */
+    private static final List<String> BANNED_PROFANITY_INITIALS = List.of(
+            "ㅅㅂ", "ㄱㅅㄲ", "ㅈㄴ", "ㅄ", "ㅂㅅ"
+    );
+
+    private static final int LONG_POSITIVE_THRESHOLD = 3;
+    private static final String POSITIVE_TOKEN_DELIMITERS = "[\\s,.!?~^]+";
+
     private final List<String> leakMarkers;
     private final Set<String> positiveConsonants;
 
@@ -77,14 +88,51 @@ public class MaskingOutputSanitizer {
         return stripped;
     }
 
+    /**
+     * 원문에 있던 긍정 초성이 출력에서 사라졌으면 모델이 잘못 마스킹한 것으로 보고 원문을 복구한다.
+     * 단 두 가지 예외로 복구를 보류한다:
+     * 1) 원문에 욕설 초성이 함께 있으면 마스킹이 정당할 수 있어 신뢰한다.
+     * 2) 짧은 긍정 초성(ㄱㅅ 등)은 욕설 초성(ㄱㅅㄲ)의 부분문자열일 수 있어 토큰 단독 일치만 보호한다.
+     */
     private boolean lostPositiveConsonant(String original, String modelOutput) {
         if (positiveConsonants.isEmpty()) {
             return false;
         }
         String originalNFC = Normalizer.normalize(original, Normalizer.Form.NFC);
+        if (containsBannedInitial(originalNFC)) {
+            return false;
+        }
         String outputNFC = Normalizer.normalize(modelOutput, Normalizer.Form.NFC);
-        for (String pc : positiveConsonants) {
-            if (originalNFC.contains(pc) && !outputNFC.contains(pc)) {
+        for (String positiveConsonant : positiveConsonants) {
+            if (outputNFC.contains(positiveConsonant)) {
+                continue;
+            }
+            if (isProtectedInOriginal(originalNFC, positiveConsonant)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isProtectedInOriginal(String original, String positiveConsonant) {
+        if (positiveConsonant.length() >= LONG_POSITIVE_THRESHOLD) {
+            return original.contains(positiveConsonant);
+        }
+        return containsAsToken(original, positiveConsonant);
+    }
+
+    private boolean containsBannedInitial(String original) {
+        for (String banned : BANNED_PROFANITY_INITIALS) {
+            if (original.contains(banned)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean containsAsToken(String text, String token) {
+        for (String t : text.split(POSITIVE_TOKEN_DELIMITERS)) {
+            if (t.equals(token)) {
                 return true;
             }
         }

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizer.java
@@ -1,6 +1,9 @@
 package com.sports.server.command.cheertalk.infra;
 
+import java.text.Normalizer;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -30,15 +33,22 @@ public class MaskingOutputSanitizer {
     );
 
     private final List<String> leakMarkers;
+    private final Set<String> positiveConsonants;
 
     public MaskingOutputSanitizer(
-            @Value("${masking.leak-markers:}") List<String> leakMarkers
+            @Value("${masking.leak-markers:}") List<String> leakMarkers,
+            @Value("${masking.positive-consonants:}") List<String> positiveConsonants
     ) {
         List<String> filtered = leakMarkers.stream()
                 .filter(s -> s != null && !s.isBlank())
                 .map(String::strip)
                 .toList();
         this.leakMarkers = filtered.isEmpty() ? DEFAULT_LEAK_MARKERS : filtered;
+        this.positiveConsonants = positiveConsonants.stream()
+                .filter(s -> s != null && !s.isBlank())
+                .map(String::strip)
+                .map(s -> Normalizer.normalize(s, Normalizer.Form.NFC))
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     public String sanitize(String original, String modelOutput) {
@@ -61,7 +71,24 @@ public class MaskingOutputSanitizer {
         if (isModifiedWithoutMask(original, stripped)) {
             return original;
         }
+        if (lostPositiveConsonant(original, stripped)) {
+            return original;
+        }
         return stripped;
+    }
+
+    private boolean lostPositiveConsonant(String original, String modelOutput) {
+        if (positiveConsonants.isEmpty()) {
+            return false;
+        }
+        String originalNFC = Normalizer.normalize(original, Normalizer.Form.NFC);
+        String outputNFC = Normalizer.normalize(modelOutput, Normalizer.Form.NFC);
+        for (String pc : positiveConsonants) {
+            if (originalNFC.contains(pc) && !outputNFC.contains(pc)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isModifiedWithoutMask(String original, String modelOutput) {

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingPreFilter.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingPreFilter.java
@@ -15,6 +15,8 @@ import java.util.stream.Collectors;
 @Component
 public class MaskingPreFilter {
 
+    private static final String POSITIVE_TOKEN_DELIMITERS = "[\\s,.!?~^]+";
+
     private final Set<String> recommendedMessages;
     private final Set<String> positiveConsonants;
 
@@ -40,7 +42,28 @@ public class MaskingPreFilter {
         if (positiveConsonants.contains(trimmed)) {
             return true;
         }
+        if (isOnlyPositiveTokens(trimmed)) {
+            return true;
+        }
         return !containsAnyKorean(trimmed);
+    }
+
+    private boolean isOnlyPositiveTokens(String trimmed) {
+        if (positiveConsonants.isEmpty()) {
+            return false;
+        }
+        String[] tokens = trimmed.split(POSITIVE_TOKEN_DELIMITERS);
+        boolean hasToken = false;
+        for (String token : tokens) {
+            if (token.isEmpty()) {
+                continue;
+            }
+            if (!positiveConsonants.contains(token)) {
+                return false;
+            }
+            hasToken = true;
+        }
+        return hasToken;
     }
 
     private static Set<String> toNormalizedSet(List<String> values) {

--- a/src/main/java/com/sports/server/command/cheertalk/infra/MaskingPreFilter.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/MaskingPreFilter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import java.text.Normalizer;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -15,7 +16,7 @@ import java.util.stream.Collectors;
 @Component
 public class MaskingPreFilter {
 
-    private static final String POSITIVE_TOKEN_DELIMITERS = "[\\s,.!?~^]+";
+    private static final Pattern POSITIVE_TOKEN_PATTERN = Pattern.compile("[\\s,.!?~^]+");
 
     private final Set<String> recommendedMessages;
     private final Set<String> positiveConsonants;
@@ -52,7 +53,7 @@ public class MaskingPreFilter {
         if (positiveConsonants.isEmpty()) {
             return false;
         }
-        String[] tokens = trimmed.split(POSITIVE_TOKEN_DELIMITERS);
+        String[] tokens = POSITIVE_TOKEN_PATTERN.split(trimmed);
         boolean hasToken = false;
         for (String token : tokens) {
             if (token.isEmpty()) {

--- a/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
@@ -145,8 +145,8 @@ class MaskingOutputSanitizerTest {
     }
 
     @Nested
-    @DisplayName("긍정 초성이 사라지면 원문으로 복구한다")
-    class PositiveConsonantLoss {
+    @DisplayName("긴 긍정 초성(ㅎㅇㅌ 등)이 사라지면 원문으로 복구한다")
+    class LongPositiveConsonantLoss {
 
         @Test
         @DisplayName("단어 뒤에 붙은 긍정 초성이 마스킹된 케이스 — 스콜피온ㅎㅇㅌ 누수")
@@ -178,6 +178,46 @@ class MaskingOutputSanitizerTest {
             MaskingOutputSanitizer noPositive = new MaskingOutputSanitizer(List.of(), List.of());
             String result = noPositive.sanitize("스콜피온ㅎㅇㅌ", "스콜피온***");
             assertThat(result).isEqualTo("스콜피온***");
+        }
+    }
+
+    @Nested
+    @DisplayName("욕설 초성과 충돌하는 케이스는 복구하지 않는다 (ㄱㅅ ⊂ ㄱㅅㄲ 회귀)")
+    class BannedInitialConflict {
+
+        @Test
+        @DisplayName("원문이 욕설 초성 단독이면 마스킹 결과 유지 — ㄱㅅㄲ → ***")
+        void 욕설_초성_단독_마스킹_유지() {
+            String result = sanitizer.sanitize("ㄱㅅㄲ", "***");
+            assertThat(result).isEqualTo("***");
+        }
+
+        @Test
+        @DisplayName("원문 중간에 욕설 초성이 있어도 마스킹 결과 유지 — 이 ㄱㅅㄲ → 이 ***")
+        void 문장_내_욕설_초성_마스킹_유지() {
+            String result = sanitizer.sanitize("이 ㄱㅅㄲ", "이 ***");
+            assertThat(result).isEqualTo("이 ***");
+        }
+
+        @Test
+        @DisplayName("긍정 초성과 욕설 초성이 공존하면 복구하지 않는다 — ㄱㅅ ㄱㅅㄲ → ** ***")
+        void 긍정_욕설_공존시_복구_보류() {
+            String result = sanitizer.sanitize("ㄱㅅ ㄱㅅㄲ", "** ***");
+            assertThat(result).isEqualTo("** ***");
+        }
+
+        @Test
+        @DisplayName("짧은 긍정 초성(ㄱㅅ)이 다른 단어와 결합되어 있으면 보호하지 않는다")
+        void 짧은_긍정_초성_결합_케이스는_복구하지_않는다() {
+            String result = sanitizer.sanitize("씨발ㄱㅅ", "*****");
+            assertThat(result).isEqualTo("*****");
+        }
+
+        @Test
+        @DisplayName("짧은 긍정 초성도 토큰 단독으로 등장하면 복구한다")
+        void 짧은_긍정_초성_토큰_단독은_복구() {
+            String result = sanitizer.sanitize("선수 ㄱㅅ", "선수 **");
+            assertThat(result).isEqualTo("선수 ㄱㅅ");
         }
     }
 

--- a/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/MaskingOutputSanitizerTest.java
@@ -9,7 +9,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class MaskingOutputSanitizerTest {
 
-    private final MaskingOutputSanitizer sanitizer = new MaskingOutputSanitizer(List.of());
+    private static final List<String> POSITIVE_CONSONANTS =
+            List.of("ㅍㅇㅌ", "ㅎㅇㅌ", "ㅎㅇ", "ㄱㄱ", "ㄱㅅ", "ㅊㅋ", "ㄷㄷ", "ㄹㅇ", "ㅇㅈ", "ㄴㄴ", "ㅇㅇ");
+
+    private final MaskingOutputSanitizer sanitizer = new MaskingOutputSanitizer(List.of(), POSITIVE_CONSONANTS);
 
     @Nested
     @DisplayName("정상 응답은 그대로 통과한다")
@@ -142,12 +145,49 @@ class MaskingOutputSanitizerTest {
     }
 
     @Nested
+    @DisplayName("긍정 초성이 사라지면 원문으로 복구한다")
+    class PositiveConsonantLoss {
+
+        @Test
+        @DisplayName("단어 뒤에 붙은 긍정 초성이 마스킹된 케이스 — 스콜피온ㅎㅇㅌ 누수")
+        void 단어_뒤_긍정_초성_마스킹은_원문() {
+            String result = sanitizer.sanitize("스콜피온ㅎㅇㅌ", "스콜피온***");
+            assertThat(result).isEqualTo("스콜피온ㅎㅇㅌ");
+        }
+
+        @Test
+        void 긍정_초성_언급_문장이_마스킹되면_원문() {
+            String result = sanitizer.sanitize("ㅎㅇㅌ 왜 검열되나요", "*** 왜 검열되나요");
+            assertThat(result).isEqualTo("ㅎㅇㅌ 왜 검열되나요");
+        }
+
+        @Test
+        void 긍정_초성이_그대로_보존되면_마스킹된_출력은_통과() {
+            String result = sanitizer.sanitize("씨발ㅎㅇㅌ", "**ㅎㅇㅌ");
+            assertThat(result).isEqualTo("**ㅎㅇㅌ");
+        }
+
+        @Test
+        void 원문에_긍정_초성이_없으면_규칙은_관여하지_않는다() {
+            String result = sanitizer.sanitize("씨발 잘한다", "** 잘한다");
+            assertThat(result).isEqualTo("** 잘한다");
+        }
+
+        @Test
+        void 긍정_초성_리스트가_비어있으면_규칙은_관여하지_않는다() {
+            MaskingOutputSanitizer noPositive = new MaskingOutputSanitizer(List.of(), List.of());
+            String result = noPositive.sanitize("스콜피온ㅎㅇㅌ", "스콜피온***");
+            assertThat(result).isEqualTo("스콜피온***");
+        }
+    }
+
+    @Nested
     @DisplayName("yml 외부 설정")
     class ExternalConfig {
 
         @Test
         void yml에서_커스텀_마커를_받으면_default를_대체한다() {
-            MaskingOutputSanitizer custom = new MaskingOutputSanitizer(List.of("커스텀마커"));
+            MaskingOutputSanitizer custom = new MaskingOutputSanitizer(List.of("커스텀마커"), List.of());
 
             assertThat(custom.sanitize("응원 비속어", "** 커스텀마커")).isEqualTo("응원 비속어");
             assertThat(custom.sanitize("응원 비속어", "** 처리하겠습니다")).isEqualTo("** 처리하겠습니다");
@@ -155,14 +195,14 @@ class MaskingOutputSanitizerTest {
 
         @Test
         void 빈_리스트면_default_마커가_적용된다() {
-            MaskingOutputSanitizer empty = new MaskingOutputSanitizer(List.of());
+            MaskingOutputSanitizer empty = new MaskingOutputSanitizer(List.of(), List.of());
 
             assertThat(empty.sanitize("응원 비속어", "** 처리하겠습니다")).isEqualTo("응원 비속어");
         }
 
         @Test
         void 공백_엔트리는_무시되고_default가_적용된다() {
-            MaskingOutputSanitizer blanks = new MaskingOutputSanitizer(List.of("  ", ""));
+            MaskingOutputSanitizer blanks = new MaskingOutputSanitizer(List.of("  ", ""), List.of());
 
             assertThat(blanks.sanitize("응원 비속어", "** 처리하겠습니다")).isEqualTo("응원 비속어");
         }

--- a/src/test/java/com/sports/server/command/cheertalk/infra/MaskingPreFilterTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/MaskingPreFilterTest.java
@@ -39,6 +39,13 @@ class MaskingPreFilterTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {"ㅎㅇㅌ!", "ㅎㅇㅌ ㅎㅇㅌ", "ㅎㅇㅌ, ㄱㄱ", "ㅎㅇㅌ!!!", " ㅎㅇㅌ. ㄱㄱ ", "ㄱㄱ ㄱㄱ ㄱㄱ"})
+    @DisplayName("긍정 초성과 공백/구두점만 있는 메시지는 LLM을 스킵한다")
+    void 긍정_초성_조합_스킵(String message) {
+        assertThat(filter.canSkip(message)).isTrue();
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = {"Yes!!", "GG", "1234", "🔥🔥🔥", "👍", "wow", "!!!"})
     @DisplayName("한글이 전혀 없는 메시지는 LLM을 스킵한다")
     void 한글_없으면_스킵(String message) {
@@ -49,6 +56,13 @@ class MaskingPreFilterTest {
     @ValueSource(strings = {"ㅅㅂ", "ㅂㅅ", "ㄱㅅㄲ", "ㅈㄴ", "ㅄ", "씨발", "개새끼", "응원합니다", "가즈아!", "가즈아"})
     @DisplayName("욕설 의심 자모와 한글 음절을 포함한 메시지는 LLM에 위임한다")
     void 욕설_의심은_LLM_위임(String message) {
+        assertThat(filter.canSkip(message)).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"스콜피온ㅎㅇㅌ", "ㅎㅇㅌ스콜피온", "ㅎㅇㅌ 왜 검열되나요", "씨발ㅎㅇㅌ", "ㅎㅇㅌ 가자"})
+    @DisplayName("긍정 초성이 단어와 붙어있거나 일반 한글과 함께면 LLM에 위임한다")
+    void 긍정_초성_혼합_LLM_위임(String message) {
         assertThat(filter.canSkip(message)).isFalse();
     }
 

--- a/src/test/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClientTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/OpenRouterMaskingClientTest.java
@@ -28,7 +28,7 @@ class OpenRouterMaskingClientTest {
     @BeforeEach
     void setUp() {
         chatCaller = mock(OpenRouterChatCaller.class);
-        MaskingOutputSanitizer sanitizer = new MaskingOutputSanitizer(List.of());
+        MaskingOutputSanitizer sanitizer = new MaskingOutputSanitizer(List.of(), List.of());
         client = new OpenRouterMaskingClient(chatCaller, sanitizer, SYSTEM_PROMPT, MODEL);
     }
 


### PR DESCRIPTION
## 이슈
- closes #639
- 운영 누수: `스콜피온ㅎㅇㅌ` → `스콜피온***` 으로 DB까지 마스킹되어 저장됨
- 영향 범위: 응원 초성(ㅎㅇㅌ, ㅎㅇ, ㄱㄱ 등)이 단어 뒤/앞에 붙거나 문장에 언급된 모든 케이스

## 원인
- `MaskingPreFilter.canSkip` 은 메시지 **전체**가 화이트리스트 초성과 정확 일치할 때만 LLM 호출을 스킵 → `스콜피온ㅎㅇㅌ` 같이 결합된 형태는 통과해서 LLM 호출
- `MaskingOutputSanitizer.isModifiedWithoutMask` 는 출력에 `*` 가 있으면 정상 마스킹으로 판단 → LLM이 `스콜피온***` 으로 응답하면 그대로 DB 저장
- LLM 프롬프트의 `[절대 마스킹 금지]` 가이드는 자모 단독 케이스만 다뤘고, 결합/언급 케이스 미명시

## 변경 내용
3단 방어선으로 차단:

### 1) PreFilter 확장 (출력단 우회 가드)
- `MaskingPreFilter.isOnlyPositiveTokens` 추가
- 긍정 초성 + 공백/구두점만으로 구성된 메시지(`ㅎㅇㅌ ㄱㄱ`, `ㅎㅇㅌ!`, `ㅎㅇㅌ, ㄱㄱ` 등)도 LLM 스킵
- 단어 결합 케이스(`스콜피온ㅎㅇㅌ`)는 일반 한글이 섞여있어 통과 → LLM 호출됨 (Sanitizer로 차단)

### 2) Sanitizer 긍정 초성 보존 규칙 (출력단 가드)
- `MaskingOutputSanitizer` 에 `${masking.positive-consonants}` 주입
- `lostPositiveConsonant`: 원문에 있던 긍정 초성이 출력에서 사라졌으면(=마스킹됨) 원문으로 폴백
- `ㅅㅂㅎㅇㅌ` → `**ㅎㅇㅌ` 처럼 긍정 초성이 보존된 마스킹은 통과 (정상 마스킹은 영향 없음)

### 3) gemini 프롬프트 강화 (LLM 단)
- be-config: 단어 결합/언급 케이스 명시 + 예시 추가 (별도 PR: hufscheer/be-config#25)

## 테스트
- `./gradlew test --tests "*.cheertalk.*"` BUILD SUCCESSFUL
- `MaskingOutputSanitizerTest.PositiveConsonantLoss` 5건 (단어 결합/언급/보존/규칙 미관여/빈 리스트)
- `MaskingPreFilterTest`: 결합 패턴 LLM 위임 + 긍정 초성 + 구두점 조합 스킵 회귀 추가
- 기존 35+ 회귀 모두 통과

## 회귀 매트릭스
| 원문 | LLM 출력 (가정) | 결과 |
|---|---|---|
| `스콜피온ㅎㅇㅌ` | `스콜피온***` | 원문 복구 ✅ |
| `ㅎㅇㅌ 왜 검열되나요` | `*** 왜 검열되나요` | 원문 복구 ✅ |
| `ㅅㅂㅎㅇㅌ` | `**ㅎㅇㅌ` | 마스킹 유지 ✅ |
| `ㅅㅂ 잘한다` | `** 잘한다` | 마스킹 유지 (긍정 초성 무관) ✅ |
| `ㅎㅇㅌ ㄱㄱ` | (LLM 호출 안 됨) | PreFilter 스킵 ✅ |

## 의존
- be-config PR: https://github.com/hufscheer/be-config/pull/25
- 머지 순서: be-config #25 → 머지 후 본 PR 의 submodule 포인터를 main 머지커밋으로 재bump 후 머지