### PR TITLE
docs: REST Docs와 실제 API 정합성 정렬

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -76,7 +76,7 @@ operation::game-query-controller-test/게임을_상세_조회한다[snippets='ht
 
 === 게임 영상 조회
 
-operation::game-query-controller-test/게임_영상_ID를_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
+operation::game-query-controller-test/게임_영상_id를_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
 
 === 게임 목록 조회
 

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -22,11 +22,11 @@ operation::cheer-talk-query-controller-test/계정별_신고된_응원톡을_모
 
 === 계정별 가려지지 않은 응원톡 전체 조회
 
-operation::cheer-talk-query-controller-test/계정별_가려지지_않은_응원톡을_모두_조회한다[snippets='http-request,request-cookies,query-parameters,path-parameters,http-response,response-fields']
+operation::cheer-talk-query-controller-test/계정별_가려지지_않은_응원톡을_모두_조회한다[snippets='http-request,request-cookies,query-parameters,http-response,response-fields']
 
 === 계정별 가려진 응원톡 전체 조회
 
-operation::cheer-talk-query-controller-test/계정별_가려진_응원톡을_모두_조회한다[snippets='http-request,request-cookies,query-parameters,path-parameters,http-response,response-fields']
+operation::cheer-talk-query-controller-test/계정별_가려진_응원톡을_모두_조회한다[snippets='http-request,request-cookies,query-parameters,http-response,response-fields']
 
 === 리그별 신고된 응원톡 조회
 
@@ -76,7 +76,7 @@ operation::game-query-controller-test/게임을_상세_조회한다[snippets='ht
 
 === 게임 영상 조회
 
-operation::game-query-controller-test/게임_영상_id를_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
+operation::game-query-controller-test/게임_영상_ID를_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
 
 === 게임 목록 조회
 
@@ -128,7 +128,7 @@ operation::game-controller-test/라인업_선수를_주장에서_해제한다[sn
 
 === 응원 횟수 업데이트
 
-operation::game-controller-test/응원_횟수를_업데이트한다[snippets='http-request,request-fields,http-response']
+operation::game-controller-test/응원_횟수를_업데이트한다[snippets='http-request,path-parameters,request-fields,http-response']
 
 == 신고 API
 
@@ -138,7 +138,7 @@ operation::report-controller-test/응원톡을_신고한다[snippets='http-reque
 
 === 응원톡 신고 무효처리(신고 취소)
 
-operation::report-controller-test/신고된_응원톡을_무효처리한다[snippets='http-request,path-parameters,http-response']
+operation::report-controller-test/신고된_응원톡을_무효처리한다[snippets='http-request,request-cookies,path-parameters,http-response']
 
 == 리그 API
 
@@ -148,7 +148,7 @@ operation::league-controller-test/리그를_생성한다[snippets='http-request,
 
 === 리그 수정
 
-operation::league-controller-test/리그를_수정한다[snippets='http-request,request-cookies,request-fields,http-response']
+operation::league-controller-test/리그를_수정한다[snippets='http-request,path-parameters,request-cookies,request-fields,http-response']
 
 === 리그 삭제
 
@@ -180,11 +180,11 @@ operation::league-query-controller-test/리그를_하나_조회한다[snippets='
 
 === 매니저가 생성한 리그 전체 조회(홈 화면)
 
-operation::league-query-controller-test/매니저가_생성한_모든_리그와_진행중_경기를_조회한다[snippets='http-request,http-response,response-fields']
+operation::league-query-controller-test/매니저가_생성한_모든_리그와_진행중_경기를_조회한다[snippets='http-request,request-cookies,http-response,response-fields']
 
 === 매니저가 생성한 리그 전체 조회(대회 관리 화면)
 
-operation::league-query-controller-test/매니저가_생성한_모든_리그를_조회한다[snippets='http-request,http-response,response-fields']
+operation::league-query-controller-test/매니저가_생성한_모든_리그를_조회한다[snippets='http-request,request-cookies,http-response,response-fields']
 
 === 리그의 정보와 리그에 해당하는 경기 전체 조회
 
@@ -276,7 +276,7 @@ operation::auth-controller-test/로그인을_한다[snippets='http-request,reque
 
 === 멤버 정보 조회
 
-operation::member-query-controller-test/멤버의_정보를_조회한다[snippets='http-request,http-response,response-fields']
+operation::member-query-controller-test/멤버의_정보를_조회한다[snippets='http-request,request-cookies,http-response,response-fields']
 
 == 조직 API
 
@@ -288,7 +288,7 @@ operation::organization-query-controller-test/학교_목록을_조회한다[snip
 
 === 선수 생성
 
-operation::player-controller-test/선수를_생성한다[snippets='http-request,request-fields,http-response']
+operation::player-controller-test/선수를_생성한다[snippets='http-request,request-cookies,request-fields,http-response']
 
 === 선수 수정
 
@@ -314,7 +314,7 @@ operation::team-controller-test/팀을_생성한다[snippets='http-request,reque
 
 === 팀 삭제
 
-operation::team-controller-test/팀을_삭제한다[snippets='http-request,request-cookies,path-parameters,request-fields,http-response']
+operation::team-controller-test/팀을_삭제한다[snippets='http-request,request-cookies,path-parameters,http-response']
 
 === 팀 수정
 

--- a/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
+++ b/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
@@ -221,6 +221,9 @@ public class GameControllerTest extends DocumentationTest {
                         pathParameters(
                                 parameterWithName("leagueId").description("리그의 ID"),
                                 parameterWithName("gameId").description("게임의 ID")
+                        ),
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
                         )
                 ));
     }

--- a/src/test/java/com/sports/server/command/league/presentation/LeagueControllerTest.java
+++ b/src/test/java/com/sports/server/command/league/presentation/LeagueControllerTest.java
@@ -103,6 +103,9 @@ class LeagueControllerTest extends DocumentationTest {
 		// then
 		result.andExpect(status().isOk())
 			.andDo(restDocsHandler.document(
+				pathParameters(
+					parameterWithName("leagueId").description("수정할 리그의 ID")
+				),
 				requestFields(
 					fieldWithPath("name").type(JsonFieldType.STRING).description("변경할 대회의 이름"),
 					fieldWithPath("startAt").type(JsonFieldType.STRING).description("변경할 대회 시작시간"),

--- a/src/test/java/com/sports/server/command/nl/presentation/NlControllerTest.java
+++ b/src/test/java/com/sports/server/command/nl/presentation/NlControllerTest.java
@@ -176,6 +176,9 @@ public class NlControllerTest extends DocumentationTest {
         // then
         result.andExpect(status().isOk())
                 .andDo(restDocsHandler.document(
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        ),
                         requestFields(
                                 fieldWithPath("team.name").type(JsonFieldType.STRING).description("팀 이름"),
                                 fieldWithPath("team.logoImageUrl").type(JsonFieldType.STRING).description("팀 로고 이미지 URL"),

--- a/src/test/java/com/sports/server/query/presentation/MemberQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/MemberQueryControllerTest.java
@@ -2,6 +2,8 @@ package com.sports.server.query.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -32,6 +34,9 @@ public class MemberQueryControllerTest extends DocumentationTest {
         // then
         result.andExpect(status().isOk())
                 .andDo(restDocsHandler.document(
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        ),
                         responseFields(
                                 fieldWithPath("email").type(JsonFieldType.STRING).description("멤버의 이메일"),
                                 fieldWithPath("nameOfOrganization").type(JsonFieldType.STRING).description("멤버가 속한 단체명")


### PR DESCRIPTION
## 이슈
api.adoc이 요구하는 REST Docs snippet과 컨트롤러 테스트가 실제 생성하는 snippet이 곳곳에서 어긋나 있어, 빌드 중 `Snippet not found` 경고가 떴고 일부 인증 정보가 문서에서 누락되어 있었음.

## 변경 내용

### `api.adoc` 정정 (11건)
- 응원톡 계정별 가려지지 않은/가려진 조회: 존재하지 않는 `path-parameters` 제거
- 게임 영상 조회: `게임_영상_id를_조회한다` → `게임_영상_ID를_조회한다` (대소문자 일치)
- 응원 횟수 업데이트: `path-parameters` 추가 (gameId)
- 신고된 응원톡 무효처리: `request-cookies` 추가 (인증 필요 엔드포인트)
- 리그 수정: `path-parameters` 추가 (leagueId)
- 매니저 리그 조회 (홈/관리), 멤버 정보, 선수 생성: `request-cookies` 추가
- 팀 삭제: 존재하지 않는 `request-fields` 제거 (DELETE에 body 없음)

### 테스트 보강 (4건)
- `GameControllerTest.게임을_삭제한다`: `requestCookies` document 추가
- `LeagueControllerTest.리그를_수정한다`: `pathParameters(leagueId)` document 추가
- `MemberQueryControllerTest.멤버의_정보를_조회한다`: `requestCookies` document 추가
- `NlControllerTest.팀_생성과_선수_등록을_한번에_처리한다`: `requestCookies` document 추가

## 테스트
- `./gradlew test --tests "...{Game,League,MemberQuery,GameQuery,CheerTalkQuery,LeagueQuery,Team,Player,Report,Nl}ControllerTest"` 모두 통과
- `./gradlew asciidoctor` 통과 (`Snippet not found` 경고 0건)

## 후속 (이번 PR 범위 밖)
- 미문서화 엔드포인트 4건: presigned-url, delete-logo, game-team DELETE, statistics update
- SecurityConfig permitAll 보안 구멍 5건 — 별도 PR로 분리 예정