### PR TITLE
docs: 미문서화 엔드포인트 4건 REST Docs 추가

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -70,6 +70,14 @@ operation::game-controller-test/게임을_수정한다[snippets='http-request,pa
 
 operation::game-controller-test/게임을_삭제한다[snippets='http-request,path-parameters,request-cookies']
 
+=== 게임팀 삭제
+
+operation::game-controller-test/게임팀을_삭제한다[snippets='http-request,path-parameters,request-cookies']
+
+=== [관리자] 종료된 게임의 리그 통계 갱신
+
+operation::game-controller-test/종료된_게임들의_리그_통계를_업데이트한다[snippets='http-request,request-fields,http-response']
+
 === 게임 상세 조회
 
 operation::game-query-controller-test/게임을_상세_조회한다[snippets='http-request,path-parameters,http-response,response-fields']
@@ -320,6 +328,10 @@ operation::team-controller-test/팀을_삭제한다[snippets='http-request,reque
 
 operation::team-controller-test/팀_정보를_선수목록과_함께_수정한다[snippets='http-request,request-cookies,path-parameters,request-fields,http-response']
 
+=== 팀 로고 이미지 삭제
+
+operation::team-controller-test/팀의_로고_이미지를_삭제한다[snippets='http-request,request-cookies,path-parameters,http-response']
+
 === 팀 선수 추가
 
 operation::team-controller-test/팀에_선수들을_추가한다[snippets='http-request,request-cookies,path-parameters,request-fields,http-response']
@@ -381,3 +393,9 @@ operation::nl-controller-test/학번_중복_여부를_확인한다[snippets='htt
 === 선수 등록 실행
 
 operation::nl-controller-test/선수를_등록한다[snippets='http-request,request-cookies,request-fields,http-response,response-fields']
+
+== 이미지 업로드 API
+
+=== 사전 서명 URL 발급
+
+operation::s3-controller-test/이미지_업로드용_사전_서명_url을_발급한다[snippets='http-request,query-parameters,request-cookies,http-response']

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -76,7 +76,7 @@ operation::game-controller-test/게임팀을_삭제한다[snippets='http-request
 
 === [관리자] 종료된 게임의 리그 통계 갱신
 
-operation::game-controller-test/종료된_게임들의_리그_통계를_업데이트한다[snippets='http-request,request-fields,http-response']
+operation::game-controller-test/종료된_게임들의_리그_통계를_업데이트한다[snippets='http-request,request-fields,request-cookies,http-response']
 
 === 게임 상세 조회
 

--- a/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
+++ b/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
@@ -258,13 +258,17 @@ public class GameControllerTest extends DocumentationTest {
         // when
         ResultActions result = mockMvc.perform(post("/admin/games/statistics/update")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(gameIds)));
+                .content(objectMapper.writeValueAsString(gameIds))
+                .cookie(new Cookie(COOKIE_NAME, "temp-cookie")));
 
         // then
         result.andExpect(status().isOk())
                 .andDo(restDocsHandler.document(
                         requestFields(
                                 fieldWithPath("[]").type(JsonFieldType.ARRAY).description("리그 통계를 갱신할 게임 ID 목록")
+                        ),
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
                         )
                 ));
     }

--- a/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
+++ b/src/test/java/com/sports/server/command/game/presentation/GameControllerTest.java
@@ -229,6 +229,47 @@ public class GameControllerTest extends DocumentationTest {
     }
 
     @Test
+    void 게임팀을_삭제한다() throws Exception {
+        // given
+        Long gameTeamId = 1L;
+
+        // when
+        ResultActions result = mockMvc.perform(delete("/game-teams/{gameTeamId}", gameTeamId)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(new Cookie(COOKIE_NAME, "temp-cookie")));
+
+        // then
+        result.andExpect(status().isNoContent())
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("gameTeamId").description("삭제할 게임팀의 ID")
+                        ),
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        )
+                ));
+    }
+
+    @Test
+    void 종료된_게임들의_리그_통계를_업데이트한다() throws Exception {
+        // given
+        List<Long> gameIds = List.of(1L, 2L, 3L);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/admin/games/statistics/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(gameIds)));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocsHandler.document(
+                        requestFields(
+                                fieldWithPath("[]").type(JsonFieldType.ARRAY).description("리그 통계를 갱신할 게임 ID 목록")
+                        )
+                ));
+    }
+
+    @Test
     void 게임팀_라인업에_선수를_추가한다() throws Exception {
         // given
         Long gameTeamId = 1L;

--- a/src/test/java/com/sports/server/command/team/presentation/TeamControllerTest.java
+++ b/src/test/java/com/sports/server/command/team/presentation/TeamControllerTest.java
@@ -178,6 +178,30 @@ public class TeamControllerTest extends DocumentationTest {
     }
 
     @Test
+    void 팀의_로고_이미지를_삭제한다() throws Exception {
+        // given
+        Long teamId = 1L;
+
+        doNothing().when(teamService).deleteLogoImage(any(), anyLong());
+
+        // when
+        ResultActions result = mockMvc.perform(post("/teams/{teamId}/delete-logo", teamId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .cookie(new Cookie(COOKIE_NAME, "temp-cookie")));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("teamId").description("로고 이미지를 삭제할 팀의 ID")
+                        ),
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        )
+                ));
+    }
+
+    @Test
     void 팀에서_선수를_제거한다() throws Exception {
         // given
         Long teamPlayerId = 1L;

--- a/src/test/java/com/sports/server/common/presentation/S3ControllerTest.java
+++ b/src/test/java/com/sports/server/common/presentation/S3ControllerTest.java
@@ -1,0 +1,42 @@
+package com.sports.server.common.presentation;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sports.server.support.DocumentationTest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class S3ControllerTest extends DocumentationTest {
+
+    @Test
+    void 이미지_업로드용_사전_서명_URL을_발급한다() throws Exception {
+        // given
+        String extension = "jpg";
+        String presignedUrl = "https://bucket.s3.ap-northeast-2.amazonaws.com/uuid.jpg?X-Amz-Algorithm=...";
+        when(s3Service.generatePresignedUrl(anyString())).thenReturn(presignedUrl);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/manager/aws/generate-presigned-url")
+                .param("extension", extension)
+                .cookie(new Cookie(COOKIE_NAME, "temp-cookie")));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocsHandler.document(
+                        queryParameters(
+                                parameterWithName("extension").description("업로드할 파일의 확장자 (예: jpg, png)")
+                        ),
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/sports/server/support/DocumentationTest.java
+++ b/src/test/java/com/sports/server/support/DocumentationTest.java
@@ -27,7 +27,9 @@ import com.sports.server.command.team.application.TeamService;
 import com.sports.server.command.team.presentation.TeamController;
 import com.sports.server.command.timeline.application.TimelineService;
 import com.sports.server.command.timeline.presentation.TimelineController;
+import com.sports.server.common.application.S3Service;
 import com.sports.server.common.log.TimeLogTemplate;
+import com.sports.server.common.presentation.S3Controller;
 import com.sports.server.query.application.*;
 import com.sports.server.query.presentation.*;
 
@@ -68,6 +70,7 @@ import org.springframework.test.web.servlet.MockMvc;
                 PlayerQueryController.class,
                 NlController.class,
                 OrganizationQueryController.class,
+                S3Controller.class,
         })
 @Import({
         TimeLogTemplate.class,
@@ -169,6 +172,9 @@ public class DocumentationTest {
 
     @MockBean
     protected OrganizationQueryService organizationQueryService;
+
+    @MockBean
+    protected S3Service s3Service;
 
     @MockBean
     protected com.sports.server.common.application.AlertService alertService;


### PR DESCRIPTION
## 이슈
PR #645 분리 합의에 따른 후속 작업. 미문서화 엔드포인트 4건의 테스트 및 api.adoc 추가.

## 변경 내용
- `S3ControllerTest` 신규 — `GET /manager/aws/generate-presigned-url`
- `TeamControllerTest` — `POST /teams/{teamId}/delete-logo` 테스트 추가
- `GameControllerTest` — `DELETE /game-teams/{gameTeamId}`, `POST /admin/games/statistics/update` 테스트 추가
- `DocumentationTest` — `S3Controller`, `S3Service` MockBean 등록
- `api.adoc` — 4건 operation:: 추가 (게임 API / 팀 API / 이미지 업로드 API 신규 섹션)

## 테스트
- ./gradlew clean test BUILD SUCCESSFUL
- scripts/check-api-docs.sh 91/91 통과 (87 → 91)

## 영향 API
없음. 테스트와 adoc만 추가, 컨트롤러/서비스 동작 변경 없음.

## 프론트 참고
없음.