### PR TITLE
fix: SecurityConfig permitAll 보안 구멍 9건 봉쇄

### DIFF
--- a/src/main/java/com/sports/server/auth/config/SecurityConfig.java
+++ b/src/main/java/com/sports/server/auth/config/SecurityConfig.java
@@ -66,6 +66,10 @@ public class SecurityConfig {
                                 mvc.pattern(HttpMethod.DELETE, "/game-teams/{gameTeamId}"),
                                 mvc.pattern(HttpMethod.POST, "/game-teams/{gameTeamId}/lineup-players"),
                                 mvc.pattern(HttpMethod.DELETE, "/game-teams/{gameTeamId}/lineup-players/{lineupPlayerId}"),
+                                mvc.pattern(HttpMethod.PATCH, "/games/{gameId}/lineup-players/{lineupPlayerId}/starter"),
+                                mvc.pattern(HttpMethod.PATCH, "/games/{gameId}/lineup-players/{lineupPlayerId}/candidate"),
+                                mvc.pattern(HttpMethod.PUT, "/games/{gameId}/lineup-players/{lineupPlayerId}/captain/register"),
+                                mvc.pattern(HttpMethod.PATCH, "/games/{gameId}/lineup-players/{lineupPlayerId}/captain/revoke"),
                                 mvc.pattern(HttpMethod.POST, "/admin/**"),
                                 mvc.pattern(HttpMethod.PATCH, "/reports/{leagueId}/{cheerTalkId}/cancel")
                         )

--- a/src/main/java/com/sports/server/auth/config/SecurityConfig.java
+++ b/src/main/java/com/sports/server/auth/config/SecurityConfig.java
@@ -62,7 +62,12 @@ public class SecurityConfig {
                                 mvc.pattern(HttpMethod.PATCH, "/players/{playerId}"),
                                 mvc.pattern(HttpMethod.DELETE, "/players/{playerId}"),
                                 mvc.pattern(HttpMethod.PATCH, "/cheer-talks/**"),
-                                mvc.pattern(HttpMethod.POST, "/nl/**")
+                                mvc.pattern(HttpMethod.POST, "/nl/**"),
+                                mvc.pattern(HttpMethod.DELETE, "/game-teams/{gameTeamId}"),
+                                mvc.pattern(HttpMethod.POST, "/game-teams/{gameTeamId}/lineup-players"),
+                                mvc.pattern(HttpMethod.DELETE, "/game-teams/{gameTeamId}/lineup-players/{lineupPlayerId}"),
+                                mvc.pattern(HttpMethod.POST, "/admin/**"),
+                                mvc.pattern(HttpMethod.PATCH, "/reports/{leagueId}/{cheerTalkId}/cancel")
                         )
                         .authenticated()
                         .anyRequest().permitAll()

--- a/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
@@ -63,9 +63,11 @@ public class GameAcceptanceTest extends AcceptanceTest {
         Long gameId = 1L;
         Long gameTeamId = 1L;
         Long lineupPlayerId = 1L;
+        configureMockJwtForEmail(MOCK_EMAIL);
 
         // when
         RestAssured.given().log().all()
+                .cookie(COOKIE_NAME, mockToken)
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .patch("/games/{gameId}/lineup-players/{lineupPlayerId}/starter", gameId, lineupPlayerId)
@@ -102,9 +104,11 @@ public class GameAcceptanceTest extends AcceptanceTest {
         Long gameId = 1L;
         Long gameTeamId = 1L;
         Long lineupPlayerId = 2L;
+        configureMockJwtForEmail(MOCK_EMAIL);
 
         // when
         RestAssured.given().log().all()
+                .cookie(COOKIE_NAME, mockToken)
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .patch("/games/{gameId}/lineup-players/{lineupPlayerId}/candidate", gameId, lineupPlayerId)
@@ -292,9 +296,11 @@ public class GameAcceptanceTest extends AcceptanceTest {
         Long gameId = 1L;
         Long gameTeamId = 1L;
         Long lineupPlayerId = 2L;
+        configureMockJwtForEmail(MOCK_EMAIL);
 
         // when
         RestAssured.given().log().all()
+                .cookie(COOKIE_NAME, mockToken)
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .put("/games/{gameId}/lineup-players/{lineupPlayerId}/captain/register", gameId,
@@ -332,9 +338,11 @@ public class GameAcceptanceTest extends AcceptanceTest {
         Long gameId = 1L;
         Long gameTeamId = 2L;
         Long lineupPlayerId = 6L;
+        configureMockJwtForEmail(MOCK_EMAIL);
 
         // when
         RestAssured.given().log().all()
+                .cookie(COOKIE_NAME, mockToken)
                 .when()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .patch("/games/{gameId}/lineup-players/{lineupPlayerId}/captain/revoke", gameId,

--- a/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/game/acceptance/GameAcceptanceTest.java
@@ -142,7 +142,10 @@ public class GameAcceptanceTest extends AcceptanceTest {
                 5L, LineupPlayerState.CANDIDATE, false
         );
 
+        configureMockJwtForEmail(MOCK_EMAIL);
+
         ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .cookie(COOKIE_NAME, mockToken)
                 .pathParam("gameTeamId", gameTeamId)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
@@ -158,7 +161,10 @@ public class GameAcceptanceTest extends AcceptanceTest {
         Long gameTeamId = 1L;
         Long lineupPlayerId = 2L;
 
+        configureMockJwtForEmail(MOCK_EMAIL);
+
         ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .cookie(COOKIE_NAME, mockToken)
                 .pathParam("gameTeamId", gameTeamId)
                 .pathParam("lineupPlayerId", lineupPlayerId)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
## 이슈

리뷰 중 발견된 SecurityConfig permitAll 보안 구멍 봉쇄. Gemini 1차 리뷰에서 추가 4건 더 발견되어 총 9건.

기존 매처에 누락되어 인증 없이 접근 가능했던 매니저/관리자 전용 엔드포인트:

**1차 5건 (게임팀/관리자/신고)**
- `DELETE /game-teams/{gameTeamId}` — 게임팀 삭제
- `POST /game-teams/{gameTeamId}/lineup-players` — 라인업 선수 추가
- `DELETE /game-teams/{gameTeamId}/lineup-players/{lineupPlayerId}` — 라인업 선수 삭제
- `POST /admin/**` — 관리자 통계 갱신 등
- `PATCH /reports/{leagueId}/{cheerTalkId}/cancel` — 신고 취소 (`POST /reports`는 공개라 보존)

**2차 4건 (라인업 상태/주장 변경)**
- `PATCH /games/{gameId}/lineup-players/{lineupPlayerId}/starter` — 선발 변경
- `PATCH /games/{gameId}/lineup-players/{lineupPlayerId}/candidate` — 후보 변경
- `PUT /games/{gameId}/lineup-players/{lineupPlayerId}/captain/register` — 주장 등록
- `PATCH /games/{gameId}/lineup-players/{lineupPlayerId}/captain/revoke` — 주장 해제

## 변경 내용

- `SecurityConfig`의 `authorizeHttpRequests`에 위 9개 매처 추가
- 영향받는 acceptance 테스트 6건에 매니저 JWT 쿠키 주입 (`configureMockJwtForEmail(MOCK_EMAIL)` + `.cookie(COOKIE_NAME, mockToken)`)

## 테스트

- 로컬 `./gradlew test` 통과 (`BUILD SUCCESSFUL`)
- `GameAcceptanceTest` 전체 그린 — 정상 매니저 토큰으로 접근 가능

## 영향 API

위 9개 엔드포인트는 이제 매니저/관리자 인증(HCC_SES 쿠키) 필수. 인증 없이 호출하면 401.

## 프론트 참고

- 모두 `apps/manager/`에서만 호출되는 엔드포인트들. fetcher가 `credentials: 'include'`로 HCC_SES 쿠키 자동 첨부 → 영향 없음
- `POST /reports`(일반 신고 작성)는 그대로 공개 — spectator 앱 영향 없음
- 비매니저(spectator) 관점 영향 없음 ✅