### PR TITLE
fix: 라인업 등록·추가 시 단일 주장 불변식 강제

### DIFF
--- a/src/main/java/com/sports/server/command/game/application/GameService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameService.java
@@ -119,6 +119,8 @@ public class GameService {
     }
 
     private void registerGameTeamAndLineup(Game game, GameRequest.TeamLineupRequest teamLineupInfo) {
+        validateSingleCaptain(teamLineupInfo);
+
         Team team = entityUtils.getEntity(teamLineupInfo.teamId(), Team.class);
         GameTeam gameTeam = GameTeam.of(game, team);
         gameTeamRepository.save(gameTeam);
@@ -132,6 +134,15 @@ public class GameService {
         List<TeamPlayer> teamPlayers = teamPlayerRepository.findAllByTeamPlayerIds(teamPlayerIdsRequest);
         validateTeamPlayers(teamPlayerIdsRequest, teamPlayers, team);
         registerLineup(gameTeam, teamPlayers, teamLineupInfo);
+    }
+
+    private void validateSingleCaptain(GameRequest.TeamLineupRequest teamLineupInfo) {
+        long captainCount = teamLineupInfo.lineupPlayers().stream()
+                .filter(GameRequest.LineupPlayerRequest::isCaptain)
+                .count();
+        if (captainCount > 1) {
+            throw new BadRequestException(GameErrorMessages.MULTIPLE_CAPTAINS_IN_REQUEST);
+        }
     }
 
     private void registerLineup(GameTeam gameTeam, List<TeamPlayer> teamPlayers, GameRequest.TeamLineupRequest teamLineupRequest){

--- a/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
+++ b/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
@@ -54,10 +54,7 @@ public class LineupPlayerService {
         TeamPlayer teamPlayer = teamPlayerRepository.findById(request.teamPlayerId())
                 .orElseThrow(() -> new NotFoundException(PlayerErrorMessages.TEAM_PLAYER_NOT_FOUND_EXCEPTION));
 
-        validatePlayerForLineup(gameTeam, teamPlayer);
-        if (request.isCaptain() && gameTeam.hasCaptain()) {
-            throw new BadRequestException(GameErrorMessages.CAPTAIN_ALREADY_EXISTS_IN_GAME_TEAM);
-        }
+        validateLineupAddition(gameTeam, teamPlayer, request.isCaptain());
 
         LineupPlayer lineupPlayer = LineupPlayer.of(
                 gameTeam,
@@ -81,13 +78,19 @@ public class LineupPlayerService {
         gameTeam.removeLineupPlayer(lineupPlayer);
     }
 
-    private void validatePlayerForLineup(final GameTeam gameTeam, final TeamPlayer teamPlayer) {
+    private void validateLineupAddition(
+            final GameTeam gameTeam,
+            final TeamPlayer teamPlayer,
+            final boolean isCaptain
+    ) {
         if (!teamPlayer.getTeam().getId().equals(gameTeam.getTeam().getId())) {
             throw new BadRequestException(GameErrorMessages.PLAYER_FROM_ANOTHER_TEAM_REGISTER_EXCEPTION);
         }
-
         if (lineupPlayerRepository.existsByGameTeamAndPlayer(gameTeam, teamPlayer.getPlayer())) {
             throw new BadRequestException(GameErrorMessages.ALREADY_REGISTERED_IN_LINEUP);
+        }
+        if (isCaptain && gameTeam.hasCaptain()) {
+            throw new BadRequestException(GameErrorMessages.CAPTAIN_ALREADY_EXISTS_IN_GAME_TEAM);
         }
     }
 }

--- a/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
+++ b/src/main/java/com/sports/server/command/game/application/LineupPlayerService.java
@@ -55,6 +55,9 @@ public class LineupPlayerService {
                 .orElseThrow(() -> new NotFoundException(PlayerErrorMessages.TEAM_PLAYER_NOT_FOUND_EXCEPTION));
 
         validatePlayerForLineup(gameTeam, teamPlayer);
+        if (request.isCaptain() && gameTeam.hasCaptain()) {
+            throw new BadRequestException(GameErrorMessages.CAPTAIN_ALREADY_EXISTS_IN_GAME_TEAM);
+        }
 
         LineupPlayer lineupPlayer = LineupPlayer.of(
                 gameTeam,

--- a/src/main/java/com/sports/server/command/game/domain/GameTeam.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameTeam.java
@@ -103,6 +103,10 @@ public class GameTeam extends BaseEntity<GameTeam> {
         }
     }
 
+    public boolean hasCaptain() {
+        return this.lineupPlayers.stream().anyMatch(LineupPlayer::isCaptain);
+    }
+
     public void removeLineupPlayer(LineupPlayer lineupPlayer) {
         this.lineupPlayers.remove(lineupPlayer);
     }

--- a/src/main/java/com/sports/server/command/game/exception/GameErrorMessages.java
+++ b/src/main/java/com/sports/server/command/game/exception/GameErrorMessages.java
@@ -23,4 +23,6 @@ public class GameErrorMessages {
     public static final String PLAYER_FROM_ANOTHER_TEAM_REGISTER_EXCEPTION = "다른 팀의 선수를 라인업에 등록할 수 없습니다.";
     public static final String LINEUP_PLAYER_NOT_IN_GAME_TEAM_EXCEPTION = "해당 라인업 선수는 요청한 게임팀에 속해있지 않습니다.";
     public static final String ALREADY_REGISTERED_IN_LINEUP = "이미 라인업에 등록된 선수입니다.";
+    public static final String MULTIPLE_CAPTAINS_IN_REQUEST = "팀 라인업에 주장은 한 명만 지정할 수 있습니다.";
+    public static final String CAPTAIN_ALREADY_EXISTS_IN_GAME_TEAM = "이미 주장이 등록된 팀입니다. 기존 주장을 먼저 해제한 뒤 추가하세요.";
 }

--- a/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
@@ -172,6 +172,25 @@ public class GameServiceTest extends ServiceTest {
             assertThatThrownBy(() -> gameService.register(leagueId, requestDto, manager)).isInstanceOf(
                     CustomException.class).hasMessage("최대 라운드보다 더 큰 라운드의 경기를 등록할 수 없습니다.");
         }
+
+        @Test
+        void 한_팀에_주장이_두_명_이상이면_예외가_발생한다() {
+            // given
+            Long leagueId = 1L;
+            Member manager = entityUtils.getEntity(1L, Member.class);
+            List<GameRequest.LineupPlayerRequest> twoCaptainsLineup = List.of(
+                    new GameRequest.LineupPlayerRequest(1L, LineupPlayerState.STARTER, true),
+                    new GameRequest.LineupPlayerRequest(2L, LineupPlayerState.STARTER, true)
+            );
+            GameRequest.TeamLineupRequest invalidTeam1 = new GameRequest.TeamLineupRequest(1L, twoCaptainsLineup);
+            GameRequest.Register invalidRequest = new GameRequest.Register(nameOfGame, 16, "FIRST_HALF", "SCHEDULED",
+                    LocalDateTime.now(), null, invalidTeam1, team2);
+
+            // when & then
+            assertThatThrownBy(() -> gameService.register(leagueId, invalidRequest, manager))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage("팀 라인업에 주장은 한 명만 지정할 수 있습니다.");
+        }
     }
 
     @Nested

--- a/src/test/java/com/sports/server/command/game/application/LineupPlayerServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/LineupPlayerServiceTest.java
@@ -2,11 +2,14 @@ package com.sports.server.command.game.application;
 
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.game.domain.LineupPlayerState;
+import com.sports.server.command.game.dto.GameRequest;
 import com.sports.server.common.application.EntityUtils;
+import com.sports.server.common.exception.CustomException;
 import com.sports.server.support.ServiceTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +67,52 @@ public class LineupPlayerServiceTest extends ServiceTest {
                 () -> assertThat(changedLineupPlayer.isCaptain()).isEqualTo(false),
                 () -> assertThat(changedLineupPlayer.getState()).isEqualTo(LineupPlayerState.CANDIDATE)
         );
+    }
+
+    @Test
+    void 주장이_이미_존재하는_팀에_주장으로_선수를_추가하면_예외가_발생한다() {
+        // given
+        Long gameTeamId = 2L;
+        GameRequest.LineupPlayerRequest request = new GameRequest.LineupPlayerRequest(
+                7L, LineupPlayerState.STARTER, true
+        );
+
+        // when & then
+        assertThatThrownBy(() -> lineupPlayerService.addPlayerToLineup(gameTeamId, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("이미 주장이 등록된 팀입니다. 기존 주장을 먼저 해제한 뒤 추가하세요.");
+    }
+
+    @Test
+    void 주장이_없는_팀에_주장으로_선수를_추가할_수_있다() {
+        // given
+        Long gameTeamId = 1L;
+        GameRequest.LineupPlayerRequest request = new GameRequest.LineupPlayerRequest(
+                1L, LineupPlayerState.STARTER, true
+        );
+
+        // when
+        Long lineupPlayerId = lineupPlayerService.addPlayerToLineup(gameTeamId, request);
+
+        // then
+        LineupPlayer added = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
+        assertThat(added.isCaptain()).isEqualTo(true);
+    }
+
+    @Test
+    void 주장이_이미_존재하는_팀에_주장이_아닌_선수는_추가할_수_있다() {
+        // given
+        Long gameTeamId = 2L;
+        GameRequest.LineupPlayerRequest request = new GameRequest.LineupPlayerRequest(
+                7L, LineupPlayerState.STARTER, false
+        );
+
+        // when
+        Long lineupPlayerId = lineupPlayerService.addPlayerToLineup(gameTeamId, request);
+
+        // then
+        LineupPlayer added = entityUtils.getEntity(lineupPlayerId, LineupPlayer.class);
+        assertThat(added.isCaptain()).isEqualTo(false);
     }
 }
 

--- a/src/test/java/com/sports/server/command/game/application/LineupPlayerServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/LineupPlayerServiceTest.java
@@ -70,7 +70,7 @@ public class LineupPlayerServiceTest extends ServiceTest {
     }
 
     @Test
-    void 주장이_이미_존재하는_팀에_주장으로_선수를_추가하면_예외가_발생한다() {
+    void 이미_주장이_있는_팀에는_주장을_추가할_수_없다() {
         // given
         Long gameTeamId = 2L;
         GameRequest.LineupPlayerRequest request = new GameRequest.LineupPlayerRequest(
@@ -84,7 +84,7 @@ public class LineupPlayerServiceTest extends ServiceTest {
     }
 
     @Test
-    void 주장이_없는_팀에_주장으로_선수를_추가할_수_있다() {
+    void 주장이_없는_팀에_주장을_추가한다() {
         // given
         Long gameTeamId = 1L;
         GameRequest.LineupPlayerRequest request = new GameRequest.LineupPlayerRequest(
@@ -100,7 +100,7 @@ public class LineupPlayerServiceTest extends ServiceTest {
     }
 
     @Test
-    void 주장이_이미_존재하는_팀에_주장이_아닌_선수는_추가할_수_있다() {
+    void 주장이_있는_팀에_일반_선수는_추가할_수_있다() {
         // given
         Long gameTeamId = 2L;
         GameRequest.LineupPlayerRequest request = new GameRequest.LineupPlayerRequest(


### PR DESCRIPTION
## 이슈

5/6 이후 운영 DB에서 한 game_team에 `is_captain=true`인 LineupPlayer가 두 명씩 존재하는 경기 5건 발견.

원인 분석:
- **프론트**: 주장 변경 시 기존 주장에 대한 `captainRevoke` 호출 누락 (FE PR #550 진행 중)
- **백엔드**: PR #621에서 `changePlayerToCaptain`에 auto-revoke가 도입됐지만, **신규 진입점에는 단일 주장 보장이 없음**
  - `GameService.registerGameTeamAndLineup` → `registerLineup`: 요청 payload에 `isCaptain=true`가 둘이어도 그대로 저장
  - `LineupPlayerService.addPlayerToLineup`: 팀에 주장이 이미 있어도 또 다른 주장 추가 가능

## 변경 내용

라인업 진입점 두 곳에 단일 주장 불변식을 추가한다. 정책은 **REJECT (BadRequest)** — auto-revoke는 `changePlayerToCaptain`에 한정.

- `GameErrorMessages`
  - `MULTIPLE_CAPTAINS_IN_REQUEST` 추가
  - `CAPTAIN_ALREADY_EXISTS_IN_GAME_TEAM` 추가
- `GameTeam.hasCaptain()` 도메인 쿼리 추가
- `GameService.registerGameTeamAndLineup`
  - 진입 시점에 `validateSingleCaptain` 호출 → 요청 라인업 내 주장이 둘 이상이면 BadRequest
- `LineupPlayerService.addPlayerToLineup`
  - 신규 등록 요청이 주장이면서 해당 게임팀에 이미 주장이 있으면 BadRequest

## 테스트

`./gradlew test` 전체 통과.

추가 케이스:
- `GameServiceTest#한_팀에_주장이_두_명_이상이면_예외가_발생한다`
- `LineupPlayerServiceTest#주장이_이미_존재하는_팀에_주장으로_선수를_추가하면_예외가_발생한다`
- `LineupPlayerServiceTest#주장이_없는_팀에_주장으로_선수를_추가할_수_있다`
- `LineupPlayerServiceTest#주장이_이미_존재하는_팀에_주장이_아닌_선수는_추가할_수_있다`

## 영향 API

- `POST /leagues/{leagueId}/games` (경기 등록)
  - 한 팀 라인업에 `isCaptain=true`가 2명 이상이면 400 → "팀 라인업에 주장은 한 명만 지정할 수 있습니다."
- `POST /game-teams/{gameTeamId}/lineup-players` (라인업에 선수 추가)
  - 이미 주장이 있는 팀에 `isCaptain=true`로 추가 요청 시 400 → "이미 주장이 등록된 팀입니다. 기존 주장을 먼저 해제한 뒤 추가하세요."

## 프론트 참고

- 라인업 등록 화면에서 주장 다중 선택이 가능했다면 클라이언트 단에서도 한 명만 허용하도록 차단 권장 (백엔드도 400으로 막힘)
- 라인업 추가 시 기존 주장이 있는 팀에 새 주장 지정이 필요하면, 먼저 `captainRevoke`로 기존 주장을 해제한 뒤 추가 요청
- 자동 교체(auto-revoke)는 기존 `PUT .../captain` 진입점에만 동작 — 신규 등록·추가 경로에서는 명시적 해제 필요

## 후속 작업 (별도 PR)

- B: 교체 선수 연결 무결성 (`recordReplacedPlayer` 덮어쓰기 / 자기교체 방어 / 교체 시 주장 정책)
- C: 손상 데이터 정리 (5건의 중복 주장 game_team)