### PR TITLE
release: 커서 페이지네이션 개선 (#654)

### DIFF
--- a/src/main/java/com/sports/server/common/dto/CursorPageResponse.java
+++ b/src/main/java/com/sports/server/common/dto/CursorPageResponse.java
@@ -1,0 +1,26 @@
+package com.sports.server.common.dto;
+
+import java.util.List;
+import java.util.function.Function;
+
+public record CursorPageResponse<T>(
+        List<T> content,
+        Long nextCursor,
+        boolean hasNext
+) {
+    public static <E, T> CursorPageResponse<T> of(List<E> entities, int size,
+                                                   Function<E, T> mapper,
+                                                   Function<E, Long> cursorExtractor) {
+        return ofBulk(entities, size, sliced -> sliced.stream().map(mapper).toList(), cursorExtractor);
+    }
+
+    public static <E, T> CursorPageResponse<T> ofBulk(List<E> entities, int size,
+                                                       Function<List<E>, List<T>> bulkMapper,
+                                                       Function<E, Long> cursorExtractor) {
+        boolean hasNext = entities.size() > size;
+        List<E> sliced = hasNext ? entities.subList(0, size) : entities;
+        List<T> content = bulkMapper.apply(sliced);
+        Long nextCursor = (hasNext && !sliced.isEmpty()) ? cursorExtractor.apply(sliced.get(sliced.size() - 1)) : null;
+        return new CursorPageResponse<>(content, nextCursor, hasNext);
+    }
+}

--- a/src/main/java/com/sports/server/query/application/CheerTalkQueryService.java
+++ b/src/main/java/com/sports/server/query/application/CheerTalkQueryService.java
@@ -1,5 +1,6 @@
 package com.sports.server.query.application;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +15,7 @@ import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.league.domain.League;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.common.application.PermissionValidator;
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.query.dto.GameTeamGameInfoDto;
@@ -33,84 +35,85 @@ public class CheerTalkQueryService {
 	private final GameQueryRepository gameQueryRepository;
 	private final LeagueQueryRepository leagueQueryRepository;
 
-	public List<CheerTalkResponse.ForSpectator> getCheerTalksByGameId(final Long gameId, final PageRequestDto pageRequest) {
+	public CursorPageResponse<CheerTalkResponse.ForSpectator> getCheerTalksByGameId(final Long gameId, final PageRequestDto pageRequest) {
 		Game game = getGame(gameId);
 		List<CheerTalk> cheerTalks = cheerTalkDynamicRepository.findByGameIdOrderByStartTime(
 			gameId, pageRequest.cursor(), pageRequest.size()
 		);
 
-		List<CheerTalkResponse.ForSpectator> responses = cheerTalks.stream()
-			.map(cheerTalk -> new CheerTalkResponse.ForSpectator(cheerTalk, game))
-			.collect(Collectors.toList());
-
-		Collections.reverse(responses);
-		return responses;
+		return CursorPageResponse.ofBulk(cheerTalks, pageRequest.size(), sliced -> {
+			List<CheerTalkResponse.ForSpectator> responses = new ArrayList<>(sliced.stream()
+				.map(cheerTalk -> new CheerTalkResponse.ForSpectator(cheerTalk, game))
+				.toList());
+			Collections.reverse(responses);
+			return responses;
+		}, CheerTalk::getId);
 	}
 
-	public List<CheerTalkResponse.ForManager> getReportedCheerTalksByAdmin(final PageRequestDto pageRequest, final Member admin) {
+	public CursorPageResponse<CheerTalkResponse.ForManager> getReportedCheerTalksByAdmin(final PageRequestDto pageRequest, final Member admin) {
 		List<CheerTalk> cheerTalks = cheerTalkDynamicRepository.findReportedCheerTalksByAdminId(
 				admin.getId(), pageRequest.cursor(), pageRequest.size()
 		);
-		return toForManagerResponses(cheerTalks);
+		return toForManagerPageResponse(cheerTalks, pageRequest.size());
 	}
 
-	public List<CheerTalkResponse.ForManager> getUnblockedCheerTalksByAdmin(final PageRequestDto pageRequest, final Member admin) {
+	public CursorPageResponse<CheerTalkResponse.ForManager> getUnblockedCheerTalksByAdmin(final PageRequestDto pageRequest, final Member admin) {
 		List<CheerTalk> cheerTalks = cheerTalkDynamicRepository.findUnblockedCheerTalksByAdminId(
 				admin.getId(), pageRequest.cursor(), pageRequest.size()
 		);
-		return toForManagerResponses(cheerTalks);
+		return toForManagerPageResponse(cheerTalks, pageRequest.size());
 	}
 
-	public List<CheerTalkResponse.ForManager> getBlockedCheerTalksByAdmin(final PageRequestDto pageRequest, final Member admin) {
+	public CursorPageResponse<CheerTalkResponse.ForManager> getBlockedCheerTalksByAdmin(final PageRequestDto pageRequest, final Member admin) {
 		List<CheerTalk> cheerTalks = cheerTalkDynamicRepository.findBlockedCheerTalksByAdminId(
 				admin.getId(), pageRequest.cursor(), pageRequest.size()
 		);
-		return toForManagerResponses(cheerTalks);
+		return toForManagerPageResponse(cheerTalks, pageRequest.size());
 	}
 
-	public List<CheerTalkResponse.ForManager> getReportedCheerTalksByLeagueId(final Long leagueId, final PageRequestDto pageRequest, final Member member) {
+	public CursorPageResponse<CheerTalkResponse.ForManager> getReportedCheerTalksByLeagueId(final Long leagueId, final PageRequestDto pageRequest, final Member member) {
 		League league = getLeague(leagueId);
 		PermissionValidator.checkPermission(league, member);
 		List<CheerTalk> cheerTalks = cheerTalkDynamicRepository.findReportedCheerTalksByLeagueId(
 				leagueId, pageRequest.cursor(), pageRequest.size()
 		);
-		return toForManagerResponses(cheerTalks);
+		return toForManagerPageResponse(cheerTalks, pageRequest.size());
 	}
 
-	public List<CheerTalkResponse.ForManager> getUnblockedCheerTalksByLeagueId(final Long leagueId, final PageRequestDto pageRequest, final Member member) {
+	public CursorPageResponse<CheerTalkResponse.ForManager> getUnblockedCheerTalksByLeagueId(final Long leagueId, final PageRequestDto pageRequest, final Member member) {
 		League league = getLeague(leagueId);
 		PermissionValidator.checkPermission(league, member);
 		List<CheerTalk> cheerTalks = cheerTalkDynamicRepository.findUnblockedCheerTalksByLeagueId(
 				leagueId, pageRequest.cursor(), pageRequest.size()
 		);
-		return toForManagerResponses(cheerTalks);
+		return toForManagerPageResponse(cheerTalks, pageRequest.size());
 	}
 
-	public List<CheerTalkResponse.ForManager> getBlockedCheerTalksByLeagueId(final Long leagueId, final PageRequestDto pageRequest, final Member member) {
+	public CursorPageResponse<CheerTalkResponse.ForManager> getBlockedCheerTalksByLeagueId(final Long leagueId, final PageRequestDto pageRequest, final Member member) {
 		League league = getLeague(leagueId);
 		PermissionValidator.checkPermission(league, member);
 		List<CheerTalk> cheerTalks = cheerTalkDynamicRepository.findBlockedCheerTalksByLeagueId(
 				leagueId, pageRequest.cursor(), pageRequest.size()
 		);
-		return toForManagerResponses(cheerTalks);
+		return toForManagerPageResponse(cheerTalks, pageRequest.size());
 	}
 
-	public List<CheerTalkResponse.ForManager> getReportedCheerTalksByGameId(final Long gameId, final PageRequestDto pageRequest, final Member member) {
+	public CursorPageResponse<CheerTalkResponse.ForManager> getReportedCheerTalksByGameId(final Long gameId, final PageRequestDto pageRequest, final Member member) {
 		Game game = getGame(gameId);
 		PermissionValidator.checkPermission(game, member);
 		List<CheerTalk> cheerTalks = cheerTalkDynamicRepository.findReportedCheerTalksByGameId(
 				gameId, pageRequest.cursor(), pageRequest.size()
 		);
-		return toForManagerResponses(cheerTalks);
+		return toForManagerPageResponse(cheerTalks, pageRequest.size());
 	}
 
-	public List<CheerTalkResponse.ForManager> getBlockedCheerTalksByGameId(final Long gameId, final PageRequestDto pageRequest, final Member member) {
+	public CursorPageResponse<CheerTalkResponse.ForManager> getBlockedCheerTalksByGameId(final Long gameId, final PageRequestDto pageRequest, final Member member) {
 		Game game = getGame(gameId);
 		PermissionValidator.checkPermission(game, member);
 		List<CheerTalk> cheerTalks = cheerTalkDynamicRepository.findBlockedCheerTalksByGameId(
 				gameId, pageRequest.cursor(), pageRequest.size()
 		);
-		return toForManagerResponses(cheerTalks);
+		return toForManagerPageResponse(cheerTalks, pageRequest.size());
 	}
 
 	private League getLeague(Long leagueId) {
@@ -123,29 +126,31 @@ public class CheerTalkQueryService {
 				.orElseThrow(() -> new NotFoundException("존재하지 않는 경기입니다."));
 	}
 
-	private List<CheerTalkResponse.ForManager> toForManagerResponses(List<CheerTalk> cheerTalks) {
-		if (cheerTalks.isEmpty()) {
-			return Collections.emptyList();
-		}
+	private CursorPageResponse<CheerTalkResponse.ForManager> toForManagerPageResponse(List<CheerTalk> cheerTalks, int size) {
+		return CursorPageResponse.ofBulk(cheerTalks, size, sliced -> {
+			if (sliced.isEmpty()) {
+				return Collections.emptyList();
+			}
 
-		List<Long> gameTeamIds = cheerTalks.stream()
-				.map(CheerTalk::getGameTeamId)
-				.distinct()
-				.toList();
+			List<Long> gameTeamIds = sliced.stream()
+					.map(CheerTalk::getGameTeamId)
+					.distinct()
+					.toList();
 
-		Map<Long, GameTeamGameInfoDto> gameInfoMap = gameQueryRepository.findGameInfoByGameTeamIds(gameTeamIds)
-				.stream()
-				.collect(Collectors.toMap(GameTeamGameInfoDto::gameTeamId, Function.identity()));
+			Map<Long, GameTeamGameInfoDto> gameInfoMap = gameQueryRepository.findGameInfoByGameTeamIds(gameTeamIds)
+					.stream()
+					.collect(Collectors.toMap(GameTeamGameInfoDto::gameTeamId, Function.identity()));
 
-		return cheerTalks.stream()
-				.map(ct -> {
-					GameTeamGameInfoDto info = gameInfoMap.get(ct.getGameTeamId());
-					return new CheerTalkResponse.ForManager(
-							ct.getId(), info.gameId(), info.leagueId(), ct.getContent(),
-							ct.getGameTeamId(), ct.getCreatedAt(), ct.isBlocked(),
-							info.gameName(), info.leagueName()
-					);
-				})
-				.toList();
+			return sliced.stream()
+					.map(ct -> {
+						GameTeamGameInfoDto info = gameInfoMap.get(ct.getGameTeamId());
+						return new CheerTalkResponse.ForManager(
+								ct.getId(), info.gameId(), info.leagueId(), ct.getContent(),
+								ct.getGameTeamId(), ct.getCreatedAt(), ct.isBlocked(),
+								info.gameName(), info.leagueName()
+						);
+					})
+					.toList();
+		}, CheerTalk::getId);
 	}
 }

--- a/src/main/java/com/sports/server/query/application/GameQueryService.java
+++ b/src/main/java/com/sports/server/query/application/GameQueryService.java
@@ -12,6 +12,7 @@ import com.sports.server.query.dto.response.GameResponseDto;
 import com.sports.server.query.dto.response.LeagueWithGamesResponse;
 import com.sports.server.query.dto.response.VideoResponse;
 import com.sports.server.common.application.EntityUtils;
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.query.repository.GameDynamicRepository;
 import com.sports.server.query.repository.GameQueryRepository;
@@ -49,22 +50,27 @@ public class GameQueryService {
         return getGameDetailResponses(games);
     }
 
-    public List<LeagueWithGamesResponse> getAllGames(final GamesQueryRequestDto queryRequestDto,
+    public CursorPageResponse<LeagueWithGamesResponse> getAllGames(final GamesQueryRequestDto queryRequestDto,
                                              final PageRequestDto pageRequest) {
         List<Game> games = gameDynamicRepository.findAllByLeagueAndState(queryRequestDto, pageRequest);
-        if (games.isEmpty()) {
-            return Collections.emptyList();
+
+        boolean hasNext = games.size() > pageRequest.size();
+        List<Game> sliced = hasNext ? games.subList(0, pageRequest.size()) : games;
+        Long nextCursor = hasNext ? sliced.get(sliced.size() - 1).getId() : null;
+
+        if (sliced.isEmpty()) {
+            return new CursorPageResponse<>(Collections.emptyList(), null, false);
         }
 
-        List<Long> gameIds = games.stream().map(Game::getId).toList();
+        List<Long> gameIds = sliced.stream().map(Game::getId).toList();
         List<GameTeam> allGameTeams = gameTeamQueryRepository.findAllByGameIds(gameIds);
         Map<Long, List<GameTeam>> teamsByGameId = allGameTeams.stream()
                 .collect(groupingBy(gameTeam -> gameTeam.getGame().getId()));
 
-        Map<League, List<Game>> gamesByLeague = games.stream()
-                .collect(Collectors.groupingBy(Game::getLeague));
+        Map<League, List<Game>> gamesByLeague = sliced.stream()
+                .collect(Collectors.groupingBy(Game::getLeague, LinkedHashMap::new, Collectors.toList()));
 
-        return gamesByLeague.entrySet().stream()
+        List<LeagueWithGamesResponse> content = gamesByLeague.entrySet().stream()
                 .map(entry -> {
                     League league = entry.getKey();
                     List<GameResponseDto> gameResponses = entry.getValue().stream()
@@ -73,6 +79,8 @@ public class GameQueryService {
                     return new LeagueWithGamesResponse(league.getId(), league.getName(), gameResponses);
                 })
                 .toList();
+
+        return new CursorPageResponse<>(content, nextCursor, hasNext);
     }
 
     public VideoResponse getVideo(Long gameId) {

--- a/src/main/java/com/sports/server/query/application/PlayerQueryService.java
+++ b/src/main/java/com/sports/server/query/application/PlayerQueryService.java
@@ -5,6 +5,7 @@ import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.team.domain.TeamPlayer;
 import com.sports.server.command.team.domain.TeamPlayerRepository;
 import com.sports.server.common.application.EntityUtils;
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.query.dto.response.PlayerResponse;
 import com.sports.server.query.dto.response.TeamResponse;
@@ -31,15 +32,20 @@ public class PlayerQueryService {
     private final TeamPlayerRepository teamPlayerRepository;
     private final PlayerInfoProvider playerInfoProvider;
 
-    public List<PlayerResponse> getAllPlayers(Member member, PageRequestDto pageRequest){
+    public CursorPageResponse<PlayerResponse> getAllPlayers(Member member, PageRequestDto pageRequest){
         List<Player> players = playerDynamicRepository.findAllByOrganizationId(
                 member.getOrganization().getId(), pageRequest.cursor(), pageRequest.size()
         );
-        if (players.isEmpty()) {
-            return Collections.emptyList();
+
+        boolean hasNext = players.size() > pageRequest.size();
+        List<Player> sliced = hasNext ? players.subList(0, pageRequest.size()) : players;
+        Long nextCursor = hasNext ? sliced.get(sliced.size() - 1).getId() : null;
+
+        if (sliced.isEmpty()) {
+            return new CursorPageResponse<>(Collections.emptyList(), null, false);
         }
 
-        List<Long> playerIds = players.stream().map(Player::getId).toList();
+        List<Long> playerIds = sliced.stream().map(Player::getId).toList();
 
         List<TeamPlayer> allTeamPlayers = teamPlayerRepository.findAllByPlayerIds(playerIds);
         Map<Long, List<TeamResponse>> playerTeamsMap = allTeamPlayers.stream()
@@ -52,7 +58,7 @@ public class PlayerQueryService {
                 ));
 
         Map<Long, Integer> playerTotalGoalCountInfo = playerInfoProvider.getPlayersTotalGoalInfo(playerIds);
-        return players.stream()
+        List<PlayerResponse> content = sliced.stream()
                 .map(player -> {
                     Long playerId = player.getId();
                     List<TeamResponse> teams = playerTeamsMap.getOrDefault(playerId, Collections.emptyList());
@@ -60,6 +66,8 @@ public class PlayerQueryService {
                     return PlayerResponse.of(player, null, totalGoals, teams);
                 })
                 .toList();
+
+        return new CursorPageResponse<>(content, nextCursor, hasNext);
     }
 
     public PlayerResponse getPlayerDetail(Long playerId){

--- a/src/main/java/com/sports/server/query/presentation/CheerTalkQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/CheerTalkQueryController.java
@@ -1,10 +1,10 @@
 package com.sports.server.query.presentation;
 
 import com.sports.server.command.member.domain.Member;
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.query.application.CheerTalkQueryService;
 import com.sports.server.query.dto.response.CheerTalkResponse;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,60 +19,60 @@ public class CheerTalkQueryController {
     private final CheerTalkQueryService cheerTalkQueryService;
 
     @GetMapping("/games/{gameId}/cheer-talks")
-    public ResponseEntity<List<CheerTalkResponse.ForSpectator>> getAllCheerTalks(
+    public ResponseEntity<CursorPageResponse<CheerTalkResponse.ForSpectator>> getAllCheerTalks(
             @PathVariable final Long gameId,
             @ModelAttribute final PageRequestDto pageRequest) {
         return ResponseEntity.ok(cheerTalkQueryService.getCheerTalksByGameId(gameId, pageRequest));
     }
 
     @GetMapping("/cheer-talks/reported")
-    public ResponseEntity<List<CheerTalkResponse.ForManager>> getAllReportedCheerTalks(
+    public ResponseEntity<CursorPageResponse<CheerTalkResponse.ForManager>> getAllReportedCheerTalks(
             @ModelAttribute final PageRequestDto pageRequest, Member member) {
         return ResponseEntity.ok(cheerTalkQueryService.getReportedCheerTalksByAdmin(pageRequest, member));
     }
 
     @GetMapping("/cheer-talks")
-    public ResponseEntity<List<CheerTalkResponse.ForManager>> getUnblockedCheerTalksByAdmin(
+    public ResponseEntity<CursorPageResponse<CheerTalkResponse.ForManager>> getUnblockedCheerTalksByAdmin(
             @ModelAttribute final PageRequestDto pageRequest, Member member) {
         return ResponseEntity.ok(cheerTalkQueryService.getUnblockedCheerTalksByAdmin(pageRequest, member));
     }
 
     @GetMapping("/cheer-talks/blocked")
-    public ResponseEntity<List<CheerTalkResponse.ForManager>> getAllBlockedCheerTalksByAdmin(
+    public ResponseEntity<CursorPageResponse<CheerTalkResponse.ForManager>> getAllBlockedCheerTalksByAdmin(
         @ModelAttribute final PageRequestDto pageable, Member member) {
         return ResponseEntity.ok(cheerTalkQueryService.getBlockedCheerTalksByAdmin(pageable, member));
     }
 
     @GetMapping("/leagues/{leagueId}/cheer-talks/reported")
-    public ResponseEntity<List<CheerTalkResponse.ForManager>> getReportedCheerTalksByLeagueId(
+    public ResponseEntity<CursorPageResponse<CheerTalkResponse.ForManager>> getReportedCheerTalksByLeagueId(
             @PathVariable final Long leagueId,
             @ModelAttribute final PageRequestDto pageRequest, Member member) {
         return ResponseEntity.ok(cheerTalkQueryService.getReportedCheerTalksByLeagueId(leagueId, pageRequest, member));
     }
 
     @GetMapping("/leagues/{leagueId}/cheer-talks")
-    public ResponseEntity<List<CheerTalkResponse.ForManager>> getUnblockedCheerTalksByLeagueId(
+    public ResponseEntity<CursorPageResponse<CheerTalkResponse.ForManager>> getUnblockedCheerTalksByLeagueId(
             @PathVariable final Long leagueId,
             @ModelAttribute final PageRequestDto pageRequest, Member member) {
         return ResponseEntity.ok(cheerTalkQueryService.getUnblockedCheerTalksByLeagueId(leagueId, pageRequest, member));
     }
 
     @GetMapping("/leagues/{leagueId}/cheer-talks/blocked")
-    public ResponseEntity<List<CheerTalkResponse.ForManager>> getBlockedCheerTalksByLeagueId(
+    public ResponseEntity<CursorPageResponse<CheerTalkResponse.ForManager>> getBlockedCheerTalksByLeagueId(
             @PathVariable final Long leagueId,
             @ModelAttribute final PageRequestDto pageRequest, Member member) {
         return ResponseEntity.ok(cheerTalkQueryService.getBlockedCheerTalksByLeagueId(leagueId, pageRequest, member));
     }
 
     @GetMapping("/games/{gameId}/cheer-talks/reported")
-    public ResponseEntity<List<CheerTalkResponse.ForManager>> getReportedCheerTalksByGameId(
+    public ResponseEntity<CursorPageResponse<CheerTalkResponse.ForManager>> getReportedCheerTalksByGameId(
             @PathVariable final Long gameId,
             @ModelAttribute final PageRequestDto pageRequest, Member member) {
         return ResponseEntity.ok(cheerTalkQueryService.getReportedCheerTalksByGameId(gameId, pageRequest, member));
     }
 
     @GetMapping("/games/{gameId}/cheer-talks/blocked")
-    public ResponseEntity<List<CheerTalkResponse.ForManager>> getBlockedCheerTalksByGameId(
+    public ResponseEntity<CursorPageResponse<CheerTalkResponse.ForManager>> getBlockedCheerTalksByGameId(
             @PathVariable final Long gameId,
             @ModelAttribute final PageRequestDto pageRequest, Member member) {
         return ResponseEntity.ok(cheerTalkQueryService.getBlockedCheerTalksByGameId(gameId, pageRequest, member));

--- a/src/main/java/com/sports/server/query/presentation/GameQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/GameQueryController.java
@@ -1,5 +1,6 @@
 package com.sports.server.query.presentation;
 
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.query.application.GameQueryService;
 import com.sports.server.query.application.GameTeamQueryService;
@@ -37,7 +38,7 @@ public class GameQueryController {
     }
 
     @GetMapping
-    public ResponseEntity<List<LeagueWithGamesResponse>> getAllGames(
+    public ResponseEntity<CursorPageResponse<LeagueWithGamesResponse>> getAllGames(
             @ModelAttribute GamesQueryRequestDto queryRequestDto,
             @ModelAttribute PageRequestDto pageRequest) {
         return ResponseEntity.ok(gameQueryService.getAllGames(queryRequestDto, pageRequest));

--- a/src/main/java/com/sports/server/query/presentation/PlayerQueryController.java
+++ b/src/main/java/com/sports/server/query/presentation/PlayerQueryController.java
@@ -1,14 +1,13 @@
 package com.sports.server.query.presentation;
 
 import com.sports.server.command.member.domain.Member;
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.query.application.PlayerQueryService;
 import com.sports.server.query.dto.response.PlayerResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,7 +17,7 @@ public class PlayerQueryController {
     private final PlayerQueryService playerQueryService;
 
     @GetMapping
-    public ResponseEntity<List<PlayerResponse>> getAllPlayers(
+    public ResponseEntity<CursorPageResponse<PlayerResponse>> getAllPlayers(
             @ModelAttribute PageRequestDto pageRequest, Member member){
         return ResponseEntity.ok(playerQueryService.getAllPlayers(member, pageRequest));
     }

--- a/src/main/java/com/sports/server/query/repository/CheerTalkDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/CheerTalkDynamicRepositoryImpl.java
@@ -150,7 +150,7 @@ public class CheerTalkDynamicRepositoryImpl implements CheerTalkDynamicRepositor
         return query
                 .where(getPaginationConditions(cursor))
                 .orderBy(cheerTalk.createdAt.desc(), cheerTalk.id.desc())
-                .limit(size)
+                .limit(size + 1)
                 .fetch();
     }
 

--- a/src/main/java/com/sports/server/query/repository/GameDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/GameDynamicRepositoryImpl.java
@@ -26,7 +26,7 @@ public class GameDynamicRepositoryImpl implements GameDynamicRepository {
                 .join(game.league, league).fetchJoin()
                 .where(conditionMapper.mapBooleanCondition(gameQueryRequestDto, pageRequestDto))
                 .orderBy(game.startTime.asc(), game.id.asc())
-                .limit(pageRequestDto.size())
+                .limit(pageRequestDto.size() + 1)
                 .fetch();
     }
 

--- a/src/main/java/com/sports/server/query/repository/PlayerDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/PlayerDynamicRepositoryImpl.java
@@ -23,7 +23,7 @@ public class PlayerDynamicRepositoryImpl implements PlayerDynamicRepository {
                         getCursorCondition(cursor)
                 )
                 .orderBy(player.id.desc())
-                .limit(size)
+                .limit(size + 1)
                 .fetch();
     }
 

--- a/src/test/java/com/sports/server/command/cheertalk/acceptance/CheerTalkAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/acceptance/CheerTalkAcceptanceTest.java
@@ -66,7 +66,7 @@ public class CheerTalkAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .extract();
 
-        List<CheerTalkResponse.ForManager> blockedCheerTalks = toResponses(getResponse, CheerTalkResponse.ForManager.class);
+        List<CheerTalkResponse.ForManager> blockedCheerTalks = toCursorPageContent(getResponse, CheerTalkResponse.ForManager.class);
 
         // then
         assertAll(
@@ -105,7 +105,7 @@ public class CheerTalkAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .extract();
 
-        List<CheerTalkResponse.ForManager> unblockedCheerTalks = toResponses(getResponse, CheerTalkResponse.ForManager.class);
+        List<CheerTalkResponse.ForManager> unblockedCheerTalks = toCursorPageContent(getResponse, CheerTalkResponse.ForManager.class);
 
         assertAll(
                 () -> assertThat(patchResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),

--- a/src/test/java/com/sports/server/command/report/acceptance/ReportAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/report/acceptance/ReportAcceptanceTest.java
@@ -129,7 +129,7 @@ class ReportAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .extract();
 
-        List<CheerTalkResponse.ForManager> reportedList = toResponses(getResponse, CheerTalkResponse.ForManager.class).stream()
+        List<CheerTalkResponse.ForManager> reportedList = toCursorPageContent(getResponse, CheerTalkResponse.ForManager.class).stream()
                 .filter(reported -> reported.cheerTalkId().equals(cheerTalkId))
                 .toList();;
         assertAll(

--- a/src/test/java/com/sports/server/query/acceptance/CheerTalkQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/CheerTalkQueryAcceptanceTest.java
@@ -39,7 +39,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                     .extract();
 
             // then
-            List<CheerTalkResponse.ForSpectator> actual = toResponses(response, CheerTalkResponse.ForSpectator.class);
+            List<CheerTalkResponse.ForSpectator> actual = toCursorPageContent(response, CheerTalkResponse.ForSpectator.class);
             assertAll(
                     () -> assertThat(actual).hasSize(10),
                     () -> assertThat(actual.get(0))
@@ -74,7 +74,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                     .extract();
 
             // then
-            List<CheerTalkResponse.ForSpectator> actual = toResponses(response, CheerTalkResponse.ForSpectator.class);
+            List<CheerTalkResponse.ForSpectator> actual = toCursorPageContent(response, CheerTalkResponse.ForSpectator.class);
             assertAll(
                     () -> assertThat(actual).hasSize(10),
 
@@ -100,7 +100,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                     .extract();
 
             // then
-            List<CheerTalkResponse.ForSpectator> actual = toResponses(response, CheerTalkResponse.ForSpectator.class);
+            List<CheerTalkResponse.ForSpectator> actual = toCursorPageContent(response, CheerTalkResponse.ForSpectator.class);
             assertAll(
                     () -> assertThat(actual).hasSize(size),
 
@@ -128,7 +128,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                     .extract();
 
             // then
-            List<CheerTalkResponse.ForSpectator> actual = toResponses(response, CheerTalkResponse.ForSpectator.class);
+            List<CheerTalkResponse.ForSpectator> actual = toCursorPageContent(response, CheerTalkResponse.ForSpectator.class);
             assertAll(
                     () -> assertThat(actual).hasSize(size),
 
@@ -152,7 +152,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                     .extract();
 
             // then
-            List<CheerTalkResponse.ForSpectator> actual = toResponses(response, CheerTalkResponse.ForSpectator.class);
+            List<CheerTalkResponse.ForSpectator> actual = toCursorPageContent(response, CheerTalkResponse.ForSpectator.class);
             assertThat(actual)
                     .filteredOn(CheerTalkResponse.ForSpectator::isBlocked)
                     .map(CheerTalkResponse.ForSpectator::content)
@@ -175,7 +175,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
-        List<CheerTalkResponse.ForManager> actual = toResponses(response, ForManager.class);
+        List<CheerTalkResponse.ForManager> actual = toCursorPageContent(response, ForManager.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(actual)
@@ -202,7 +202,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
-        List<CheerTalkResponse.ForManager> actual = toResponses(response, ForManager.class);
+        List<CheerTalkResponse.ForManager> actual = toCursorPageContent(response, ForManager.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(actual)
@@ -233,7 +233,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
             .extract();
 
         // then
-        List<CheerTalkResponse.ForManager> actual = toResponses(response, CheerTalkResponse.ForManager.class);
+        List<CheerTalkResponse.ForManager> actual = toCursorPageContent(response, CheerTalkResponse.ForManager.class);
         assertAll(
             () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
             () -> assertThat(actual).map(CheerTalkResponse.ForManager::cheerTalkId)
@@ -257,7 +257,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
-        List<CheerTalkResponse.ForManager> actual = toResponses(response, ForManager.class);
+        List<CheerTalkResponse.ForManager> actual = toCursorPageContent(response, ForManager.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(actual)
@@ -281,7 +281,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
-        List<CheerTalkResponse.ForManager> actual = toResponses(response, ForManager.class);
+        List<CheerTalkResponse.ForManager> actual = toCursorPageContent(response, ForManager.class);
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(actual)
@@ -310,7 +310,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                     .extract();
 
             // then
-            List<CheerTalkResponse.ForManager> actual = toResponses(response, ForManager.class);
+            List<CheerTalkResponse.ForManager> actual = toCursorPageContent(response, ForManager.class);
             assertAll(
                     () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                     () -> assertThat(actual)
@@ -338,7 +338,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                     .extract();
 
             // then
-            List<CheerTalkResponse.ForManager> actual = toResponses(response, ForManager.class);
+            List<CheerTalkResponse.ForManager> actual = toCursorPageContent(response, ForManager.class);
             assertAll(
                     () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                     () -> assertThat(actual)
@@ -374,7 +374,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                     .extract();
 
             // then
-            List<CheerTalkResponse.ForManager> actual = toResponses(response, ForManager.class);
+            List<CheerTalkResponse.ForManager> actual = toCursorPageContent(response, ForManager.class);
             assertAll(
                     () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                     () -> assertThat(actual)
@@ -402,7 +402,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                     .extract();
 
             // then
-            List<CheerTalkResponse.ForManager> actual = toResponses(response, ForManager.class);
+            List<CheerTalkResponse.ForManager> actual = toCursorPageContent(response, ForManager.class);
             assertAll(
                     () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                     () -> assertThat(actual)
@@ -430,7 +430,7 @@ class CheerTalkQueryAcceptanceTest extends AcceptanceTest {
                     .extract();
 
             // then
-            List<CheerTalkResponse.ForManager> actual = toResponses(response, ForManager.class);
+            List<CheerTalkResponse.ForManager> actual = toCursorPageContent(response, ForManager.class);
             assertAll(
                     () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                     () -> assertThat(actual)

--- a/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
@@ -83,7 +83,7 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         //then
-        List<LeagueWithGamesResponse> gamesWithLeague = toResponses(response, LeagueWithGamesResponse.class);
+        List<LeagueWithGamesResponse> gamesWithLeague = toCursorPageContent(response, LeagueWithGamesResponse.class);
         LeagueWithGamesResponse gameWithLeague = gamesWithLeague.get(0);
         List<GameResponseDto> games = gameWithLeague.games();
 

--- a/src/test/java/com/sports/server/query/acceptance/PlayerQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/PlayerQueryAcceptanceTest.java
@@ -62,7 +62,7 @@ public class PlayerQueryAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
-        List<PlayerResponse> actual = toResponses(response, PlayerResponse.class);
+        List<PlayerResponse> actual = toCursorPageContent(response, PlayerResponse.class);
         List<PlayerResponse> expected = List.of(new PlayerResponse(player2, null), new PlayerResponse(player1, null));
 
         assertAll(

--- a/src/test/java/com/sports/server/query/application/CheerTalkQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/CheerTalkQueryServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.common.application.EntityUtils;
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.query.dto.response.CheerTalkResponse;
 import com.sports.server.support.ServiceTest;
@@ -54,7 +55,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
 
             // when
             List<CheerTalkResponse.ForManager> results = cheerTalkQueryService.getReportedCheerTalksByAdmin(
-                    pageRequestDto, admin1);
+                    pageRequestDto, admin1).content();
 
             // then
             assertAll(
@@ -69,7 +70,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
         void 관리자2의_신고된_응원톡만_조회된다() {
             // when
             List<CheerTalkResponse.ForManager> responses = cheerTalkQueryService.getReportedCheerTalksByAdmin(
-                    pageRequestDto, admin2);
+                    pageRequestDto, admin2).content();
 
             // then
             // 관리자2는 신고된 응원톡이 없으므로 빈 리스트가 반환되어야 함
@@ -80,7 +81,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
         void 다른_관리자의_신고된_응원톡은_조회되지_않는다() {
             // when
             List<CheerTalkResponse.ForManager> responses = cheerTalkQueryService.getReportedCheerTalksByAdmin(
-                    pageRequestDto, admin1);
+                    pageRequestDto, admin1).content();
 
             // then
             // 관리자1의 신고된 응원톡만 조회되어야 하고, 관리자2의 신고된 응원톡은 조회되지 않아야 함
@@ -101,7 +102,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
 
 			// when
 			List<CheerTalkResponse.ForManager> responses = cheerTalkQueryService.getBlockedCheerTalksByAdmin(
-				pageRequestDto, admin1);
+				pageRequestDto, admin1).content();
 
 			// then
 			assertAll(
@@ -122,7 +123,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
 
 			// when
 			List<CheerTalkResponse.ForManager> responses = cheerTalkQueryService.getBlockedCheerTalksByAdmin(
-				pageRequestDto, admin2);
+				pageRequestDto, admin2).content();
 
 			// then
 			assertAll(
@@ -142,7 +143,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
 		void 다른_관리자의_응원톡은_조회되지_않는다() {
 			// when
 			List<CheerTalkResponse.ForManager> responses = cheerTalkQueryService.getBlockedCheerTalksByAdmin(
-				pageRequestDto, admin1);
+				pageRequestDto, admin1).content();
 
 			// then
 			// 관리자1의 응원톡만 조회되어야 하고, 관리자2의 응원톡들(26L, 29L)은 조회되지 않아야 함
@@ -154,7 +155,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
 		void 관리자2가_여러_리그를_관리할_때_모든_리그의_블락된_응원톡이_조회된다() {
 			// when
 			List<CheerTalkResponse.ForManager> responses = cheerTalkQueryService.getBlockedCheerTalksByAdmin(
-				pageRequestDto, admin2);
+				pageRequestDto, admin2).content();
 
 			// then
 			assertAll(
@@ -177,7 +178,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
         void 관리자1의_응원톡이_최신순으로_조회된다() {
             // when
             List<CheerTalkResponse.ForManager> results = cheerTalkQueryService.getUnblockedCheerTalksByAdmin(
-                    pageRequestDto, admin1);
+                    pageRequestDto, admin1).content();
 
             // then
             assertAll(
@@ -195,7 +196,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
         void 관리자2의_응원톡이_최신순으로_조회된다() {
             // when
             List<CheerTalkResponse.ForManager> results = cheerTalkQueryService.getUnblockedCheerTalksByAdmin(
-                    pageRequestDto, admin2);
+                    pageRequestDto, admin2).content();
 
             // then
             assertAll(
@@ -215,7 +216,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
         void 차단되지_않은_응원톡만_조회된다() {
             // when
             List<CheerTalkResponse.ForManager> results =
-                    cheerTalkQueryService.getUnblockedCheerTalksByAdmin(pageRequestDto, admin1);
+                    cheerTalkQueryService.getUnblockedCheerTalksByAdmin(pageRequestDto, admin1).content();
 
             // then
             assertThat(
@@ -227,7 +228,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
         void 다른_관리자의_응원톡은_조회되지_않는다() {
             // when
             List<CheerTalkResponse.ForManager> responses
-                    = cheerTalkQueryService.getUnblockedCheerTalksByAdmin(pageRequestDto, admin1);
+                    = cheerTalkQueryService.getUnblockedCheerTalksByAdmin(pageRequestDto, admin1).content();
 
             // then
             // 관리자1의 응원톡만 조회되어야 하고, 관리자2의 응원톡들(24L, 25L, 27L, 28L)은 조회되지 않아야 함
@@ -240,7 +241,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
         void 관리자가_여러_리그를_관리할_때_모든_리그의_응원톡이_조회된다() {
             // when
             List<CheerTalkResponse.ForManager> results =
-                    cheerTalkQueryService.getUnblockedCheerTalksByAdmin(pageRequestDto, admin2);
+                    cheerTalkQueryService.getUnblockedCheerTalksByAdmin(pageRequestDto, admin2).content();
 
             // then
             assertAll(
@@ -261,7 +262,7 @@ public class CheerTalkQueryServiceTest extends ServiceTest {
 
             // when
             List<CheerTalkResponse.ForManager> results =
-                    cheerTalkQueryService.getUnblockedCheerTalksByAdmin(request, admin1);
+                    cheerTalkQueryService.getUnblockedCheerTalksByAdmin(request, admin1).content();
 
             // then
             assertAll(

--- a/src/test/java/com/sports/server/query/application/GameQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/GameQueryServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.common.exception.CustomException;
 import com.sports.server.query.dto.request.GamesQueryRequestDto;
@@ -53,7 +54,7 @@ public class GameQueryServiceTest extends ServiceTest {
                 leagueTeamIds, null);
 
         //when
-        List<LeagueWithGamesResponse> response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto);
+        List<LeagueWithGamesResponse> response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).content();
 
         // then
         assertAll(
@@ -78,7 +79,7 @@ public class GameQueryServiceTest extends ServiceTest {
                 null);
 
         //when
-        List<LeagueWithGamesResponse> response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto);
+        List<LeagueWithGamesResponse> response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).content();
 
         // then
         assertAll(
@@ -103,7 +104,7 @@ public class GameQueryServiceTest extends ServiceTest {
         List<LeagueWithGamesResponse> firstPage = gameQueryService.getAllGames(
                 queryRequestDto,
                 new PageRequestDto(null, size)
-        );
+        ).content();
 
         List<GameResponseDto> allGamesInFirstPage = firstPage.stream()
                 .flatMap(leagueWithGames -> leagueWithGames.games().stream())
@@ -113,7 +114,7 @@ public class GameQueryServiceTest extends ServiceTest {
         List<LeagueWithGamesResponse> secondPage = gameQueryService.getAllGames(
                 queryRequestDto,
                 new PageRequestDto(cursor, size)
-        );
+        ).content();
 
         // then
         List<Long> secondPageGameIds = secondPage.stream()
@@ -135,7 +136,7 @@ public class GameQueryServiceTest extends ServiceTest {
         GamesQueryRequestDto queryRequestDto = new GamesQueryRequestDto(null, stateValue, leagueTeamIds, null);
 
         //when
-        List<LeagueWithGamesResponse> response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto);
+        List<LeagueWithGamesResponse> response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).content();
 
         //then
         assertAll(
@@ -154,7 +155,7 @@ public class GameQueryServiceTest extends ServiceTest {
         GamesQueryRequestDto queryRequestDto = new GamesQueryRequestDto(null, stateValue, leagueTeamIds, null);
 
         //when
-        LeagueWithGamesResponse response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).get(0);
+        LeagueWithGamesResponse response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).content().get(0);
         List<GameResponseDto> games = response.games();
 
         //then
@@ -177,7 +178,7 @@ public class GameQueryServiceTest extends ServiceTest {
         GamesQueryRequestDto queryRequestDto = new GamesQueryRequestDto(null, "FINISHED", leagueTeamIds, null);
 
         //when
-        LeagueWithGamesResponse response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).get(0);
+        LeagueWithGamesResponse response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).content().get(0);
         List<GameResponseDto> games = response.games();
 
         // then
@@ -203,7 +204,7 @@ public class GameQueryServiceTest extends ServiceTest {
             PageRequestDto pageRequestDto = new PageRequestDto(1L, 3);
 
             //when
-            LeagueWithGamesResponse response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).get(0);
+            LeagueWithGamesResponse response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).content().get(0);
             List<GameResponseDto> games = response.games();
 
             //then
@@ -221,7 +222,7 @@ public class GameQueryServiceTest extends ServiceTest {
             PageRequestDto pageRequestDto = new PageRequestDto(1L, null);
 
             //when
-            LeagueWithGamesResponse response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).get(0);
+            LeagueWithGamesResponse response = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).content().get(0);
             List<GameResponseDto> games = response.games();
 
             //then
@@ -239,11 +240,11 @@ public class GameQueryServiceTest extends ServiceTest {
             GamesQueryRequestDto queryRequestDto = new GamesQueryRequestDto(leagueId, stateValue, null, null);
 
             //when
-            LeagueWithGamesResponse response1 = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).get(0);
+            LeagueWithGamesResponse response1 = gameQueryService.getAllGames(queryRequestDto, pageRequestDto).content().get(0);
             List<GameResponseDto> firstPage = response1.games();
 
             Long cursor = firstPage.get(size - 1).id();
-            LeagueWithGamesResponse response2 = gameQueryService.getAllGames(queryRequestDto, new PageRequestDto(cursor, size)).get(0);
+            LeagueWithGamesResponse response2 = gameQueryService.getAllGames(queryRequestDto, new PageRequestDto(cursor, size)).content().get(0);
             List<GameResponseDto> secondPage = response2.games();
 
             //then
@@ -266,19 +267,19 @@ public class GameQueryServiceTest extends ServiceTest {
             List<GameResponseDto> after15 = gameQueryService.getAllGames(
                     queryRequestDto,
                     new PageRequestDto(15L, null)
-            ).get(0).games();
+            ).content().get(0).games();
             List<GameResponseDto> after19 = gameQueryService.getAllGames(
                     queryRequestDto,
                     new PageRequestDto(19L, null)
-            ).get(0).games();
+            ).content().get(0).games();
             List<GameResponseDto> after18 = gameQueryService.getAllGames(
                     queryRequestDto,
                     new PageRequestDto(18L, null)
-            ).get(0).games();
+            ).content().get(0).games();
             List<GameResponseDto> after16 = gameQueryService.getAllGames(
                     queryRequestDto,
                     new PageRequestDto(16L, null)
-            ).get(0).games();
+            ).content().get(0).games();
 
             //then
             assertAll(
@@ -306,11 +307,11 @@ public class GameQueryServiceTest extends ServiceTest {
             List<GameResponseDto> firstPage = gameQueryService.getAllGames(
                     queryRequestDto,
                     new PageRequestDto(null, 4)
-            ).get(0).games();
+            ).content().get(0).games();
             List<GameResponseDto> after21 = gameQueryService.getAllGames(
                     queryRequestDto,
                     new PageRequestDto(22L, 3)
-            ).get(0).games();
+            ).content().get(0).games();
 
             //then
             assertAll(
@@ -333,11 +334,11 @@ public class GameQueryServiceTest extends ServiceTest {
         List<GameResponseDto> firstPage = gameQueryService.getAllGames(
                 queryRequestDto,
                 new PageRequestDto(null, 4)
-        ).get(0).games();
+        ).content().get(0).games();
         List<GameResponseDto> secondPage = gameQueryService.getAllGames(
                 queryRequestDto,
                 new PageRequestDto(4L, 4)
-        ).get(0).games();
+        ).content().get(0).games();
 
         //then
         assertAll(
@@ -359,11 +360,11 @@ public class GameQueryServiceTest extends ServiceTest {
         List<GameResponseDto> firstPage = gameQueryService.getAllGames(
                 queryRequestDto,
                 new PageRequestDto(null, 4)
-        ).get(0).games();
+        ).content().get(0).games();
         List<GameResponseDto> secondPage = gameQueryService.getAllGames(
                 queryRequestDto,
                 new PageRequestDto(10L, null)
-        ).get(0).games();
+        ).content().get(0).games();
 
         //then
         assertAll(
@@ -386,7 +387,7 @@ public class GameQueryServiceTest extends ServiceTest {
         List<GameResponseDto> responseDtos = gameQueryService.getAllGames(
                 queryRequestDto,
                 new PageRequestDto(null, 4)
-        ).get(0).games();;
+        ).content().get(0).games();;
 
         // then
         List<Long> gameTeamIds = responseDtos.get(0).gameTeams().stream().map(TeamResponse::gameTeamId).toList();

--- a/src/test/java/com/sports/server/query/presentation/CheerTalkQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/CheerTalkQueryControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sports.server.command.member.domain.Member;
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.common.dto.PageRequestDto;
 import com.sports.server.query.dto.response.CheerTalkResponse;
 import com.sports.server.support.DocumentationTest;
@@ -40,14 +41,14 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 		PageRequestDto pageRequestDto = new PageRequestDto(1L, 2);
 
 		LocalDateTime createdAt = LocalDateTime.of(2024, 1, 21, 11, 46, 0);
-		List<CheerTalkResponse.ForSpectator> response = List.of(
+		CursorPageResponse<CheerTalkResponse.ForSpectator> response = new CursorPageResponse<>(List.of(
 			new CheerTalkResponse.ForSpectator(
 				2L, "응원해요", 1L, createdAt, false, "경기1", "리그1"
 			),
 			new CheerTalkResponse.ForSpectator(
 				3L, "파이팅", 2L, createdAt, false, "경기1", "리그1"
 			)
-		);
+		), null, false);
 
 		given(cheerTalkQueryService.getCheerTalksByGameId(gameId, pageRequestDto))
 			.willReturn(response);
@@ -69,14 +70,17 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 					parameterWithName("gameId").description("게임의 ID")
 				),
 				responseFields(
-					fieldWithPath("[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
-					fieldWithPath("[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
-					fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER)
+					fieldWithPath("content").type(JsonFieldType.ARRAY).description("응원톡 목록"),
+					fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+					fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+					fieldWithPath("content[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
+					fieldWithPath("content[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
+					fieldWithPath("content[].gameTeamId").type(JsonFieldType.NUMBER)
 						.description("응원톡에 해당하는 게임팀의 ID"),
-					fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
-					fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
-						fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("게임의 이름"),
-						fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("리그의 이름")
+					fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
+					fieldWithPath("content[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
+						fieldWithPath("content[].gameName").type(JsonFieldType.STRING).description("게임의 이름"),
+						fieldWithPath("content[].leagueName").type(JsonFieldType.STRING).description("리그의 이름")
 				)
 			));
 	}
@@ -88,14 +92,14 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 		PageRequestDto pageRequestDto = new PageRequestDto(1L, 2);
 
 		LocalDateTime createdAt = LocalDateTime.of(2024, 1, 21, 11, 46, 0);
-		List<CheerTalkResponse.ForManager> response = List.of(
+		CursorPageResponse<CheerTalkResponse.ForManager> response = new CursorPageResponse<>(List.of(
 			new CheerTalkResponse.ForManager(
 				2L, 1L, 1L, "응원해요", 1L, createdAt, false, "게임 이름", "리그 이름"
 			),
 			new CheerTalkResponse.ForManager(
 				3L, 1L, 1L, "파이팅", 2L, createdAt, false, "게임 이름", "리그 이름"
 			)
-		);
+		), null, false);
 
 		given(cheerTalkQueryService.getReportedCheerTalksByAdmin(
 			eq(pageRequestDto),
@@ -120,16 +124,19 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 						parameterWithName("size").description("조회하고자 하는 응원톡의 개수")
 					),
 					responseFields(
-						fieldWithPath("[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
-						fieldWithPath("[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
-						fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
-						fieldWithPath("[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
-						fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER)
+						fieldWithPath("content").type(JsonFieldType.ARRAY).description("응원톡 목록"),
+						fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+						fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+						fieldWithPath("content[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
+						fieldWithPath("content[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
+						fieldWithPath("content[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
+						fieldWithPath("content[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
+						fieldWithPath("content[].gameTeamId").type(JsonFieldType.NUMBER)
 							.description("응원톡에 해당하는 게임팀의 ID"),
-						fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
-						fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
-						fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
-						fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
+						fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
+						fieldWithPath("content[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
+						fieldWithPath("content[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
+						fieldWithPath("content[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
 					)
 			));
 	}
@@ -141,14 +148,14 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 		PageRequestDto pageRequestDto = new PageRequestDto(1L, 2);
 
 		LocalDateTime createdAt = LocalDateTime.of(2024, 1, 21, 11, 46, 0);
-		List<CheerTalkResponse.ForManager> response = List.of(
+		CursorPageResponse<CheerTalkResponse.ForManager> response = new CursorPageResponse<>(List.of(
 			new CheerTalkResponse.ForManager(
 				2L, 1L, 1L, "응원해요", 1L, createdAt, false, "게임 이름", "리그 이름"
 			),
 			new CheerTalkResponse.ForManager(
 				3L, 1L, 1L, "파이팅", 2L, createdAt, false, "게임 이름", "리그 이름"
 			)
-		);
+		), null, false);
 
 		given(cheerTalkQueryService.getUnblockedCheerTalksByAdmin(
 			eq(pageRequestDto),
@@ -173,16 +180,19 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 						parameterWithName("size").description("조회하고자 하는 응원톡의 개수")
 					),
 					responseFields(
-						fieldWithPath("[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
-						fieldWithPath("[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
-						fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
-						fieldWithPath("[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
-						fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER)
+						fieldWithPath("content").type(JsonFieldType.ARRAY).description("응원톡 목록"),
+						fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+						fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+						fieldWithPath("content[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
+						fieldWithPath("content[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
+						fieldWithPath("content[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
+						fieldWithPath("content[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
+						fieldWithPath("content[].gameTeamId").type(JsonFieldType.NUMBER)
 							.description("응원톡에 해당하는 게임팀의 ID"),
-						fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
-						fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
-						fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
-						fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
+						fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
+						fieldWithPath("content[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
+						fieldWithPath("content[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
+						fieldWithPath("content[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
 					)
 				)
 			);
@@ -194,11 +204,11 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 		Cookie cookie = new Cookie(COOKIE_NAME, "temp-cookie");
 
 		LocalDateTime createdAt = LocalDateTime.of(2024, 1, 21, 11, 46, 0);
-		List<CheerTalkResponse.ForManager> responses = List.of(
+		CursorPageResponse<CheerTalkResponse.ForManager> responses = new CursorPageResponse<>(List.of(
 			new CheerTalkResponse.ForManager(2L, 1L, 1L, "미안하다이거보여주려고어그로끌었다", 1L, createdAt, true, "제 1경기 학츄핑 vs 하츄핑",
 				"매봉역 배 타코 빨리 먹기 대작전"),
 			new CheerTalkResponse.ForManager(3L, 1L, 1L, "이학을국회로", 1L, createdAt, true, "제 2경기 학츄핑 vs 시진핑",
-				"매봉역 배 타코 빨리 먹기 대작전"));
+				"매봉역 배 타코 빨리 먹기 대작전")), null, false);
 
 		doReturn(responses).when(cheerTalkQueryService)
 			.getBlockedCheerTalksByAdmin(any(PageRequestDto.class), any(Member.class));
@@ -221,16 +231,19 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 						parameterWithName("size").description("조회하고자 하는 응원톡의 개수")
 					),
 					responseFields(
-						fieldWithPath("[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
-						fieldWithPath("[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
-						fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
-						fieldWithPath("[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
-						fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
-						fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
-						fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름"),
-						fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER)
+						fieldWithPath("content").type(JsonFieldType.ARRAY).description("응원톡 목록"),
+						fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+						fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+						fieldWithPath("content[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
+						fieldWithPath("content[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
+						fieldWithPath("content[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
+						fieldWithPath("content[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
+						fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
+						fieldWithPath("content[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
+						fieldWithPath("content[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름"),
+						fieldWithPath("content[].gameTeamId").type(JsonFieldType.NUMBER)
 							.description("응원톡에 해당하는 게임팀의 ID"),
-						fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부")
+						fieldWithPath("content[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부")
 					)
 			));
 	}
@@ -243,10 +256,10 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 		PageRequestDto pageRequestDto = new PageRequestDto(1L, 2);
 
 		LocalDateTime createdAt = LocalDateTime.of(2024, 1, 21, 11, 46, 0);
-		List<CheerTalkResponse.ForManager> response = List.of(
+		CursorPageResponse<CheerTalkResponse.ForManager> response = new CursorPageResponse<>(List.of(
 			new CheerTalkResponse.ForManager(2L, 1L, 1L, "응원해요", 1L, createdAt, false, "게임 이름", "리그 이름"),
 			new CheerTalkResponse.ForManager(3L, 1L, 1L, "파이팅", 2L, createdAt, false, "게임 이름", "리그 이름")
-		);
+		), null, false);
 
 		given(cheerTalkQueryService.getReportedCheerTalksByLeagueId(eq(leagueId), eq(pageRequestDto), any(Member.class)))
 			.willReturn(response);
@@ -273,15 +286,18 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 					parameterWithName("size").description("조회하고자 하는 응원톡의 개수")
 				),
 				responseFields(
-					fieldWithPath("[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
-					fieldWithPath("[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
-					fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
-					fieldWithPath("[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
-					fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER).description("응원톡에 해당하는 게임팀의 ID"),
-					fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
-					fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
-					fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
-					fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
+					fieldWithPath("content").type(JsonFieldType.ARRAY).description("응원톡 목록"),
+					fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+					fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+					fieldWithPath("content[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
+					fieldWithPath("content[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
+					fieldWithPath("content[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
+					fieldWithPath("content[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
+					fieldWithPath("content[].gameTeamId").type(JsonFieldType.NUMBER).description("응원톡에 해당하는 게임팀의 ID"),
+					fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
+					fieldWithPath("content[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
+					fieldWithPath("content[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
+					fieldWithPath("content[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
 				)
 			));
 	}
@@ -294,10 +310,10 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 		PageRequestDto pageRequestDto = new PageRequestDto(1L, 2);
 
 		LocalDateTime createdAt = LocalDateTime.of(2024, 1, 21, 11, 46, 0);
-		List<CheerTalkResponse.ForManager> response = List.of(
+		CursorPageResponse<CheerTalkResponse.ForManager> response = new CursorPageResponse<>(List.of(
 			new CheerTalkResponse.ForManager(2L, 1L, 1L, "응원해요", 1L, createdAt, false, "게임 이름", "리그 이름"),
 			new CheerTalkResponse.ForManager(3L, 1L, 1L, "파이팅", 2L, createdAt, false, "게임 이름", "리그 이름")
-		);
+		), null, false);
 
 		given(cheerTalkQueryService.getUnblockedCheerTalksByLeagueId(eq(leagueId), eq(pageRequestDto), any(Member.class)))
 			.willReturn(response);
@@ -324,15 +340,18 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 					parameterWithName("size").description("조회하고자 하는 응원톡의 개수")
 				),
 				responseFields(
-					fieldWithPath("[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
-					fieldWithPath("[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
-					fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
-					fieldWithPath("[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
-					fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER).description("응원톡에 해당하는 게임팀의 ID"),
-					fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
-					fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
-					fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
-					fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
+					fieldWithPath("content").type(JsonFieldType.ARRAY).description("응원톡 목록"),
+					fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+					fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+					fieldWithPath("content[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
+					fieldWithPath("content[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
+					fieldWithPath("content[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
+					fieldWithPath("content[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
+					fieldWithPath("content[].gameTeamId").type(JsonFieldType.NUMBER).description("응원톡에 해당하는 게임팀의 ID"),
+					fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
+					fieldWithPath("content[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
+					fieldWithPath("content[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
+					fieldWithPath("content[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
 				)
 			));
 	}
@@ -344,10 +363,10 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 		Long leagueId = 1L;
 
 		LocalDateTime createdAt = LocalDateTime.of(2024, 1, 21, 11, 46, 0);
-		List<CheerTalkResponse.ForManager> response = List.of(
+		CursorPageResponse<CheerTalkResponse.ForManager> response = new CursorPageResponse<>(List.of(
 			new CheerTalkResponse.ForManager(2L, 1L, 1L, "나쁜말", 1L, createdAt, true, "게임 이름", "리그 이름"),
 			new CheerTalkResponse.ForManager(3L, 1L, 1L, "또나쁜말", 2L, createdAt, true, "게임 이름", "리그 이름")
-		);
+		), null, false);
 
 		doReturn(response).when(cheerTalkQueryService)
 			.getBlockedCheerTalksByLeagueId(eq(leagueId), any(PageRequestDto.class), any(Member.class));
@@ -374,15 +393,18 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 					parameterWithName("size").description("조회하고자 하는 응원톡의 개수")
 				),
 				responseFields(
-					fieldWithPath("[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
-					fieldWithPath("[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
-					fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
-					fieldWithPath("[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
-					fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER).description("응원톡에 해당하는 게임팀의 ID"),
-					fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
-					fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
-					fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
-					fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
+					fieldWithPath("content").type(JsonFieldType.ARRAY).description("응원톡 목록"),
+					fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+					fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+					fieldWithPath("content[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
+					fieldWithPath("content[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
+					fieldWithPath("content[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
+					fieldWithPath("content[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
+					fieldWithPath("content[].gameTeamId").type(JsonFieldType.NUMBER).description("응원톡에 해당하는 게임팀의 ID"),
+					fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
+					fieldWithPath("content[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
+					fieldWithPath("content[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
+					fieldWithPath("content[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
 				)
 			));
 	}
@@ -395,10 +417,10 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 		PageRequestDto pageRequestDto = new PageRequestDto(1L, 2);
 
 		LocalDateTime createdAt = LocalDateTime.of(2024, 1, 21, 11, 46, 0);
-		List<CheerTalkResponse.ForManager> response = List.of(
+		CursorPageResponse<CheerTalkResponse.ForManager> response = new CursorPageResponse<>(List.of(
 			new CheerTalkResponse.ForManager(2L, 1L, 1L, "응원해요", 1L, createdAt, false, "게임 이름", "리그 이름"),
 			new CheerTalkResponse.ForManager(3L, 1L, 1L, "파이팅", 2L, createdAt, false, "게임 이름", "리그 이름")
-		);
+		), null, false);
 
 		given(cheerTalkQueryService.getReportedCheerTalksByGameId(eq(gameId), eq(pageRequestDto), any(Member.class)))
 			.willReturn(response);
@@ -425,15 +447,18 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 					parameterWithName("size").description("조회하고자 하는 응원톡의 개수")
 				),
 				responseFields(
-					fieldWithPath("[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
-					fieldWithPath("[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
-					fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
-					fieldWithPath("[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
-					fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER).description("응원톡에 해당하는 게임팀의 ID"),
-					fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
-					fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
-					fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
-					fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
+					fieldWithPath("content").type(JsonFieldType.ARRAY).description("응원톡 목록"),
+					fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+					fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+					fieldWithPath("content[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
+					fieldWithPath("content[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
+					fieldWithPath("content[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
+					fieldWithPath("content[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
+					fieldWithPath("content[].gameTeamId").type(JsonFieldType.NUMBER).description("응원톡에 해당하는 게임팀의 ID"),
+					fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
+					fieldWithPath("content[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
+					fieldWithPath("content[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
+					fieldWithPath("content[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
 				)
 			));
 	}
@@ -445,10 +470,10 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 		Long gameId = 1L;
 
 		LocalDateTime createdAt = LocalDateTime.of(2024, 1, 21, 11, 46, 0);
-		List<CheerTalkResponse.ForManager> response = List.of(
+		CursorPageResponse<CheerTalkResponse.ForManager> response = new CursorPageResponse<>(List.of(
 			new CheerTalkResponse.ForManager(2L, 1L, 1L, "나쁜말", 1L, createdAt, true, "게임 이름", "리그 이름"),
 			new CheerTalkResponse.ForManager(3L, 1L, 1L, "또나쁜말", 2L, createdAt, true, "게임 이름", "리그 이름")
-		);
+		), null, false);
 
 		doReturn(response).when(cheerTalkQueryService)
 			.getBlockedCheerTalksByGameId(eq(gameId), any(PageRequestDto.class), any(Member.class));
@@ -475,15 +500,18 @@ public class CheerTalkQueryControllerTest extends DocumentationTest {
 					parameterWithName("size").description("조회하고자 하는 응원톡의 개수")
 				),
 				responseFields(
-					fieldWithPath("[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
-					fieldWithPath("[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
-					fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
-					fieldWithPath("[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
-					fieldWithPath("[].gameTeamId").type(JsonFieldType.NUMBER).description("응원톡에 해당하는 게임팀의 ID"),
-					fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
-					fieldWithPath("[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
-					fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
-					fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
+					fieldWithPath("content").type(JsonFieldType.ARRAY).description("응원톡 목록"),
+					fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+					fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+					fieldWithPath("content[].cheerTalkId").type(JsonFieldType.NUMBER).description("응원톡의 ID"),
+					fieldWithPath("content[].gameId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 게임의 ID"),
+					fieldWithPath("content[].leagueId").type(JsonFieldType.NUMBER).description("응원톡이 등록된 리그의 ID"),
+					fieldWithPath("content[].content").type(JsonFieldType.STRING).description("응원톡의 내용"),
+					fieldWithPath("content[].gameTeamId").type(JsonFieldType.NUMBER).description("응원톡에 해당하는 게임팀의 ID"),
+					fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성된 날짜 및 시각"),
+					fieldWithPath("content[].isBlocked").type(JsonFieldType.BOOLEAN).description("응원톡의 블락 여부"),
+					fieldWithPath("content[].gameName").type(JsonFieldType.STRING).description("응원톡이 등록된 게임의 이름"),
+					fieldWithPath("content[].leagueName").type(JsonFieldType.STRING).description("응원톡이 등록된 리그의 이름")
 				)
 			));
 	}

--- a/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sports.server.command.game.domain.LineupPlayerState;
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.query.dto.response.*;
 import com.sports.server.query.dto.response.QuarterResponse;
 import com.sports.server.support.DocumentationTest;
@@ -123,7 +124,8 @@ class GameQueryControllerTest extends DocumentationTest {
                 new LeagueWithGamesResponse(1L, "2025 외대월드컵", responses)
         );
 
-        given(gameQueryService.getAllGames(any(), any())).willReturn(finalResponse);
+        CursorPageResponse<LeagueWithGamesResponse> cursorResponse = new CursorPageResponse<>(finalResponse, null, false);
+        given(gameQueryService.getAllGames(any(), any())).willReturn(cursorResponse);
 
         // when
         ResultActions result = mockMvc.perform(get("/games")
@@ -148,30 +150,33 @@ class GameQueryControllerTest extends DocumentationTest {
                                 parameterWithName("round").description("라운드의 이름 ex. 4강->4, 결승->2")
                         ),
                         responseFields(
-                                fieldWithPath("[]").description("리그 목록"),
-                                fieldWithPath("[].leagueId").type(JsonFieldType.NUMBER).description("리그 ID"),
-                                fieldWithPath("[].leagueName").type(JsonFieldType.STRING).description("리그 이름"),
-                                fieldWithPath("[].games").type(JsonFieldType.ARRAY).description("게임 목록"),
-                                fieldWithPath("[].games[].id").type(JsonFieldType.NUMBER).description("게임의 ID"),
-                                fieldWithPath("[].games[].startTime").type(JsonFieldType.STRING).description("게임 시작 시간"),
-                                fieldWithPath("[].games[].gameQuarter").type(JsonFieldType.OBJECT).description("게임 쿼터"),
-                                fieldWithPath("[].games[].gameQuarter.key").type(JsonFieldType.STRING).description("게임 쿼터 키"),
-                                fieldWithPath("[].games[].gameQuarter.label").type(JsonFieldType.STRING).description("게임 쿼터 표시명"),
-                                fieldWithPath("[].games[].gameName").type(JsonFieldType.STRING).description("게임 이름"),
-                                fieldWithPath("[].games[].round").type(JsonFieldType.NUMBER)
+                                fieldWithPath("content").type(JsonFieldType.ARRAY).description("리그별 게임 목록"),
+                                fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+                                fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+                                fieldWithPath("content[]").description("리그 목록"),
+                                fieldWithPath("content[].leagueId").type(JsonFieldType.NUMBER).description("리그 ID"),
+                                fieldWithPath("content[].leagueName").type(JsonFieldType.STRING).description("리그 이름"),
+                                fieldWithPath("content[].games").type(JsonFieldType.ARRAY).description("게임 목록"),
+                                fieldWithPath("content[].games[].id").type(JsonFieldType.NUMBER).description("게임의 ID"),
+                                fieldWithPath("content[].games[].startTime").type(JsonFieldType.STRING).description("게임 시작 시간"),
+                                fieldWithPath("content[].games[].gameQuarter").type(JsonFieldType.OBJECT).description("게임 쿼터"),
+                                fieldWithPath("content[].games[].gameQuarter.key").type(JsonFieldType.STRING).description("게임 쿼터 키"),
+                                fieldWithPath("content[].games[].gameQuarter.label").type(JsonFieldType.STRING).description("게임 쿼터 표시명"),
+                                fieldWithPath("content[].games[].gameName").type(JsonFieldType.STRING).description("게임 이름"),
+                                fieldWithPath("content[].games[].round").type(JsonFieldType.NUMBER)
                                         .description("라운드의 이름 ex. 4강->4, 결승->2"),
-                                fieldWithPath("[].games[].videoId").type(JsonFieldType.STRING).description("경기 영상 ID"),
-                                fieldWithPath("[].games[].isPkTaken").type(JsonFieldType.BOOLEAN)
+                                fieldWithPath("content[].games[].videoId").type(JsonFieldType.STRING).description("경기 영상 ID"),
+                                fieldWithPath("content[].games[].isPkTaken").type(JsonFieldType.BOOLEAN)
                                         .description("승부차기 진출 여부"),
-                                fieldWithPath("[].games[].gameTeams[].gameTeamId").type(JsonFieldType.NUMBER)
+                                fieldWithPath("content[].games[].gameTeams[].gameTeamId").type(JsonFieldType.NUMBER)
                                         .description("게임팀의 ID"),
-                                fieldWithPath("[].games[].gameTeams[].gameTeamName").type(JsonFieldType.STRING)
+                                fieldWithPath("content[].games[].gameTeams[].gameTeamName").type(JsonFieldType.STRING)
                                         .description("게임팀의 이름"),
-                                fieldWithPath("[].games[].gameTeams[].logoImageUrl").type(JsonFieldType.STRING)
+                                fieldWithPath("content[].games[].gameTeams[].logoImageUrl").type(JsonFieldType.STRING)
                                         .description("게임팀의 이미지 URL"),
-                                fieldWithPath("[].games[].gameTeams[].score").type(JsonFieldType.NUMBER)
+                                fieldWithPath("content[].games[].gameTeams[].score").type(JsonFieldType.NUMBER)
                                         .description("게임팀의 현재 점수"),
-                                fieldWithPath("[].games[].gameTeams[].pkScore").type(JsonFieldType.NUMBER)
+                                fieldWithPath("content[].games[].gameTeams[].pkScore").type(JsonFieldType.NUMBER)
                                         .description("게임팀의 승부차기 점수")
                         )
                 ));

--- a/src/test/java/com/sports/server/query/presentation/PlayerQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/PlayerQueryControllerTest.java
@@ -1,5 +1,6 @@
 package com.sports.server.query.presentation;
 
+import com.sports.server.common.dto.CursorPageResponse;
 import com.sports.server.query.dto.response.PlayerResponse;
 import com.sports.server.query.dto.response.TeamResponse;
 import com.sports.server.support.DocumentationTest;
@@ -36,14 +37,14 @@ public class PlayerQueryControllerTest extends DocumentationTest {
                 new TeamResponse(1L, "정치외교학과 PSD", "s3:logoImageUrl1", "사회과학대학", "#F7CAC9", "SOCCER")
         );
 
-        List<PlayerResponse> responses = List.of(
+        CursorPageResponse<PlayerResponse> response = new CursorPageResponse<>(List.of(
                 new PlayerResponse(1L, null, "선수1", "202500001", null, 0, teamResponses1),
                 new PlayerResponse(2L, null, "선수2", "202500002", null, 5, teamResponses2),
                 new PlayerResponse(3L, null, "선수3", "202500003", null, 10, Collections.emptyList())
-        );
+        ), null, false);
 
         given(playerQueryService.getAllPlayers(any(), any()))
-                .willReturn(responses);
+                .willReturn(response);
 
         // when
         ResultActions result = mockMvc.perform(get("/players")
@@ -64,17 +65,20 @@ public class PlayerQueryControllerTest extends DocumentationTest {
                                 cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
                         ),
                         responseFields(
-                                fieldWithPath("[].playerId").type(JsonFieldType.NUMBER).description("선수의 ID"),
-                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("선수의 이름"),
-                                fieldWithPath("[].studentNumber").type(JsonFieldType.STRING).description("선수의 학번"),
-                                fieldWithPath("[].totalGoalCount").type(JsonFieldType.NUMBER).description("선수의 전체 골 개수"),
-                                fieldWithPath("[].teams").type(JsonFieldType.ARRAY).description("선수의 모든 소속팀 목록"),
-                                fieldWithPath("[].teams[].id").type(JsonFieldType.NUMBER).description("소속팀의 ID"),
-                                fieldWithPath("[].teams[].name").type(JsonFieldType.STRING).description("소속팀의 이름"),
-                                fieldWithPath("[].teams[].logoImageUrl").type(JsonFieldType.STRING).description("소속팀의 로고 이미지 url"),
-                                fieldWithPath("[].teams[].unit").type(JsonFieldType.STRING).description("소속팀의 소속 단위"),
-                                fieldWithPath("[].teams[].teamColor").type(JsonFieldType.STRING).description("소속팀의 대표 색상"),
-                                fieldWithPath("[].teams[].sportType").type(JsonFieldType.STRING).description("소속팀의 종목")
+                                fieldWithPath("content").type(JsonFieldType.ARRAY).description("선수 목록"),
+                                fieldWithPath("content[].playerId").type(JsonFieldType.NUMBER).description("선수의 ID"),
+                                fieldWithPath("content[].name").type(JsonFieldType.STRING).description("선수의 이름"),
+                                fieldWithPath("content[].studentNumber").type(JsonFieldType.STRING).description("선수의 학번"),
+                                fieldWithPath("content[].totalGoalCount").type(JsonFieldType.NUMBER).description("선수의 전체 골 개수"),
+                                fieldWithPath("content[].teams").type(JsonFieldType.ARRAY).description("선수의 모든 소속팀 목록"),
+                                fieldWithPath("content[].teams[].id").type(JsonFieldType.NUMBER).description("소속팀의 ID"),
+                                fieldWithPath("content[].teams[].name").type(JsonFieldType.STRING).description("소속팀의 이름"),
+                                fieldWithPath("content[].teams[].logoImageUrl").type(JsonFieldType.STRING).description("소속팀의 로고 이미지 url"),
+                                fieldWithPath("content[].teams[].unit").type(JsonFieldType.STRING).description("소속팀의 소속 단위"),
+                                fieldWithPath("content[].teams[].teamColor").type(JsonFieldType.STRING).description("소속팀의 대표 색상"),
+                                fieldWithPath("content[].teams[].sportType").type(JsonFieldType.STRING).description("소속팀의 종목"),
+                                fieldWithPath("nextCursor").type(JsonFieldType.NUMBER).optional().description("다음 페이지 커서"),
+                                fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부")
                         )
                 ));
     }

--- a/src/test/java/com/sports/server/support/AcceptanceTest.java
+++ b/src/test/java/com/sports/server/support/AcceptanceTest.java
@@ -87,6 +87,12 @@ public class AcceptanceTest {
                 .getList(".", dtoType);
     }
 
+    protected <T> List<T> toCursorPageContent(ExtractableResponse<Response> response,
+                                               Class<T> dtoType) {
+        return response.jsonPath()
+                .getList("content", dtoType);
+    }
+
     protected <T> T toResponse(ExtractableResponse<Response> response,
                                Class<T> dtoType) {
         return response.jsonPath()


### PR DESCRIPTION
## 이슈
- #654 (커서 페이지네이션 개선)
- develop → main 통합 PR(#659)에서 #658(organizations 로고 + V16 마이그레이션) 등은 보류하고, 안전하게 prod 에 올릴 수 있는 **#654 변경분만** 분리하여 release.

## 구현 내용
- `CursorPageResponse` 응답에 `nextCursor`(다음 페이지 시작 커서), `hasNext`(다음 페이지 존재 여부) 추가 — 클라이언트가 다음 페이지 존재 여부를 명시적으로 판단 가능
- `CursorPageResponse.ofBulk` 벌크 매핑 메서드 추가 + `size=0` 일 때 `IndexOutOfBoundsException` 안전성 보강
- `GameQueryService` `Collectors.groupingBy` 가 `HashMap` 을 써서 리그 노출 순서가 보장되지 않던 문제를 `LinkedHashMap` 으로 수정
- `CheerTalkQueryService` 의 중복 슬라이싱/커서 추출 로직을 `CursorPageResponse.ofBulk` 로 통합해 제거

## 테스트
- `./gradlew test` 통과 (PR #654 머지 시점 CI green)
- 커서 페이지네이션 응답 구조 변경에 맞춰 기존 테스트 갱신 포함

## 영향 API
| Method | Path | 변경 |
|---|---|---|
| GET | 커서 페이지네이션 사용 엔드포인트 전반 (`/cheer-talks` 등) | 응답에 `nextCursor`, `hasNext` 필드 추가 |
| GET | 리그/게임 목록 조회 | 리그 순서 일관성 보장(LinkedHashMap) |

## 프론트 참고
- `hasNext === false` 일 때 \"더 보기\" 버튼 비활성/숨김 처리 가능 — 기존엔 size 검사로 추정
- `nextCursor` 명시적으로 사용 가능 — 기존 cursor 파라미터 그대로 유지

## 운영/마이그레이션 참고
- 마이그레이션 없음
- 응답 필드 **추가** 이므로 기존 클라이언트 영향 없음 (Spring 기본 Jackson 정책상 unknown 필드 무시)

## 본 PR 구성 방식
- develop HEAD 의 PR #654 머지 커밋(ffc52ddb) 을 `git cherry-pick -m 1` 로 main 위에 squash 효과로 가져옴
- PR #658(organizations 로고 + V16 마이그레이션), 기타 `docs:` 커밋은 **포함되지 않음**