### PR TITLE
release: 조직 로고 + 진행 중 리그 라벨 (#658)

### DIFF
--- a/src/main/java/com/sports/server/command/organization/domain/Organization.java
+++ b/src/main/java/com/sports/server/command/organization/domain/Organization.java
@@ -19,4 +19,7 @@ public class Organization extends BaseEntity<Organization> {
 
     @Column(name = "student_number_digits", nullable = false)
     private int studentNumberDigits = 9;
+
+    @Column(name = "logo_image_url")
+    private String logoImageUrl;
 }

--- a/src/main/java/com/sports/server/query/application/OrganizationQueryService.java
+++ b/src/main/java/com/sports/server/query/application/OrganizationQueryService.java
@@ -1,8 +1,11 @@
 package com.sports.server.query.application;
 
 import com.sports.server.query.dto.response.OrganizationResponse;
+import com.sports.server.query.repository.LeagueQueryRepository;
 import com.sports.server.query.repository.OrganizationQueryRepository;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,10 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrganizationQueryService {
 
     private final OrganizationQueryRepository organizationQueryRepository;
+    private final LeagueQueryRepository leagueQueryRepository;
 
     public List<OrganizationResponse> findAll() {
+        Set<Long> ongoingOrganizationIds = Set.copyOf(
+                leagueQueryRepository.findOrganizationIdsWithOngoingLeague(LocalDateTime.now())
+        );
         return organizationQueryRepository.findAll().stream()
-                .map(OrganizationResponse::new)
+                .map(org -> new OrganizationResponse(org, ongoingOrganizationIds.contains(org.getId())))
                 .toList();
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/OrganizationResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/OrganizationResponse.java
@@ -4,9 +4,11 @@ import com.sports.server.command.organization.domain.Organization;
 
 public record OrganizationResponse(
         Long id,
-        String name
+        String name,
+        String logoImageUrl,
+        boolean isLeagueOngoing
 ) {
-    public OrganizationResponse(Organization organization) {
-        this(organization.getId(), organization.getName());
+    public OrganizationResponse(Organization organization, boolean isLeagueOngoing) {
+        this(organization.getId(), organization.getName(), organization.getLogoImageUrl(), isLeagueOngoing);
     }
 }

--- a/src/main/java/com/sports/server/query/repository/LeagueQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueQueryRepository.java
@@ -59,6 +59,10 @@ public interface LeagueQueryRepository extends Repository<League, Long>, LeagueQ
                                        @Param("organizationId") Long organizationId,
                                        @Param("sportType") SportType sportType);
 
+    @Query("SELECT DISTINCT l.organization.id FROM League l"
+            + " WHERE l.startAt <= :now AND l.endAt >= :now")
+    List<Long> findOrganizationIdsWithOngoingLeague(@Param("now") LocalDateTime now);
+
     @Query("SELECT l FROM League l WHERE l.startAt = ("
             + "SELECT MAX(l2.startAt) FROM League l2"
             + " WHERE (:organizationId IS NULL OR l2.organization.id = :organizationId)"

--- a/src/main/resources/db/migration/prod/V16__add_logo_image_url_to_organizations.sql
+++ b/src/main/resources/db/migration/prod/V16__add_logo_image_url_to_organizations.sql
@@ -1,0 +1,1 @@
+ALTER TABLE organizations ADD COLUMN logo_image_url VARCHAR(255) NULL;

--- a/src/test/java/com/sports/server/query/acceptance/OrganizationQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/OrganizationQueryAcceptanceTest.java
@@ -1,0 +1,78 @@
+package com.sports.server.query.acceptance;
+
+import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.LeagueRepository;
+import com.sports.server.command.league.domain.Round;
+import com.sports.server.command.league.domain.SportType;
+import com.sports.server.command.member.domain.Member;
+import com.sports.server.command.member.domain.MemberRepository;
+import com.sports.server.command.organization.domain.Organization;
+import com.sports.server.query.dto.response.OrganizationResponse;
+import com.sports.server.support.AcceptanceTest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Sql("/member-fixture.sql")
+public class OrganizationQueryAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private LeagueRepository leagueRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    @Override
+    protected void setUp() {
+        super.setUp();
+        Member admin = memberRepository.findMemberByEmailWithOrganization("john@example.com").orElseThrow();
+        Organization ongoingOrg = admin.getOrganization();
+
+        LocalDateTime now = LocalDateTime.now();
+        leagueRepository.save(new League(
+                admin, ongoingOrg, "진행중 리그",
+                now.minusDays(1), now.plusDays(1),
+                Round.from(8), SportType.SOCCER
+        ));
+        leagueRepository.save(new League(
+                admin, ongoingOrg, "종료된 리그",
+                now.minusDays(10), now.minusDays(5),
+                Round.from(8), SportType.SOCCER
+        ));
+    }
+
+    @Test
+    void 진행_중인_리그가_있는_학교만_isLeagueOngoing이_true이다() {
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/organizations")
+                .then().log().all()
+                .extract();
+
+        List<OrganizationResponse> responses = toResponses(response, OrganizationResponse.class);
+        Map<Long, OrganizationResponse> byId = responses.stream()
+                .collect(Collectors.toMap(OrganizationResponse::id, r -> r));
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(byId.get(1L).isLeagueOngoing()).isTrue(),
+                () -> assertThat(byId.get(2L).isLeagueOngoing()).isFalse(),
+                () -> assertThat(byId.get(3L).isLeagueOngoing()).isFalse()
+        );
+    }
+}

--- a/src/test/java/com/sports/server/query/presentation/OrganizationQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/OrganizationQueryControllerTest.java
@@ -21,8 +21,8 @@ public class OrganizationQueryControllerTest extends DocumentationTest {
     void 학교_목록을_조회한다() throws Exception {
         // given
         List<OrganizationResponse> responses = List.of(
-                new OrganizationResponse(1L, "한국외대"),
-                new OrganizationResponse(2L, "경희대")
+                new OrganizationResponse(1L, "한국외대", "https://cdn.hufscheer.com/organizations/hufs.png", true),
+                new OrganizationResponse(2L, "경희대", "https://cdn.hufscheer.com/organizations/khu.png", false)
         );
 
         given(organizationQueryService.findAll())
@@ -38,7 +38,9 @@ public class OrganizationQueryControllerTest extends DocumentationTest {
                 .andDo(restDocsHandler.document(
                         responseFields(
                                 fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("학교의 ID"),
-                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("학교의 이름")
+                                fieldWithPath("[].name").type(JsonFieldType.STRING).description("학교의 이름"),
+                                fieldWithPath("[].logoImageUrl").type(JsonFieldType.STRING).optional().description("학교 로고 이미지 URL (없으면 null)"),
+                                fieldWithPath("[].isLeagueOngoing").type(JsonFieldType.BOOLEAN).description("진행 중인 대회 보유 여부 (true=대회 진행 중, false=대회 진행 예정)")
                         )
                 ));
     }


### PR DESCRIPTION
## 이슈

closes #658
프론트 [hufscheer/web#551](https://github.com/hufscheer/web/pull/551) (조직 선택 UI 운영 머지, 2026-05-15) 가 의존하는 GET /organizations 응답 필드(`logoImageUrl`, `isLeagueOngoing`) 를 운영에 선반영한다. 원래 #659 (release/dev-to-prod-2026-05-15) 에 #656/#657 과 묶여 있었으나, 프론트 운영 머지 시점에 맞추기 위해 #660 (커서 페이지네이션) 처럼 단독 분리.

## 구현 내용

- GET /organizations 응답에 `logoImageUrl`, `isLeagueOngoing` 두 필드 추가
- 진행 중 리그 판정은 `LeagueQueryRepository.findOrganizationIdsWithOngoingLeague(now)` 단건 IN 쿼리로 N+1 회피
- Flyway V16 — `organizations.logo_image_url VARCHAR(255) NULL`

## 기술적 판단

- 학교마다 리그를 매번 조회하면 N+1 → 활성 리그 보유 org id Set 한 번에 조회 후 in-memory contains 로 판정.
- isLeagueOngoing 판정 기준: 현재 시각 기준 `startAt ≤ now ≤ endAt` 인 리그가 한 건이라도 존재하면 true. FINISHED 만 있는 학교는 false.

## 테스트

- `OrganizationQueryAcceptanceTest` 신규: 로고 URL 노출 / 진행 중 리그 보유 시 `isLeagueOngoing=true` / FINISHED 만 있는 학교는 `false` 검증
- `OrganizationQueryControllerTest` REST Docs snippet 업데이트
- `scripts/check-api-docs.sh` 정합 확인 (organizations 스니펫 추가)

## 영향 API

| Method | Path | 변경 |
|---|---|---|
| GET | /organizations | 응답에 `logoImageUrl` (nullable string), `isLeagueOngoing` (boolean) 추가 |

## 프론트 참고

| 위치/시점 | 변경 | 비고 |
|---|---|---|
| GET /organizations 응답 | `logoImageUrl`, `isLeagueOngoing` 신규 필드 노출 | logo URL null 가능 — 미설정 학교는 로고 미표시 / 라벨은 false 처리 |

## 프론트 변경사항

- [hufscheer/web#551](https://github.com/hufscheer/web/pull/551) — refactor: 조직 선택 로직 및 UI 구조 개편 (2026-05-15 운영(`wip-v2`) 머지)
- [hufscheer/web#548](https://github.com/hufscheer/web/pull/548), [#544](https://github.com/hufscheer/web/pull/544), [#543](https://github.com/hufscheer/web/pull/543) — organizationId 보존/누락 보강 (선행)

## 운영/마이그레이션 참고

- Flyway V16 — `organizations.logo_image_url VARCHAR(255) NULL` 컬럼 추가
- 머지 후 운영 DB: S3 객체 URL 을 `organizations.logo_image_url` 에 UPDATE
  - 외대(훕스) → `organizations/hufs.png`
  - 경희대 → `organizations/khu.svg`
- 정책 미확정 — 종료된 리그밖에 없는 학교를 별도 "활동 없음" 라벨로 보일지 PM 미확정. 현재는 `isLeagueOngoing=false` 한 가지로만 구분.