### PR TITLE
refactor: Team.organization_id 컬럼 제거 — Organization → Unit → Team 단일 계층화 (#663)

### DIFF
--- a/src/main/java/com/sports/server/command/team/application/TeamService.java
+++ b/src/main/java/com/sports/server/command/team/application/TeamService.java
@@ -48,7 +48,6 @@ public class TeamService {
 
         Unit unit = findUnit(request.unit(), member.getOrganization().getId());
         Team team = request.toEntity(imgUrl, unit);
-        team.setOrganization(member.getOrganization());
         teamRepository.save(team);
         eventPublisher.publishEvent(new LogoImageNormalizationRequestedEvent(request.logoImageUrl()));
 
@@ -63,7 +62,6 @@ public class TeamService {
 
         Unit unit = findUnit(request.unit(), member.getOrganization().getId());
         Team team = request.toEntity(imgUrl, unit);
-        team.setOrganization(member.getOrganization());
         teamRepository.save(team);
         eventPublisher.publishEvent(new LogoImageNormalizationRequestedEvent(request.logoImageUrl()));
         return team.getId();
@@ -74,12 +72,7 @@ public class TeamService {
         PermissionValidator.checkPermission(team, member);
 
         Unit unit = Optional.ofNullable(request.unit())
-                .map(unitName -> {
-                    Long unitOrgId = team.getOrganization() != null
-                            ? team.getOrganization().getId()
-                            : (member.getOrganization() != null ? member.getOrganization().getId() : null);
-                    return findUnit(unitName, unitOrgId);
-                })
+                .map(unitName -> findUnit(unitName, team.getUnit().getOrganization().getId()))
                 .orElse(null);
         String resolvedLogoUrl = resolveLogoImageUrl(request.logoImageUrl(), team);
         team.update(request.name(), resolvedLogoUrl, unit, request.teamColor());

--- a/src/main/java/com/sports/server/command/team/domain/Team.java
+++ b/src/main/java/com/sports/server/command/team/domain/Team.java
@@ -3,7 +3,6 @@ package com.sports.server.command.team.domain;
 import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.league.domain.LeagueTeam;
 import com.sports.server.command.league.domain.SportType;
-import com.sports.server.command.organization.domain.Organization;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.common.domain.BaseEntity;
@@ -44,10 +43,6 @@ public class Team extends BaseEntity<Team> implements ManagedEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "sport_type", nullable = false)
     private SportType sportType;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "organization_id")
-    private Organization organization;
 
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
@@ -138,12 +133,8 @@ public class Team extends BaseEntity<Team> implements ManagedEntity {
         if (manager.isAdministrator()) {
             return true;
         }
-        return this.organization != null && manager.getOrganization() != null
-                && this.organization.getId().equals(manager.getOrganization().getId());
-    }
-
-    public void setOrganization(Organization organization) {
-        this.organization = organization;
+        return manager.getOrganization() != null
+                && this.unit.getOrganization().getId().equals(manager.getOrganization().getId());
     }
 
 }

--- a/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
@@ -101,6 +101,6 @@ public class TeamQueryDynamicRepositoryImpl implements TeamQueryDynamicRepositor
         if (organizationId == null) {
             return null;
         }
-        return team.organization.id.eq(organizationId);
+        return team.unit.organization.id.eq(organizationId);
     }
 }

--- a/src/main/resources/db/migration/prod/V18__remove_team_organization_id_column.sql
+++ b/src/main/resources/db/migration/prod/V18__remove_team_organization_id_column.sql
@@ -1,0 +1,6 @@
+-- Team.organization_id FK 제거 (Organization → Unit → Team 단일 계층화)
+-- 검증 (2026-05-25 prod):
+--   teams.organization_id <> units.organization_id, NULL 모두 0건
+--   teams.unit_id IS NULL 0건, units.organization_id IS NULL 0건
+ALTER TABLE teams DROP FOREIGN KEY FK_TEAMS_ON_ORGANIZATION;
+ALTER TABLE teams DROP COLUMN organization_id;

--- a/src/test/resources/team-query-fixture.sql
+++ b/src/test/resources/team-query-fixture.sql
@@ -18,12 +18,12 @@ VALUES (1, '사회과학대학', 1),
        (4, '경영대학', 2);
 
 
-INSERT INTO teams (id, unit_id, name, logo_image_url, team_color, organization_id)
-VALUES (1, 1, '팀A', 'http://example.com/logo_a.png', '#FF0000', 1),
-       (2, 2, '팀B', 'http://example.com/logo_b.png', '#0000FF', 1),
-       (3, 3, '팀C', 'http://example.com/logo_c.png', '#0000FF', 1),
-       (4, 1, '팀D', 'http://example.com/logo_d.png', '#0000FF', 1),
-       (20, 4, '다른조직팀', 'http://example.com/logo_other.png', '#00FF00', 2);
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color)
+VALUES (1, 1, '팀A', 'http://example.com/logo_a.png', '#FF0000'),
+       (2, 2, '팀B', 'http://example.com/logo_b.png', '#0000FF'),
+       (3, 3, '팀C', 'http://example.com/logo_c.png', '#0000FF'),
+       (4, 1, '팀D', 'http://example.com/logo_d.png', '#0000FF'),
+       (20, 4, '다른조직팀', 'http://example.com/logo_other.png', '#00FF00');
 
 
 INSERT INTO players (id, name, student_number)
@@ -167,10 +167,10 @@ VALUES ('GAME_PROGRESS', 1, 'POST_GAME', 20, 'GAME_END', 1, 2, 2, 3, 'PENALTY_SH
 
 -- === 최근 경기 조회 위한 데이터 ===
 
-INSERT INTO teams (id, unit_id, name, logo_image_url, team_color, organization_id)
-VALUES (10, 2, '게임없는팀', 'image', '#000000', 1),
-       (11, 2, '게임2개팀', 'image', '#00FF00', 1),
-       (12, 2, '게임많은팀', 'image', '#FF00FF', 1);
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color)
+VALUES (10, 2, '게임없는팀', 'image', '#000000'),
+       (11, 2, '게임2개팀', 'image', '#00FF00'),
+       (12, 2, '게임많은팀', 'image', '#FF00FF');
 
 INSERT INTO players (id, name, student_number)
 VALUES (20, '선수20', '202400001'),
@@ -231,11 +231,11 @@ VALUES (3, '멀티스포츠 학교', 9);
 INSERT INTO units (id, name, organization_id)
 VALUES (50, '멀티스포츠과', 3);
 
-INSERT INTO teams (id, unit_id, name, logo_image_url, team_color, organization_id, sport_type)
-VALUES (50, 50, '멀티스포츠 축구팀', 'http://example.com/logo_soccer.png', '#111111', 3, 'SOCCER'),
-       (51, 50, '멀티스포츠 농구팀', 'http://example.com/logo_basket.png', '#222222', 3, 'BASKETBALL'),
-       (52, 50, '상대 축구팀', 'http://example.com/logo_op_soccer.png', '#333333', 3, 'SOCCER'),
-       (53, 50, '상대 농구팀', 'http://example.com/logo_op_basket.png', '#444444', 3, 'BASKETBALL');
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color, sport_type)
+VALUES (50, 50, '멀티스포츠 축구팀', 'http://example.com/logo_soccer.png', '#111111', 'SOCCER'),
+       (51, 50, '멀티스포츠 농구팀', 'http://example.com/logo_basket.png', '#222222', 'BASKETBALL'),
+       (52, 50, '상대 축구팀', 'http://example.com/logo_op_soccer.png', '#333333', 'SOCCER'),
+       (53, 50, '상대 농구팀', 'http://example.com/logo_op_basket.png', '#444444', 'BASKETBALL');
 
 INSERT INTO players (id, name, student_number)
 VALUES (50, '멀티선수50', '202100050');


### PR DESCRIPTION
## 이슈
closes #663

## 변경 내용
- `Team` 엔티티: `organization` FK/필드 + `setOrganization` 제거. `isManagedBy` 는 `unit.organization` 경유로 재작성
- `TeamService`: register/registerAndReturnId 의 `setOrganization` 호출 제거 (Unit 이 이미 organization 보유)
- `TeamService#update`: Unit 조회 시 `team.getUnit().getOrganization().getId()` 사용 (Team 자체의 organization 미사용)
- `TeamQueryDynamicRepositoryImpl#teamsInOrganization`: `team.organization.id` → `team.unit.organization.id`
- Flyway `V18__remove_team_organization_id_column.sql`: `FK_TEAMS_ON_ORGANIZATION` 및 `teams.organization_id` 컬럼 DROP

## 테스트
- 사전 검증 (prod 2026-05-25):
  - `teams.organization_id <> units.organization_id` → 0건
  - `teams.organization_id IS NULL` → 0건
  - `teams.unit_id IS NULL` → 0건
- 영향 받는 테스트 픽스처 정리:
  - `team-query-fixture.sql` 의 teams INSERT 3건에서 `organization_id` 컬럼 제거
- 회귀:
  - `TeamQueryAcceptanceTest`, `TeamManagerQueryAcceptanceTest`, `TeamQueryServiceTest` 통과
  - `com.sports.server.command.team.*` 통과

## 영향 API
없음 — DB 컬럼 1개와 내부 도메인 메서드 정리. 응답 스키마/요청 스키마 변경 없음.

## 프론트 참고
없음 — 외부 계약 변경 없음.

## 마이그레이션 영향
- Flyway V18 적용 후 `teams.organization_id` 컬럼 영구 제거
- 롤백 시 별도 add-column + 데이터 복원 마이그레이션 필요 (`units.organization_id` 에서 join 으로 복원 가능)