### PR TITLE
fix: BasicAuth 봇 스캔에서 AuthenticationManager 무한 재귀로 500 폭증 (#667)

### DIFF
--- a/src/main/java/com/sports/server/auth/config/SecurityConfig.java
+++ b/src/main/java/com/sports/server/auth/config/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -77,8 +76,7 @@ public class SecurityConfig {
                         .authenticated()
                         .anyRequest().permitAll()
                 )
-                .httpBasic(basic -> basic.authenticationEntryPoint(authEntryPoint))
-                .exceptionHandling(Customizer.withDefaults())
+                .exceptionHandling(eh -> eh.authenticationEntryPoint(authEntryPoint))
                 .addFilterBefore(jwtAuthorizationFilter,
                         UsernamePasswordAuthenticationFilter.class);
 


### PR DESCRIPTION
## 이슈
closes #667

## 변경 내용
- `SecurityConfig` 에서 `httpBasic(...)` 설정 제거
- 401 응답용 `AuthenticationEntryPoint` 는 `exceptionHandling(...)` 로 이전
- 미사용된 `Customizer` import 정리

### 배경
2026-05-27 09:11~09:22 KST 사이 prod/dev 양쪽에서 HTTP 5xx 알람 firing.
운영 Loki 로그 추적 결과 다음 패턴 확인:

```
GET /manager/html  Authorization: Basic YWRtaW46MTIzNA==  (bot scan)
→ ProviderManager.authenticate(...) 가 자기 자신으로 위임되며 무한 재귀
→ java.lang.StackOverflowError
→ LogFilter 가 Throwable 을 InternalServerException 으로 wrap → 500 응답
```

원인은 `httpBasic(...)` 로 `BasicAuthenticationFilter` 가 체인에 등록되었으나,
별도 `UserDetailsService`/`AuthenticationProvider` 가 정의되어 있지 않아 Spring
Security 6.x 의 `AuthenticationConfiguration` 자기 위임 사이클로 빠진 것.

실제 인증은 `JwtAuthorizationFilter`(쿠키 `HCC_SES`) 가 담당하므로 BasicAuth 는
사용처가 없음 → 안전하게 제거 가능.