### PR TITLE
hotfix: BasicAuth 봇 스캔에서 AuthenticationManager 무한 재귀로 500 폭증 (#667)

### DIFF
--- a/src/main/java/com/sports/server/auth/config/SecurityConfig.java
+++ b/src/main/java/com/sports/server/auth/config/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -77,8 +76,7 @@ public class SecurityConfig {
                         .authenticated()
                         .anyRequest().permitAll()
                 )
-                .httpBasic(basic -> basic.authenticationEntryPoint(authEntryPoint))
-                .exceptionHandling(Customizer.withDefaults())
+                .exceptionHandling(eh -> eh.authenticationEntryPoint(authEntryPoint))
                 .addFilterBefore(jwtAuthorizationFilter,
                         UsernamePasswordAuthenticationFilter.class);
 


### PR DESCRIPTION
## 이슈
refs #667, #668

## 변경 내용
- `SecurityConfig` 에서 `httpBasic(...)` 설정 제거
- 401 응답용 `AuthenticationEntryPoint` 는 `exceptionHandling(...)` 로 이전
- 미사용된 `Customizer` import 정리

### 배경
2026-05-27 09:11~09:22 KST 사이 prod/dev 양쪽에서 HTTP 5xx 알람 firing.
운영 Loki 로그 추적 결과 다음 패턴 확인:

```
GET /manager/html  Authorization: Basic YWRtaW46MTIzNA==  (bot scan)
→ ProviderManager.authenticate(...) 자기 위임 → StackOverflowError
→ LogFilter 가 InternalServerException 으로 wrap → 500 응답
```

`JwtAuthorizationFilter`(쿠키 `HCC_SES`) 가 실 인증을 담당하므로 BasicAuth 사용처
없음 → 안전하게 제거.

## prod 직접 hotfix 사유
- develop 에 #668 로 머지 완료 (커밋 `030badf1`)
- 기존 dev > prod PR (#646) 는 다른 변경 누적 중이라 별도 hotfix 로 빠르게 prod 반영
- main → develop 역동기화는 추후 main → develop sync PR 로 흡수

## 테스트
- develop CI: #668 build SUCCESS
- 동일 패치를 main 에 적용 (단일 파일 1+/3-)
- prod 머지 후 Grafana 5xx/Exception firing 알람 미발생 + `/manager/html` BasicAuth 호출에 401 정상 응답 감시

## 영향 API
- 인증 흐름 동일 (`JwtAuthorizationFilter` 유지)
- 401 응답 포맷 동일 (entryPoint 보존)
- BasicAuth 헤더로 보호 경로 접근 시: 기존 500(StackOverflowError) → 401(정상)

## 프론트 참고
- 영향 없음