### PR TITLE
refactor: 라운드 표기 '4강' → '준결승' 명명 변경

### DIFF
--- a/src/main/java/com/sports/server/command/league/domain/Round.java
+++ b/src/main/java/com/sports/server/command/league/domain/Round.java
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum Round {
     FINAL("결승", 2),
-    SEMI_FINAL("4강", 4),
+    SEMI_FINAL("준결승", 4),
     QUARTER_FINAL("8강", 8),
     ROUND_16("16강", 16),
     PRELIMINARY("예선", 100);

--- a/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
@@ -117,7 +117,7 @@ class GameQueryControllerTest extends DocumentationTest {
                 new GameResponseDto.TeamResponse(4L, "D팀", "logo.com", 2, 0)
         );
         List<GameResponseDto> responses = List.of(
-                new GameResponseDto(1L, startTime, new QuarterResponse("FIRST_HALF", "전반전"), "4강", 4, "abc123", gameTeams1, false),
+                new GameResponseDto(1L, startTime, new QuarterResponse("FIRST_HALF", "전반전"), "준결승", 4, "abc123", gameTeams1, false),
                 new GameResponseDto(2L, startTime, new QuarterResponse("FIRST_HALF", "전반전"), "결승전", 2, "abc123", gameTeams2, false)
         );
         List<LeagueWithGamesResponse> finalResponse = List.of(
@@ -422,7 +422,7 @@ class GameQueryControllerTest extends DocumentationTest {
         );
         
         List<GameDetailResponse> responses = List.of(
-                new GameDetailResponse(1L, startTime1, "video1", new QuarterResponse("FIRST_HALF", "전반전"), "4강", gameTeams1, "FINISHED", 4, false, 1L, "춘계리그"),
+                new GameDetailResponse(1L, startTime1, "video1", new QuarterResponse("FIRST_HALF", "전반전"), "준결승", gameTeams1, "FINISHED", 4, false, 1L, "춘계리그"),
                 new GameDetailResponse(2L, startTime2, "video2", new QuarterResponse("SECOND_HALF", "후반전"), "결승", gameTeams2, "PLAYING", 2, false, 1L, "춘계리그")
         );
 


### PR DESCRIPTION
## 이슈

Slack 논의:
- 토너먼트 3-4위전을 별도 라운드로 신설하지 않고, 준결승 라운드에 같이 포함시키는 운영 정책으로 정리
- 이에 맞춰 `Round.SEMI_FINAL` 의 한글 description 을 `4강` → `준결승` 으로 변경 (네이버 스포츠 표기 관례와 동일)

## 변경 내용

- `Round.SEMI_FINAL` description: `"4강"` → `"준결승"`
- 테스트 fixture 한글 라벨 동기화

DB 영향 없음. `@Enumerated(EnumType.STRING)` 매핑이라 enum 키(`SEMI_FINAL`)만 저장되어 마이그레이션 불필요.

## 테스트

- `GameQueryControllerTest` fixture 2건 한글 라벨 갱신 (`"4강"` → `"준결승"`)
- 기존 description 기반 `Round.from(String)` lookup 동작 검증 (변경된 description 으로 매핑)

## 영향 API

응답 JSON 의 `gameName` / `round` description 필드에서 기존 `"4강"` 으로 내려가던 값이 `"준결승"` 으로 변경됨.

- 스펙테이터: `GET /games/**` 응답의 `gameName` (4강 라벨 노출 부분)
- 매니저: 게임 생성/수정 시 라운드 선택 라벨 (`POST /leagues/{leagueId}/games` 등)

요청측에서도 `Round.from(String)` 으로 매핑되므로 매니저가 description 으로 보낼 때 `"4강"` 으로 보내면 400. `"준결승"` 으로 변경해서 보내야 함.

## 프론트 참고

- 라운드 라벨로 `"4강"` 문자열을 비교/표시하는 곳 전부 `"준결승"` 으로 동기화 필요
- 라운드 dropdown / 셀렉트 옵션 라벨 갱신
- 매니저 라운드 선택 시 `"준결승"` description 으로 요청