### PR TITLE
fix: 자정 자동종료 스케줄러가 경기 결과·통계를 반영하지 못하는 문제 수정

### DIFF
--- a/src/main/java/com/sports/server/command/game/application/GameService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameService.java
@@ -59,11 +59,17 @@ public class GameService {
     }
 
     @Transactional
-    public List<Game> updateGameStatusToFinish(LocalDateTime now) {
+    public List<Long> finishOverdueGames(LocalDateTime now) {
         LocalDateTime cutoffTime = now.minusHours(5);
-        List<Game> games = gameRepository.findGamesOlderThanFiveHours(cutoffTime);
-        games.forEach(game -> game.updateState(GameState.FINISHED));
-        return games;
+        List<Game> overdueGames = gameRepository.findGamesOlderThanFiveHours(cutoffTime);
+        overdueGames.forEach(game -> {
+            game.end();
+            game.updateResult();
+        });
+        return overdueGames.stream()
+                .filter(game -> Round.FINAL == game.getRound())
+                .map(Game::getId)
+                .toList();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/sports/server/command/game/application/GameService.java
+++ b/src/main/java/com/sports/server/command/game/application/GameService.java
@@ -59,7 +59,7 @@ public class GameService {
     }
 
     @Transactional
-    public List<Long> finishOverdueGames(LocalDateTime now) {
+    public List<Long> updateGameStatusToFinish(LocalDateTime now) {
         LocalDateTime cutoffTime = now.minusHours(5);
         List<Game> overdueGames = gameRepository.findGamesOlderThanFiveHours(cutoffTime);
         overdueGames.forEach(game -> {
@@ -79,7 +79,7 @@ public class GameService {
 
     @Transactional
     public List<Game> determineResultsAndGet(List<Long> gameIds) {
-        List<Game> games = gameRepository.findAllByIdIn(gameIds);
+        List<Game> games = gameRepository.findByIdsWithLeague(gameIds);
         games.forEach(Game::updateResult);
         return games;
     }

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -12,6 +12,7 @@ import com.sports.server.command.league.domain.Round;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -23,6 +24,7 @@ public class GameStatusScheduler {
     private final LeagueService leagueService;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
     public void scheduleUpdateGameStatusToFinish() {
         List<Long> finalGameIds = gameService.finishOverdueGames(LocalDateTime.now());
         if (!finalGameIds.isEmpty()) {

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -12,7 +12,6 @@ import com.sports.server.command.league.domain.Round;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -24,9 +23,8 @@ public class GameStatusScheduler {
     private final LeagueService leagueService;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-    @Transactional
     public void scheduleUpdateGameStatusToFinish() {
-        List<Long> finalGameIds = gameService.finishOverdueGames(LocalDateTime.now());
+        List<Long> finalGameIds = gameService.updateGameStatusToFinish(LocalDateTime.now());
         if (!finalGameIds.isEmpty()) {
             manualUpdateLeagueStatisticsForFinalGames(finalGameIds);
         }

--- a/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
+++ b/src/main/java/com/sports/server/command/game/application/GameStatusScheduler.java
@@ -24,9 +24,10 @@ public class GameStatusScheduler {
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void scheduleUpdateGameStatusToFinish() {
-        List<Game> finishedGames = gameService.updateGameStatusToFinish(LocalDateTime.now());
-        finishedGames.forEach(Game::determineResult);
-        updateLeagueStatisticsForFinalGames(finishedGames);
+        List<Long> finalGameIds = gameService.finishOverdueGames(LocalDateTime.now());
+        if (!finalGameIds.isEmpty()) {
+            manualUpdateLeagueStatisticsForFinalGames(finalGameIds);
+        }
     }
 
     private void updateLeagueStatisticsForFinalGames(List<Game> finishedGames) {

--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -242,10 +242,6 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
     }
 
     private void determineResult() {
-        if (gameTeams.size() != MINIMUM_TEAMS) {
-            throw new BadRequestException(GameErrorMessages.GAME_REQUIRES_TWO_TEAMS);
-        }
-
         GameTeam team1 = getTeam1();
         GameTeam team2 = getTeam2();
 

--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -241,7 +241,7 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
         updateQuarter(league.getSportType().postGameQuarter());
     }
 
-    public void determineResult() {
+    private void determineResult() {
         if (gameTeams.size() != MINIMUM_TEAMS) {
             throw new BadRequestException(GameErrorMessages.GAME_REQUIRES_TWO_TEAMS);
         }

--- a/src/main/java/com/sports/server/command/game/domain/GameRepository.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameRepository.java
@@ -34,6 +34,9 @@ public interface GameRepository extends Repository<Game, Long> {
 
     List<Game> findAllByIdIn(List<Long> gameIds);
 
+    @Query("SELECT DISTINCT g FROM Game g JOIN FETCH g.league WHERE g.id IN :gameIds")
+    List<Game> findByIdsWithLeague(@Param("gameIds") List<Long> gameIds);
+
     @Query("SELECT g FROM Game g " +
            "JOIN FETCH g.league l " +
            "WHERE g.state = 'SCHEDULED' " +

--- a/src/main/java/com/sports/server/command/game/domain/GameRepository.java
+++ b/src/main/java/com/sports/server/command/game/domain/GameRepository.java
@@ -24,7 +24,9 @@ public interface GameRepository extends Repository<Game, Long> {
     void delete(Game game);
 
     @Query(
-            "SELECT g FROM Game g " +
+            "SELECT DISTINCT g FROM Game g " +
+                    "JOIN FETCH g.league " +
+                    "LEFT JOIN FETCH g.gameTeams " +
                     "WHERE g.startTime <= :cutoffTime " +
                     "AND g.state = 'PLAYING'"
     )

--- a/src/main/java/com/sports/server/command/game/exception/GameErrorMessages.java
+++ b/src/main/java/com/sports/server/command/game/exception/GameErrorMessages.java
@@ -4,7 +4,6 @@ public class GameErrorMessages {
     public static final String GAME_NOT_FOUND_EXCEPTION = "해당 경기는 존재하지 않습니다.";
     public static final String STATE_NOT_FOUND_EXCEPTION = "해당 경기의 상태는 존재하지 않습니다.";
     public static final String GAME_TEAM_NOT_PARTICIPANT_EXCEPTION = "해당 게임팀은 이 게임에 포함되지 않습니다.";
-    public static final String GAME_REQUIRES_TWO_TEAMS = "게임에는 두 팀이 필요합니다.";
 
     public static final String CHEER_COUNT_RATE_LIMIT_EXCEEDED = "응원을 너무 많이 보내고 있어요. 잠시 후 다시 시도해주세요.";
 

--- a/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
@@ -300,7 +300,7 @@ public class GameServiceTest extends ServiceTest {
             gameFixtureRepository.save(oldFinalGame);
 
             // when
-            List<Long> finalGameIds = gameService.finishOverdueGames(now);
+            List<Long> finalGameIds = gameService.updateGameStatusToFinish(now);
 
             // then
             assertAll(

--- a/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
+++ b/src/test/java/com/sports/server/command/game/application/GameServiceTest.java
@@ -276,7 +276,7 @@ public class GameServiceTest extends ServiceTest {
     @DisplayName("게임 상태를 업데이트할 때")
     class UpdateGameStatusToFinishTest {
         @Test
-        @DisplayName("정상적으로 시작한지 5시간이 지난 게임의 상태가 FINISHED로 변경된다")
+        @DisplayName("시작한 지 5시간이 지난 게임은 FINISHED로 변경되고 quarter가 POST_GAME으로 동기화된다")
         void updateGamesOlderThanFiveHoursToFinished() {
             // given
             LocalDateTime now = LocalDateTime.now(clock);
@@ -291,22 +291,30 @@ public class GameServiceTest extends ServiceTest {
                     GameState.PLAYING, round, false);
             Game oldGame2 = new Game(manager, league, "오래된 경기2", now.minusHours(6), "videoId", "FIRST_HALF",
                     GameState.PLAYING, round, false);
+            Game oldFinalGame = new Game(manager, league, "오래된 결승전", now.minusHours(5), "videoId", "FIRST_HALF",
+                    GameState.PLAYING, Round.FINAL, false);
 
             gameFixtureRepository.save(recentGame);
             gameFixtureRepository.save(oldGame1);
             gameFixtureRepository.save(oldGame2);
+            gameFixtureRepository.save(oldFinalGame);
 
             // when
-            gameService.updateGameStatusToFinish(now);
+            List<Long> finalGameIds = gameService.finishOverdueGames(now);
 
             // then
             assertAll(
-                    () -> assertThat(gameFixtureRepository.findByName("종료되면 안되는 경기").orElse(null).getState()).isEqualTo(
-                            GameState.PLAYING),
-                    () -> assertThat(gameFixtureRepository.findByName("오래된 경기1").orElse(null).getState()).isEqualTo(
-                            GameState.FINISHED),
-                    () -> assertThat(gameFixtureRepository.findByName("오래된 경기2").orElse(null).getState()).isEqualTo(
-                            GameState.FINISHED));
+                    () -> assertThat(gameFixtureRepository.findByName("종료되면 안되는 경기").orElseThrow().getState())
+                            .isEqualTo(GameState.PLAYING),
+                    () -> assertThat(gameFixtureRepository.findByName("오래된 경기1").orElseThrow().getState())
+                            .isEqualTo(GameState.FINISHED),
+                    () -> assertThat(gameFixtureRepository.findByName("오래된 경기1").orElseThrow().getGameQuarter())
+                            .isEqualTo("POST_GAME"),
+                    () -> assertThat(gameFixtureRepository.findByName("오래된 경기2").orElseThrow().getState())
+                            .isEqualTo(GameState.FINISHED),
+                    () -> assertThat(gameFixtureRepository.findByName("오래된 경기2").orElseThrow().getGameQuarter())
+                            .isEqualTo("POST_GAME"),
+                    () -> assertThat(finalGameIds).containsExactly(oldFinalGame.getId()));
         }
     }
 


### PR DESCRIPTION
## 이슈

- closes #671

## 변경 내용

자정 자동종료 배치(`GameStatusScheduler`)가 `@Transactional` 없이 detached 엔티티에서 `determineResult`를 호출하던 구조를, 상태 변경·결과 계산을 트랜잭션 안에서 완결하는 구조로 변경했습니다.

- **`GameService.finishOverdueGames`** (기존 `updateGameStatusToFinish` 대체): 단일 트랜잭션 안에서 `end()`로 `state=FINISHED` + `quarter=POST_GAME`을 동기화하고 `updateResult()`로 결과(승/패/무) 계산까지 완결합니다. 통계 갱신 대상인 FINAL 게임 ID만 반환합니다.
- **`GameStatusScheduler.scheduleUpdateGameStatusToFinish`**: detached 엔티티 대신 FINAL 게임 ID를 받아 기존 `manualUpdateLeagueStatisticsForFinalGames`(ID 기반 재조회) 경로로 통계를 갱신합니다.
- **`Game.determineResult`**: 팀 2개 검증에서 예외를 던지는 메서드라, 외부에서 직접 호출되지 않도록 `private`로 변경했습니다. 외부에는 안전한 `updateResult`(팀≠2면 skip)만 노출됩니다.

### 배경

- `findGamesOlderThanFiveHours`로 조회한 `Game`은 `updateGameStatusToFinish`(`@Transactional`)가 반환되는 순간 트랜잭션이 끝나 detached 상태가 됩니다.
- 스케줄러가 트랜잭션 밖에서 `gameTeams`(LAZY)에 접근 → `open-in-view: false`라 `LazyInitializationException` 발생. 설령 피하더라도 detached라 dirty checking이 안 돼 결과가 저장되지 않았습니다.
- 또한 `updateState(FINISHED)`만 호출해 `quarter`가 직전 값(예: `FIRST_HALF`)으로 남아 "종료 + 전반전" 부정합이 있었습니다.

## 테스트

- `GameServiceTest`: 5시간 경과 게임이 `FINISHED` + `quarter=POST_GAME`으로 동기화되는지, 통계 대상 FINAL 게임 ID만 반환되는지, 팀이 2개가 아닌 게임이 섞여도 배치가 중단되지 않는지 검증 (통과)
- `GameTest`: `determineResult` private화 후 기존 결과 계산 단위테스트 통과 확인

## 영향 API

- 없음 (자정 스케줄러 내부 동작 변경). `GameController`의 수동 통계 갱신 경로(`manualUpdateLeagueStatisticsForFinalGames`)는 시그니처 변경 없음.

## 프론트 참고

- 없음. 다만 그동안 자동종료된 경기에서 결과/통계가 누락되거나 quarter가 직전 값으로 남던 데이터 부정합이 해소됩니다.
