### PR TITLE
fix: 신고 없는 응원톡 무효처리 시 NPE 수정

### DIFF
--- a/src/main/java/com/sports/server/command/report/application/ReportService.java
+++ b/src/main/java/com/sports/server/command/report/application/ReportService.java
@@ -10,6 +10,7 @@ import com.sports.server.command.report.dto.ReportRequest;
 import com.sports.server.command.report.exception.ReportErrorMessage;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.exception.CustomException;
+import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.common.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,7 +34,8 @@ public class ReportService {
     public void cancel(final Long leagueId, final Long cheerTalkId, final Member manager) {
         checkPermission(leagueId, manager);
 
-        Report report = reportRepository.findByCheerTalkId(cheerTalkId);
+        Report report = reportRepository.findByCheerTalkId(cheerTalkId)
+                .orElseThrow(() -> new NotFoundException(ReportErrorMessage.REPORT_NOT_EXIST));
         report.cancel();
     }
 

--- a/src/main/java/com/sports/server/command/report/domain/ReportRepository.java
+++ b/src/main/java/com/sports/server/command/report/domain/ReportRepository.java
@@ -11,5 +11,5 @@ public interface ReportRepository extends Repository<Report, Long> {
     Optional<Report> findById(Long id);
 
     Optional<Report> findByCheerTalk(CheerTalk cheerTalk);
-    Report findByCheerTalkId(Long cheerTalkId);
+    Optional<Report> findByCheerTalkId(Long cheerTalkId);
 }

--- a/src/test/java/com/sports/server/command/report/application/ReportServiceTest.java
+++ b/src/test/java/com/sports/server/command/report/application/ReportServiceTest.java
@@ -11,6 +11,7 @@ import com.sports.server.command.report.domain.ReportState;
 import com.sports.server.command.report.dto.ReportRequest;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.exception.CustomException;
+import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.common.exception.UnauthorizedException;
 import com.sports.server.support.ServiceTest;
 import java.util.Optional;
@@ -120,7 +121,7 @@ class ReportServiceTest extends ServiceTest {
             reportService.cancel(leagueId, cheerTalkId, manager);
 
             // then
-            Report report = reportRepository.findByCheerTalkId(cheerTalkId);
+            Report report = reportRepository.findByCheerTalkId(cheerTalkId).orElseThrow();
             assertThat(report.getState()).isEqualTo(ReportState.INVALID);
         }
 
@@ -133,6 +134,17 @@ class ReportServiceTest extends ServiceTest {
             // when & then
             assertThatThrownBy(() -> reportService.cancel(leagueId, cheerTalkId, manager))
                     .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        void 신고가_없는_응원톡을_무효처리하면_예외가_발생한다() {
+            // given
+            cheerTalkId = 1L;
+            manager = entityUtils.getEntity(1L, Member.class);
+
+            // when & then
+            assertThatThrownBy(() -> reportService.cancel(leagueId, cheerTalkId, manager))
+                    .isInstanceOf(NotFoundException.class);
         }
     }
 }

--- a/src/test/java/com/sports/server/command/report/application/ReportServiceTest.java
+++ b/src/test/java/com/sports/server/command/report/application/ReportServiceTest.java
@@ -144,7 +144,8 @@ class ReportServiceTest extends ServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reportService.cancel(leagueId, cheerTalkId, manager))
-                    .isInstanceOf(NotFoundException.class);
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("해당 응원톡에 대한 신고가 존재하지 않습니다.");
         }
     }
 }


### PR DESCRIPTION
## 이슈
- closes #673

## 변경 내용
신고가 없는 응원톡을 무효처리할 때 발생하던 `NullPointerException`(→500)을 수정했습니다.

- `ReportRepository.findByCheerTalkId`: raw `Report` → `Optional<Report>` 반환으로 변경 (같은 레포 `findByCheerTalk`와 일관)
- `ReportService.cancel`: `orElseThrow(NotFoundException(REPORT_NOT_EXIST))`로 처리 — 이미 정의돼 있으나 미사용이던 `ReportErrorMessage.REPORT_NOT_EXIST`를 활용, 500 → 404로 정정

## 테스트
- `ReportServiceTest`: 신고가 없는 응원톡(픽스처 cheerTalk 1)을 무효처리하면 `NotFoundException`이 발생하는지 검증 추가 (통과)

## 영향 API
- `PATCH /reports/{leagueId}/{cheerTalkId}/cancel` — 신고가 없는 cheerTalkId 요청 시 응답이 500 → **404**로 변경

## 프론트 참고
- 신고가 없는(또는 잘못된) cheerTalkId로 무효처리 호출 시 500 대신 404를 받습니다. 어드민 UI에서 해당 케이스 처리 시 참고해 주세요.

## 참고 (별도 후속)
- `Report.cheerTalk`의 `@JoinColumn(unique=true)`가 `ddl-auto: none`이라 실제 DB 제약 없이 죽어 있어, 동시 중복 신고 시 `IncorrectResultSizeDataAccessException` 가능 — 마이그레이션이 얽혀 이번 범위에서 분리.
