### PR TITLE
fix: league statistics 조회 시 team LAZY loading으로 인한 EntityNotFoundException 수정

### DIFF
--- a/src/main/java/com/sports/server/query/repository/LeagueStatisticsQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueStatisticsQueryRepository.java
@@ -10,12 +10,14 @@ import java.util.Optional;
 
 public interface LeagueStatisticsQueryRepository extends Repository<LeagueStatistics, Long> {
 
-    @Query("SELECT ls FROM LeagueStatistics ls " +
-            "LEFT JOIN FETCH ls.firstWinnerTeam " +
-            "LEFT JOIN FETCH ls.secondWinnerTeam " +
-            "LEFT JOIN FETCH ls.mostCheeredTeam " +
-            "LEFT JOIN FETCH ls.mostCheerTalksTeam " +
-            "WHERE ls.league.id = :leagueId")
+    @Query("""
+            SELECT ls FROM LeagueStatistics ls
+            LEFT JOIN FETCH ls.firstWinnerTeam
+            LEFT JOIN FETCH ls.secondWinnerTeam
+            LEFT JOIN FETCH ls.mostCheeredTeam
+            LEFT JOIN FETCH ls.mostCheerTalksTeam
+            WHERE ls.league.id = :leagueId
+            """)
     Optional<LeagueStatistics> findByLeagueId(@Param("leagueId") Long leagueId);
 
     @Query("SELECT ls FROM LeagueStatistics ls JOIN FETCH ls.league " +

--- a/src/main/java/com/sports/server/query/repository/LeagueStatisticsQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/LeagueStatisticsQueryRepository.java
@@ -10,7 +10,13 @@ import java.util.Optional;
 
 public interface LeagueStatisticsQueryRepository extends Repository<LeagueStatistics, Long> {
 
-    Optional<LeagueStatistics> findByLeagueId(Long leagueId);
+    @Query("SELECT ls FROM LeagueStatistics ls " +
+            "LEFT JOIN FETCH ls.firstWinnerTeam " +
+            "LEFT JOIN FETCH ls.secondWinnerTeam " +
+            "LEFT JOIN FETCH ls.mostCheeredTeam " +
+            "LEFT JOIN FETCH ls.mostCheerTalksTeam " +
+            "WHERE ls.league.id = :leagueId")
+    Optional<LeagueStatistics> findByLeagueId(@Param("leagueId") Long leagueId);
 
     @Query("SELECT ls FROM LeagueStatistics ls JOIN FETCH ls.league " +
             "WHERE ls.firstWinnerTeam.id IN :teamIds OR ls.secondWinnerTeam.id IN :teamIds")


### PR DESCRIPTION
## 이슈
closes #675

## 변경 내용
- `LeagueStatisticsQueryRepository.findByLeagueId()`에 `LEFT JOIN FETCH` 추가
- `firstWinnerTeam`, `secondWinnerTeam`, `mostCheeredTeam`, `mostCheerTalksTeam` 4개 team 연관관계를 즉시 로드하도록 변경
- 참조 팀이 DB에 없거나 null인 경우에도 `EntityNotFoundException` 없이 null로 안전 처리

## 테스트
- 기존 `LeagueStatisticsServiceTest` 통과 확인

## 영향받는 API
| API | 변경 |
|-----|------|
| `GET /leagues/{leagueId}/statistics` | LAZY loading → JOIN FETCH로 변경, 동작 결과 동일 |