### PR TITLE
chore: 조회 성능 개선을 위한 복합 인덱스 추가

### DIFF
--- a/src/main/resources/db/migration/prod/V19__add_composite_indexes.sql
+++ b/src/main/resources/db/migration/prod/V19__add_composite_indexes.sql
@@ -1,4 +1,4 @@
-ALTER TABLE games ADD INDEX idx_games_state_league (state, league_id);
+ALTER TABLE games ADD INDEX idx_games_league_state (league_id, state);
 ALTER TABLE cheer_talks ADD INDEX idx_cheer_talks_gameteam_status_created (game_team_id, block_status, created_at DESC, id DESC);
-ALTER TABLE leagues ADD INDEX idx_leagues_deleted_org_sport_start_end (is_deleted, organization_id, sport_type, start_at, end_at);
+ALTER TABLE leagues ADD INDEX idx_leagues_org_sport_start_end (organization_id, sport_type, start_at, end_at);
 ALTER TABLE timelines ADD INDEX idx_timelines_game_type (game_id, type);

--- a/src/main/resources/db/migration/prod/V19__add_composite_indexes.sql
+++ b/src/main/resources/db/migration/prod/V19__add_composite_indexes.sql
@@ -1,0 +1,4 @@
+ALTER TABLE games ADD INDEX idx_games_league_state (league_id, state);
+ALTER TABLE cheer_talks ADD INDEX idx_cheer_talks_gameteam_status_created (game_team_id, block_status, created_at DESC, id DESC);
+ALTER TABLE leagues ADD INDEX idx_leagues_org_sport_start_end (organization_id, sport_type, start_at, end_at);
+ALTER TABLE timelines ADD INDEX idx_timelines_game_type (game_id, type);

--- a/src/main/resources/db/migration/prod/V19__add_composite_indexes.sql
+++ b/src/main/resources/db/migration/prod/V19__add_composite_indexes.sql
@@ -1,4 +1,4 @@
-ALTER TABLE games ADD INDEX idx_games_league_state (league_id, state);
+ALTER TABLE games ADD INDEX idx_games_state_league (state, league_id);
 ALTER TABLE cheer_talks ADD INDEX idx_cheer_talks_gameteam_status_created (game_team_id, block_status, created_at DESC, id DESC);
-ALTER TABLE leagues ADD INDEX idx_leagues_org_sport_start_end (organization_id, sport_type, start_at, end_at);
+ALTER TABLE leagues ADD INDEX idx_leagues_deleted_org_sport_start_end (is_deleted, organization_id, sport_type, start_at, end_at);
 ALTER TABLE timelines ADD INDEX idx_timelines_game_type (game_id, type);


### PR DESCRIPTION
## 이슈

closes #677

## 변경 내용

`V19__add_composite_indexes.sql` 추가 — 다중 조건 필터·커서 페이징에 쓰이는 복합 인덱스 4개 추가

| 테이블 | 인덱스 | 대상 쿼리 |
|--------|--------|-----------|
| `games` | `(league_id, state)` | `WHERE league_id IN ? AND state = 'PLAYING'` |
| `cheer_talks` | `(game_team_id, block_status, created_at DESC, id DESC)` | 커서 페이징 + 상태 필터 |
| `leagues` | `(organization_id, sport_type, start_at, end_at)` | `findInProgressLeagues`, `findLeaguesByLatestStartAt` |
| `timelines` | `(game_id, type)` | 게임별 ScoreTimeline 타입 필터링 |

기존 UNIQUE 복합 인덱스(`uc_game_team`, `uc_league_team`, `uc_lineup_player`)와 중복 없음.

## 테스트

- DDL 단독 변경으로 응답 변화 없음
- 로컬 Flyway 마이그레이션 정상 실행 확인

## 영향 API

없음

## 프론트 참고

없음