### PR TITLE
perf: 쿼리 최적화 - 중복 Game 조회 제거 / FETCH JOIN 보강 / COUNT 쿼리 교체

### DIFF
--- a/src/main/java/com/sports/server/query/application/GameQueryService.java
+++ b/src/main/java/com/sports/server/query/application/GameQueryService.java
@@ -47,7 +47,9 @@ public class GameQueryService {
         entityUtils.getEntity(teamId, Team.class);
 
         List<Game> games = gameQueryRepository.findGamesByTeamId(teamId);
-        return getGameDetailResponses(games);
+        return games.stream()
+                .map(game -> new GameDetailResponse(game, game.getGameTeams()))
+                .toList();
     }
 
     public CursorPageResponse<LeagueWithGamesResponse> getAllGames(final GamesQueryRequestDto queryRequestDto,

--- a/src/main/java/com/sports/server/query/application/LeagueQueryService.java
+++ b/src/main/java/com/sports/server/query/application/LeagueQueryService.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -145,7 +146,7 @@ public class LeagueQueryService {
 
     public LeagueDetailResponse findLeagueDetail(Long leagueId) {
         return leagueQueryRepository.findById(leagueId)
-                .map(league -> LeagueDetailResponse.of(league, teamDynamicRepository.findByLeagueAndRound(league, null).size()))
+                .map(league -> LeagueDetailResponse.of(league, (int) teamDynamicRepository.countByLeague(league)))
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 리그입니다"));
     }
 
@@ -255,19 +256,16 @@ public class LeagueQueryService {
 
     public List<RecentLeagueGamesResponse> findRecentLeaguesGames(Long organizationId, SportType sportType) {
         LocalDateTime now = LocalDateTime.now();
-        List<League> recentLeagues = getRecentLeagues(now, organizationId, sportType);
-        if (recentLeagues.isEmpty()) {
+        LeaguesWithGames result = getRecentLeaguesWithGames(now, organizationId, sportType);
+        if (result.leagues().isEmpty()) {
             return Collections.emptyList();
         }
 
-        List<Long> leagueIds = recentLeagues.stream().map(League::getId).toList();
-        List<Game> games = gameQueryRepository.findAllByLeagueIds(leagueIds);
-
-        Map<Long, List<GameTeam>> teamsByGameId = getTeamsByGameId(games);
-        Map<League, List<Game>> gamesByLeague = games.stream()
+        Map<Long, List<GameTeam>> teamsByGameId = getTeamsByGameId(result.games());
+        Map<League, List<Game>> gamesByLeague = result.games().stream()
                 .collect(Collectors.groupingBy(Game::getLeague));
 
-        return recentLeagues.stream()
+        return result.leagues().stream()
                 .map(league -> toRecentLeagueGamesResponse(
                         league,
                         gamesByLeague.getOrDefault(league, Collections.emptyList()),
@@ -277,12 +275,14 @@ public class LeagueQueryService {
                 .toList();
     }
 
-    private List<League> getRecentLeagues(LocalDateTime now, Long organizationId, SportType sportType) {
+    private record LeaguesWithGames(List<League> leagues, List<Game> games) {}
+
+    private LeaguesWithGames getRecentLeaguesWithGames(LocalDateTime now, Long organizationId, SportType sportType) {
         List<League> leaguesInDateRange = leagueQueryRepository.findInProgressLeagues(now, organizationId, sportType);
         if (!leaguesInDateRange.isEmpty()) {
-            List<Long> leagueIds = leaguesInDateRange.stream().map(League::getId).toList();
-            List<Game> games = gameQueryRepository.findAllByLeagueIds(leagueIds);
-            Map<Long, List<Game>> gamesByLeagueId = games.stream()
+            List<Long> candidateLeagueIds = leaguesInDateRange.stream().map(League::getId).toList();
+            List<Game> candidateGames = gameQueryRepository.findAllByLeagueIds(candidateLeagueIds);
+            Map<Long, List<Game>> gamesByLeagueId = candidateGames.stream()
                     .collect(Collectors.groupingBy(game -> game.getLeague().getId()));
 
             List<League> inProgressLeagues = leaguesInDateRange.stream()
@@ -290,10 +290,22 @@ public class LeagueQueryService {
                     .toList();
 
             if (!inProgressLeagues.isEmpty()) {
-                return inProgressLeagues;
+                Set<Long> inProgressLeagueIds = inProgressLeagues.stream()
+                        .map(League::getId)
+                        .collect(Collectors.toSet());
+                List<Game> filteredGames = candidateGames.stream()
+                        .filter(g -> inProgressLeagueIds.contains(g.getLeague().getId()))
+                        .toList();
+                return new LeaguesWithGames(inProgressLeagues, filteredGames);
             }
         }
-        return leagueQueryRepository.findLeaguesByLatestStartAt(organizationId, sportType);
+
+        List<League> latestLeagues = leagueQueryRepository.findLeaguesByLatestStartAt(organizationId, sportType);
+        if (latestLeagues.isEmpty()) {
+            return new LeaguesWithGames(Collections.emptyList(), Collections.emptyList());
+        }
+        List<Long> latestLeagueIds = latestLeagues.stream().map(League::getId).toList();
+        return new LeaguesWithGames(latestLeagues, gameQueryRepository.findAllByLeagueIds(latestLeagueIds));
     }
 
     private boolean isLeagueInProgress(List<Game> games) {

--- a/src/main/java/com/sports/server/query/repository/GameQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/GameQueryRepository.java
@@ -58,7 +58,7 @@ public interface GameQueryRepository extends Repository<Game, Long> {
     List<GameTeamGameInfoDto> findGameInfoByGameTeamIds(@Param("gameTeamIds") List<Long> gameTeamIds);
 
     @Query(
-            "SELECT DISTINCT g FROM Game g "
+            "SELECT g FROM Game g "
                     + "JOIN FETCH g.league l "
                     + "JOIN FETCH g.gameTeams gt "
                     + "JOIN FETCH gt.team "

--- a/src/main/java/com/sports/server/query/repository/GameQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/GameQueryRepository.java
@@ -58,11 +58,16 @@ public interface GameQueryRepository extends Repository<Game, Long> {
     List<GameTeamGameInfoDto> findGameInfoByGameTeamIds(@Param("gameTeamIds") List<Long> gameTeamIds);
 
     @Query(
-            "SELECT g FROM Game g "
+            "SELECT DISTINCT g FROM Game g "
                     + "JOIN FETCH g.league l "
-                    + "WHERE EXISTS (SELECT 1 FROM GameTeam gt WHERE gt.game = g "
-                    + "AND gt.team.id = :teamId)"
-                    + "ORDER BY g.id DESC ")
+                    + "JOIN FETCH g.gameTeams gt "
+                    + "JOIN FETCH gt.team "
+                    + "WHERE g.id IN ("
+                    + "  SELECT g2.id FROM Game g2 "
+                    + "  JOIN g2.gameTeams gt2 "
+                    + "  WHERE gt2.team.id = :teamId"
+                    + ") "
+                    + "ORDER BY g.id DESC")
     List<Game> findGamesByTeamId(@Param("teamId") Long teamId);
 
     @Query("SELECT g FROM Game g " +

--- a/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepository.java
@@ -12,6 +12,8 @@ public interface TeamQueryDynamicRepository {
 
     List<LeagueTeam> findByLeagueAndRound(League league, Integer roundNumber);
 
+    long countByLeague(League league);
+
     List<Team> findAllByUnitsAndSportType(List<Unit> units, SportType sportType, Long organizationId);
 
     List<Unit> findDistinctUnitsBySportTypeAndOrganizationId(SportType sportType, Long organizationId);

--- a/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
@@ -73,11 +73,12 @@ public class TeamQueryDynamicRepositoryImpl implements TeamQueryDynamicRepositor
 
     @Override
     public long countByLeague(final League league) {
-        return jpaQueryFactory
+        Long count = jpaQueryFactory
                 .select(leagueTeam.count())
                 .from(leagueTeam)
                 .where(leagueTeam.league.eq(league))
                 .fetchOne();
+        return count != null ? count : 0L;
     }
 
     @Override

--- a/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
+++ b/src/main/java/com/sports/server/query/repository/TeamQueryDynamicRepositoryImpl.java
@@ -72,6 +72,15 @@ public class TeamQueryDynamicRepositoryImpl implements TeamQueryDynamicRepositor
     }
 
     @Override
+    public long countByLeague(final League league) {
+        return jpaQueryFactory
+                .select(leagueTeam.count())
+                .from(leagueTeam)
+                .where(leagueTeam.league.eq(league))
+                .fetchOne();
+    }
+
+    @Override
     public List<Unit> findDistinctUnitsBySportTypeAndOrganizationId(final SportType sportType, final Long organizationId) {
         return jpaQueryFactory
                 .select(team.unit).distinct()


### PR DESCRIPTION
## 이슈
closes #679

## 변경 내용

### 1. `findRecentLeaguesGames` 중복 Game 조회 제거
`getRecentLeagues()` 내부와 `findRecentLeaguesGames()`에서 동일 `leagueIds`로 `findAllByLeagueIds`를 2회 호출하던 문제를 수정합니다.

- `getRecentLeagues` → `getRecentLeaguesWithGames` 로 변경, `LeaguesWithGames(leagues, games)` record 반환
- 진행 중인 리그 경로: DB 조회 2회 → 1회
- 폴백 경로(`latestStartAt`): 기존과 동일하게 1회

### 2. `findGamesByTeamId` FETCH JOIN 보강
`league`만 FETCH JOIN하고 `gameTeams`를 로드하지 않아 `getAllGamesDetailByTeam` 호출 시 `findAllByGameIds` 추가 조회가 발생하던 문제를 수정합니다.

- `JOIN FETCH g.gameTeams gt` + `JOIN FETCH gt.team` 추가
- WHERE 조건을 서브쿼리로 분리해 상대팀 GameTeam까지 정상 로드
- `getAllGamesDetailByTeam`에서 `game.getGameTeams()` 직접 사용, 추가 조회 제거

### 3. `findLeagueDetail` COUNT 쿼리 교체
`teamDynamicRepository.findByLeagueAndRound(league, null).size()` — 전체 목록을 가져와 size() 호출하던 부분을 COUNT 쿼리로 교체합니다.

- `TeamQueryDynamicRepository`에 `countByLeague(League)` 추가
- `findLeagueDetail`에서 COUNT 쿼리 사용

## 테스트
- `LeagueQueryServiceTest`, `GameQueryServiceTest` 통과 확인

## 영향 API
- `GET /leagues/recent-games`
- `GET /leagues/{leagueId}`
- `GET /games?teamId={teamId}`

## 프론트 참고
없음