### PR TITLE
chore: 미사용 jjwt 제거 및 auth0 java-jwt 3.19.1 → 4.4.0 업그레이드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,8 +78,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-test'
 
     // jwt
-    implementation 'io.jsonwebtoken:jjwt:0.9.1'
-    implementation 'com.auth0:java-jwt:3.19.1'
+    implementation 'com.auth0:java-jwt:4.4.0'
 
     // aws
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'


### PR DESCRIPTION
## 이슈

closes #681

## 변경 내용

- `io.jsonwebtoken:jjwt:0.9.1` 제거
  - 코드베이스 전체에서 `import io.jsonwebtoken` 사용 없음 (데드 의존성)
- `com.auth0:java-jwt` 3.19.1 → 4.4.0 업그레이드
  - 실제 사용 중인 유일한 JWT 라이브러리
  - `JwtUtil.java` API (`JWT.create()`, `JWT.require()`, `DecodedJWT`, `Claim`) 호환성 확인

## 테스트

- `compileJava` / `compileTestJava` 빌드 성공

## 영향 API

없음 (의존성 정리만)

## 프론트 참고

없음