### PR TITLE
fix: GET /leagues/{leagueId}/statistics 소프트 삭제 팀 참조 시 NPE 방지

### DIFF
--- a/src/main/java/com/sports/server/query/dto/response/LeagueTeamResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueTeamResponse.java
@@ -23,6 +23,9 @@ public record LeagueTeamResponse(
     }
 
     public static LeagueTeamResponse ofWithCheerCount(final LeagueTeam leagueTeam) {
+        if (leagueTeam == null) {
+            return null;
+        }
         return new LeagueTeamResponse(
                 leagueTeam.getTeam().getId(),
                 leagueTeam.getId(),
@@ -35,6 +38,9 @@ public record LeagueTeamResponse(
     }
 
     public static LeagueTeamResponse ofWithTotalTalkCount(final LeagueTeam leagueTeam) {
+        if (leagueTeam == null) {
+            return null;
+        }
         return new LeagueTeamResponse(
                 leagueTeam.getTeam().getId(),
                 leagueTeam.getId(),


### PR DESCRIPTION
## 이슈

closes #683

## 변경 내용

`LeagueTeamResponse.ofWithCheerCount` / `ofWithTotalTalkCount` 에 null 가드 추가.

`mostCheeredTeam` / `mostCheerTalksTeam` 에 해당하는 팀이 소프트 삭제되어 `findLeagueTeamFor()` 가 null 을 반환할 때 NPE 가 발생하던 문제를 수정. null 반환 시 해당 필드는 응답에서 제외(`@JsonInclude(NON_NULL)`).

## 배경

- `Team` 에 `@Where(clause = "is_deleted = 0")` 적용 → 소프트 삭제 팀 lazy load 시 `EntityNotFoundException`
- DB FK 를 NULL 로 패치해도 `ofWithCheerCount(null)` → NPE 연속 발생
- 이 PR 은 같은 상황이 재발해도 안전하게 처리되도록 방어

## 즉시 조치 (배포 전 완료)

- prod DB `league_statistics` / `league_teams` 에서 삭제 팀(id=73) 참조 제거
- 500 → 404("통계 데이터 없음") 전환 완료

## 테스트

- 컴파일 성공 확인
- null 입력 시 null 반환, 정상 입력 시 기존 동작 동일

## 영향 API

- `GET /leagues/{leagueId}/statistics`

## 프론트 참고

없음 (`mostCheeredTeam` / `mostCheerTalksTeam` 필드가 null 일 때 응답에서 제외되는 기존 동작 유지)