### PR TITLE
fix: MissingServletRequestParameterException 400 처리 추가 (#686)

### DIFF
--- a/src/main/java/com/sports/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/sports/server/common/advice/ControllerExceptionAdvice.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.security.core.AuthenticationException;
@@ -61,6 +62,13 @@ public class ControllerExceptionAdvice {
         alertService.sendErrorAlert(request.getRequestURI(), request.getMethod(), e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.of("서버 오류가 발생했습니다."));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected ResponseEntity<ErrorResponse> handleMissingRequestParam(MissingServletRequestParameterException e, HttpServletRequest request) {
+        logClientError(request, HttpStatus.BAD_REQUEST, e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.of(e.getParameterName() + " 파라미터가 필요합니다."));
     }
 
     @ExceptionHandler(BindException.class)


### PR DESCRIPTION
## 이슈
closes #686

## 변경 내용
`ControllerExceptionAdvice`에 `MissingServletRequestParameterException` 전용 핸들러 추가

**기존**: 파라미터 누락 → catch-all `Exception` 핸들러 → 500 + `alertService.sendErrorAlert()` 호출
**변경**: 파라미터 누락 → 전용 핸들러 → 400 Bad Request (알림 없음)

## 테스트
- 기존 빌드/컴파일 통과 확인

## 영향 API
- `GET /games/search` — `year`/`month` 누락 시 응답 코드 500 → 400

## 프론트 참고
기존에 파라미터를 정상적으로 보내던 경우 영향 없음