### PR TITLE
refactor: 응원톡/응원 카운트 rate limiter 캐시 maximumSize 힙 예산 기반 재산정

### DIFF
--- a/src/main/java/com/sports/server/command/cheertalk/infra/CaffeineCheerTalkRateLimiter.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/CaffeineCheerTalkRateLimiter.java
@@ -19,13 +19,13 @@ public class CaffeineCheerTalkRateLimiter implements CheerTalkRateLimiter {
     private static final long RATE_WINDOW_NANOS = TimeUnit.SECONDS.toNanos(60);
     // window의 1.5배 — 경계 구간 안전 버퍼
     private static final long RATE_TTL_SECONDS = 90L;
-    private static final long RATE_MAX_SIZE = 50_000L;
+    private static final long RATE_MAX_SIZE = 10_000L;
 
     private static final int DEDUP_LIMIT = 3;
     private static final long DEDUP_WINDOW_NANOS = TimeUnit.SECONDS.toNanos(3);
     // window의 2배 — 경계 구간 안전 버퍼
     private static final long DEDUP_TTL_SECONDS = 6L;
-    private static final long DEDUP_MAX_SIZE = 100_000L;
+    private static final long DEDUP_MAX_SIZE = 20_000L;
 
     private static final String UNKNOWN_CLIENT = "unknown";
 

--- a/src/main/java/com/sports/server/command/game/infra/CaffeineCheerCountRateLimiter.java
+++ b/src/main/java/com/sports/server/command/game/infra/CaffeineCheerCountRateLimiter.java
@@ -18,7 +18,7 @@ public class CaffeineCheerCountRateLimiter implements CheerCountRateLimiter {
     private static final long RATE_WINDOW_NANOS = TimeUnit.SECONDS.toNanos(60);
     // window의 1.5배 — 경계 구간 안전 버퍼
     private static final long RATE_TTL_SECONDS = 90L;
-    private static final long RATE_MAX_SIZE = 50_000L;
+    private static final long RATE_MAX_SIZE = 10_000L;
 
     private static final String UNKNOWN_CLIENT = "unknown";
 


### PR DESCRIPTION
## 관련 이슈
- #691

## 변경 내용
`CaffeineCheerTalkRateLimiter`(R1 50,000 / R2 dedup 100,000)와 `CaffeineCheerCountRateLimiter`(50,000)의 `maximumSize`가 도입 시점(#616, #617)부터 근거 없이 설정되어 있음을 확인, 힙 예산 기반으로 재산정.

- `CaffeineCheerTalkRateLimiter.RATE_MAX_SIZE`: 50,000 → 10,000
- `CaffeineCheerTalkRateLimiter.DEDUP_MAX_SIZE`: 100,000 → 20,000
- `CaffeineCheerCountRateLimiter.RATE_MAX_SIZE`: 50,000 → 10,000

### 왜 수정했는가
- 커밋 히스토리·PR(#616, #617, #628) 본문·리뷰 코멘트를 모두 확인했으나 rate limit 임계값(120/min, 60/min)에 대한 정책 근거는 남아있는 반면, **캐시 `maximumSize` 숫자에 대한 근거는 어디에도 없었음** — 도입 당시의 매직넘버
- 현재 서버는 `t3.small`(총 메모리 2GiB, 힙 배분 약 1GB~1.2GB)에서 동작. 기존 값 기준 워스트케이스 메모리는 R1 ~180MB + R2 ~90MB = **~270MB (힙의 ~27%)**
- 이 캐시들은 트래픽 폭증(=봇 스팸) 상황에서 커지는 구조라, 서버가 이미 부하받는 순간에 GC 압박·OOM 리스크까지 겹칠 위험이 있음. `t3.small`은 버스터블(CPU 크레딧 기반) 인스턴스라 GC 부하 증가가 CPU 크레딧 소진과 겹칠 수도 있음

### 판정 근거
```
maximumSize = (피크 시 동시 활성 방문자 수 추정치) × (안전 버퍼 5~10배)
→ 이 값 × entry당 워스트케이스 메모리가 힙 예산 안에 들어오는지 검증
```
- 피크 시(교내 체육대회 등) 동시 활성 방문자 추정치: 수백~1,000명
- entry당 워스트케이스 메모리: R1 ~3.6KB(boxed `Long` 120개가 대부분), R2 ~0.9KB
- R1: 버퍼 10배 → 10,000 (워스트케이스 ~36MB)
- R2: 방문자×문구 조합이라 카디널리티가 더 커서 20,000 (워스트케이스 ~18MB)
- 재산정 후 합계 워스트케이스: **~54MB (힙의 ~5%)**

### 트레이드오프
- `VisitorId`는 쿠키 기반이라 클라이언트가 통제 가능한 식별자. maximumSize를 낮추면 봇이 매 요청마다 새 식별자로 캐시를 채워도 메모리 사용량은 예측 가능한 범위로 묶이지만, 이건 "식별자 회전을 통한 rate limit 우회 자체"를 막는 건 아니고 그건 이슈 #615의 1단 방어(nginx IP 기반 limit_req)가 담당하는 별개 영역
- 버퍼가 너무 적으면 실제 피크가 추정치를 초과할 때 caffeine의 용량 기반 eviction으로 활성 사용자의 카운터가 조기 초기화될 수 있어, 5~10배 버퍼를 확보함