### PR TITLE
feat: 타임라인 조회에 record별 삭제 가능 여부 제공 (#698)

### DIFF
--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -11,7 +11,7 @@ import com.sports.server.command.timeline.domain.GameProgressTimelineRepository;
 import com.sports.server.command.timeline.domain.GameProgressType;
 import com.sports.server.command.timeline.domain.ScoreTimeline;
 import com.sports.server.command.timeline.domain.Timeline;
-import com.sports.server.command.timeline.domain.TimelineDeletability;
+import com.sports.server.command.timeline.domain.TimelineDeletabilityEvaluator;
 import com.sports.server.command.timeline.domain.TimelineCreatedEvent;
 import com.sports.server.command.timeline.domain.TimelineRepository;
 import com.sports.server.command.timeline.dto.TimelineRequest;
@@ -166,14 +166,14 @@ public class TimelineService {
     }
 
     private void validateMiddleDeletable(Game game, Timeline target, List<Timeline> subsequents) {
-        TimelineDeletability.Result result = TimelineDeletability.evaluateMiddle(game.getState(), target, subsequents);
+        TimelineDeletabilityEvaluator.Result result = TimelineDeletabilityEvaluator.evaluateMiddle(game.getState(), target, subsequents);
         if (!result.deletable()) {
             throw new CustomException(statusOf(result.reason()), result.reasonMessage());
         }
     }
 
-    private HttpStatus statusOf(TimelineDeletability.Reason reason) {
-        if (reason == TimelineDeletability.Reason.INCONSISTENT_PROGRESS_STATE) {
+    private HttpStatus statusOf(TimelineDeletabilityEvaluator.Reason reason) {
+        if (reason == TimelineDeletabilityEvaluator.Reason.INCONSISTENT_PROGRESS_STATE) {
             return HttpStatus.INTERNAL_SERVER_ERROR;
         }
         return HttpStatus.BAD_REQUEST;

--- a/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
+++ b/src/main/java/com/sports/server/command/timeline/application/TimelineService.java
@@ -3,17 +3,15 @@ package com.sports.server.command.timeline.application;
 import com.sports.server.command.game.application.GameStatusScheduler;
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.GameRepository;
-import com.sports.server.command.game.domain.GameState;
 import com.sports.server.command.game.domain.GameTeam;
-import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.league.domain.Quarter;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.timeline.domain.GameProgressTimeline;
 import com.sports.server.command.timeline.domain.GameProgressTimelineRepository;
 import com.sports.server.command.timeline.domain.GameProgressType;
-import com.sports.server.command.timeline.domain.ReplacementTimeline;
 import com.sports.server.command.timeline.domain.ScoreTimeline;
 import com.sports.server.command.timeline.domain.Timeline;
+import com.sports.server.command.timeline.domain.TimelineDeletability;
 import com.sports.server.command.timeline.domain.TimelineCreatedEvent;
 import com.sports.server.command.timeline.domain.TimelineRepository;
 import com.sports.server.command.timeline.dto.TimelineRequest;
@@ -30,8 +28,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 
 @Slf4j
@@ -170,32 +166,17 @@ public class TimelineService {
     }
 
     private void validateMiddleDeletable(Game game, Timeline target, List<Timeline> subsequents) {
-        if (game.getState() != GameState.PLAYING) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, TimelineErrorMessage.MIDDLE_DELETE_ONLY_WHILE_PLAYING);
-        }
-        if (target instanceof GameProgressTimeline) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, TimelineErrorMessage.PROGRESS_TIMELINE_NOT_LAST);
-        }
-        if (subsequents.stream().anyMatch(Timeline::isGameEnd)) {
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, TimelineErrorMessage.INCONSISTENT_PROGRESS_STATE);
-        }
-        if (target instanceof ReplacementTimeline replacement) {
-            validateReplacementNotReferenced(replacement, subsequents);
+        TimelineDeletability.Result result = TimelineDeletability.evaluateMiddle(game.getState(), target, subsequents);
+        if (!result.deletable()) {
+            throw new CustomException(statusOf(result.reason()), result.reasonMessage());
         }
     }
 
-    private void validateReplacementNotReferenced(ReplacementTimeline target, List<Timeline> subsequents) {
-        Set<Long> replacementPlayerIds = target.getRelatedLineupPlayers().stream()
-                .map(LineupPlayer::getId)
-                .collect(Collectors.toSet());
-
-        boolean referenced = subsequents.stream()
-                .flatMap(timeline -> timeline.getRelatedLineupPlayers().stream())
-                .anyMatch(player -> replacementPlayerIds.contains(player.getId()));
-
-        if (referenced) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, TimelineErrorMessage.REPLACEMENT_PLAYER_HAS_LATER_RECORDS);
+    private HttpStatus statusOf(TimelineDeletability.Reason reason) {
+        if (reason == TimelineDeletability.Reason.INCONSISTENT_PROGRESS_STATE) {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
         }
+        return HttpStatus.BAD_REQUEST;
     }
 
     private void rollbackWithUnderflowLog(Timeline timeline) {

--- a/src/main/java/com/sports/server/command/timeline/domain/TimelineDeletability.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/TimelineDeletability.java
@@ -1,0 +1,104 @@
+package com.sports.server.command.timeline.domain;
+
+import com.sports.server.command.game.domain.GameState;
+import com.sports.server.command.game.domain.LineupPlayer;
+import com.sports.server.command.timeline.exception.TimelineErrorMessage;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class TimelineDeletability {
+
+    private TimelineDeletability() {
+    }
+
+    public enum Reason {
+        MIDDLE_DELETE_ONLY_WHILE_PLAYING(TimelineErrorMessage.MIDDLE_DELETE_ONLY_WHILE_PLAYING),
+        PROGRESS_TIMELINE_NOT_LAST(TimelineErrorMessage.PROGRESS_TIMELINE_NOT_LAST),
+        INCONSISTENT_PROGRESS_STATE(TimelineErrorMessage.INCONSISTENT_PROGRESS_STATE),
+        REPLACEMENT_PLAYER_HAS_LATER_RECORDS(TimelineErrorMessage.REPLACEMENT_PLAYER_HAS_LATER_RECORDS);
+
+        private final String message;
+
+        Reason(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    public record Result(boolean deletable, Reason reason) {
+
+        public static Result allowed() {
+            return new Result(true, null);
+        }
+
+        public static Result blocked(Reason reason) {
+            return new Result(false, reason);
+        }
+
+        public String reasonMessage() {
+            return reason == null ? null : reason.getMessage();
+        }
+    }
+
+    public static Map<Long, Result> evaluate(GameState gameState, List<Timeline> timelines) {
+        List<Timeline> ordered = timelines.stream()
+                .sorted(Comparator.comparing(Timeline::getId))
+                .toList();
+
+        Map<Long, Result> results = new HashMap<>();
+        Set<Long> laterPlayerIds = new HashSet<>();
+        boolean gameEndLater = false;
+
+        for (int i = ordered.size() - 1; i >= 0; i--) {
+            Timeline timeline = ordered.get(i);
+            boolean isLast = i == ordered.size() - 1;
+
+            results.put(timeline.getId(), isLast
+                    ? Result.allowed()
+                    : evaluateMiddle(gameState, timeline, gameEndLater, laterPlayerIds));
+
+            gameEndLater = gameEndLater || timeline.isGameEnd();
+            timeline.getRelatedLineupPlayers().stream()
+                    .map(LineupPlayer::getId)
+                    .forEach(laterPlayerIds::add);
+        }
+        return results;
+    }
+
+    public static Result evaluateMiddle(GameState gameState, Timeline target, List<Timeline> subsequents) {
+        boolean gameEndLater = subsequents.stream().anyMatch(Timeline::isGameEnd);
+        Set<Long> laterPlayerIds = subsequents.stream()
+                .flatMap(timeline -> timeline.getRelatedLineupPlayers().stream())
+                .map(LineupPlayer::getId)
+                .collect(Collectors.toSet());
+        return evaluateMiddle(gameState, target, gameEndLater, laterPlayerIds);
+    }
+
+    private static Result evaluateMiddle(GameState gameState, Timeline target,
+                                         boolean gameEndLater, Set<Long> laterPlayerIds) {
+        if (gameState != GameState.PLAYING) {
+            return Result.blocked(Reason.MIDDLE_DELETE_ONLY_WHILE_PLAYING);
+        }
+        if (target instanceof GameProgressTimeline) {
+            return Result.blocked(Reason.PROGRESS_TIMELINE_NOT_LAST);
+        }
+        if (gameEndLater) {
+            return Result.blocked(Reason.INCONSISTENT_PROGRESS_STATE);
+        }
+        if (target instanceof ReplacementTimeline
+                && target.getRelatedLineupPlayers().stream()
+                .anyMatch(player -> laterPlayerIds.contains(player.getId()))) {
+            return Result.blocked(Reason.REPLACEMENT_PLAYER_HAS_LATER_RECORDS);
+        }
+        return Result.allowed();
+    }
+}

--- a/src/main/java/com/sports/server/command/timeline/domain/TimelineDeletabilityEvaluator.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/TimelineDeletabilityEvaluator.java
@@ -12,9 +12,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public final class TimelineDeletability {
+public final class TimelineDeletabilityEvaluator {
 
-    private TimelineDeletability() {
+    private TimelineDeletabilityEvaluator() {
     }
 
     public enum Reason {

--- a/src/main/java/com/sports/server/query/application/TimelineQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TimelineQueryService.java
@@ -15,6 +15,7 @@ import com.sports.server.command.timeline.domain.GameProgressTimelineRepository;
 import com.sports.server.command.timeline.domain.GameProgressType;
 import com.sports.server.command.timeline.domain.ScoreTimeline;
 import com.sports.server.command.timeline.domain.Timeline;
+import com.sports.server.command.timeline.domain.TimelineDeletability;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.query.dto.response.AvailableProgressResponse;
 import com.sports.server.query.dto.response.AvailableProgressResponse.ProgressAction;
@@ -44,7 +45,13 @@ public class TimelineQueryService {
     private final EntityUtils entityUtils;
 
     public GameTimelineResponse getTimelines(final Long gameId) {
-        Map<Quarter, List<Timeline>> timelines = timelineQueryRepository.findByGameId(gameId)
+        List<Timeline> allTimelines = timelineQueryRepository.findByGameId(gameId);
+
+        Map<Long, TimelineDeletability.Result> deletability = allTimelines.isEmpty()
+                ? Map.of()
+                : TimelineDeletability.evaluate(allTimelines.get(0).getGame().getState(), allTimelines);
+
+        Map<Quarter, List<Timeline>> timelines = allTimelines
                 .stream()
                 .collect(groupingBy(Timeline::getRecordedQuarter));
 
@@ -53,7 +60,8 @@ public class TimelineQueryService {
                 .sorted(comparingInt(Quarter::getOrder).reversed())
                 .map(quarter -> TimelineResponse.of(
                         quarter,
-                        timelines.get(quarter)
+                        timelines.get(quarter),
+                        deletability
                 )).toList();
 
         WinnerResponse winner = gameTeamQueryRepository

--- a/src/main/java/com/sports/server/query/application/TimelineQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TimelineQueryService.java
@@ -15,7 +15,7 @@ import com.sports.server.command.timeline.domain.GameProgressTimelineRepository;
 import com.sports.server.command.timeline.domain.GameProgressType;
 import com.sports.server.command.timeline.domain.ScoreTimeline;
 import com.sports.server.command.timeline.domain.Timeline;
-import com.sports.server.command.timeline.domain.TimelineDeletability;
+import com.sports.server.command.timeline.domain.TimelineDeletabilityEvaluator;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.query.dto.response.AvailableProgressResponse;
 import com.sports.server.query.dto.response.AvailableProgressResponse.ProgressAction;
@@ -47,9 +47,9 @@ public class TimelineQueryService {
     public GameTimelineResponse getTimelines(final Long gameId) {
         List<Timeline> allTimelines = timelineQueryRepository.findByGameId(gameId);
 
-        Map<Long, TimelineDeletability.Result> deletability = allTimelines.isEmpty()
+        Map<Long, TimelineDeletabilityEvaluator.Result> deletability = allTimelines.isEmpty()
                 ? Map.of()
-                : TimelineDeletability.evaluate(allTimelines.get(0).getGame().getState(), allTimelines);
+                : TimelineDeletabilityEvaluator.evaluate(allTimelines.get(0).getGame().getState(), allTimelines);
 
         Map<Quarter, List<Timeline>> timelines = allTimelines
                 .stream()

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -23,9 +23,11 @@ public record RecordResponse(
         ReplacementRecordResponse replacementRecord,
         ProgressRecordResponse progressRecord,
         PkRecordResponse pkRecord,
-        WarningCardRecordResponse warningCardRecord
+        WarningCardRecordResponse warningCardRecord,
+        boolean deletable,
+        String undeletableReason
 ) {
-    public static RecordResponse from(Timeline timeline) {
+    public static RecordResponse from(Timeline timeline, TimelineDeletability.Result deletability) {
         Optional<LineupPlayer> lineupPlayer = getPlayer(timeline);
         Optional<GameTeam> gameTeam = lineupPlayer.map(LineupPlayer::getGameTeam);
         Optional<Team> team = gameTeam.map(GameTeam::getTeam);
@@ -51,7 +53,9 @@ public record RecordResponse(
                 timeline instanceof PKTimeline pkTimeline
                         ? new PkRecordResponse(pkTimeline.getId(), pkTimeline.getIsSuccess()) : null,
                 timeline instanceof WarningCardTimeline warningCardTimeline
-                        ? new WarningCardRecordResponse(warningCardTimeline.getWarningCardType()) : null
+                        ? new WarningCardRecordResponse(warningCardTimeline.getWarningCardType()) : null,
+                deletability.deletable(),
+                deletability.reasonMessage()
         );
     }
 

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -27,7 +27,7 @@ public record RecordResponse(
         boolean deletable,
         String undeletableReason
 ) {
-    public static RecordResponse from(Timeline timeline, TimelineDeletability.Result deletability) {
+    public static RecordResponse from(Timeline timeline, TimelineDeletabilityEvaluator.Result deletability) {
         Optional<LineupPlayer> lineupPlayer = getPlayer(timeline);
         Optional<GameTeam> gameTeam = lineupPlayer.map(LineupPlayer::getGameTeam);
         Optional<Team> team = gameTeam.map(GameTeam::getTeam);

--- a/src/main/java/com/sports/server/query/dto/response/TimelineResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/TimelineResponse.java
@@ -2,18 +2,21 @@ package com.sports.server.query.dto.response;
 
 import com.sports.server.command.league.domain.Quarter;
 import com.sports.server.command.timeline.domain.Timeline;
+import com.sports.server.command.timeline.domain.TimelineDeletability;
 
 import java.util.List;
+import java.util.Map;
 
 public record TimelineResponse(
         QuarterResponse gameQuarter,
         List<RecordResponse> records
 ) {
-    public static TimelineResponse of(Quarter quarter, List<Timeline> timelines) {
+    public static TimelineResponse of(Quarter quarter, List<Timeline> timelines,
+                                      Map<Long, TimelineDeletability.Result> deletability) {
         return new TimelineResponse(
                 QuarterResponse.from(quarter),
                 timelines.stream()
-                        .map(RecordResponse::from)
+                        .map(timeline -> RecordResponse.from(timeline, deletability.get(timeline.getId())))
                         .toList()
         );
     }

--- a/src/main/java/com/sports/server/query/dto/response/TimelineResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/TimelineResponse.java
@@ -2,7 +2,7 @@ package com.sports.server.query.dto.response;
 
 import com.sports.server.command.league.domain.Quarter;
 import com.sports.server.command.timeline.domain.Timeline;
-import com.sports.server.command.timeline.domain.TimelineDeletability;
+import com.sports.server.command.timeline.domain.TimelineDeletabilityEvaluator;
 
 import java.util.List;
 import java.util.Map;
@@ -12,7 +12,7 @@ public record TimelineResponse(
         List<RecordResponse> records
 ) {
     public static TimelineResponse of(Quarter quarter, List<Timeline> timelines,
-                                      Map<Long, TimelineDeletability.Result> deletability) {
+                                      Map<Long, TimelineDeletabilityEvaluator.Result> deletability) {
         return new TimelineResponse(
                 QuarterResponse.from(quarter),
                 timelines.stream()

--- a/src/test/java/com/sports/server/query/application/TimelineQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/TimelineQueryServiceTest.java
@@ -1,0 +1,119 @@
+package com.sports.server.query.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.sports.server.command.league.domain.SoccerQuarter;
+import com.sports.server.command.league.domain.SportType;
+import com.sports.server.command.member.domain.Member;
+import com.sports.server.command.member.domain.MemberRepository;
+import com.sports.server.command.timeline.application.TimelineService;
+import com.sports.server.command.timeline.dto.TimelineRequest;
+import com.sports.server.command.timeline.exception.TimelineErrorMessage;
+import com.sports.server.query.dto.response.RecordResponse;
+import com.sports.server.support.ServiceTest;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql(scripts = "/timeline-fixture.sql")
+class TimelineQueryServiceTest extends ServiceTest {
+
+    @Autowired
+    private TimelineQueryService timelineQueryService;
+
+    @Autowired
+    private TimelineService timelineService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    // game 6: 점수 0:0 + QUARTER_START 만 있는 정합 상태 (TimelineServiceTest.DeleteTest 와 동일 픽스처)
+    private final Long replayGameId = 6L;
+    private final Long replayGameTeamId = 9L;
+    private final Long starter1Id = 31L;
+    private final Long starter2Id = 32L;
+    private final Long candidate1Id = 33L;
+
+    private Member manager;
+
+    @BeforeEach
+    void setUp() {
+        manager = memberRepository.findMemberByEmail("john.doe@example.com").orElseThrow();
+    }
+
+    @Test
+    void 진행_중_경기는_기록별_삭제_가능_여부와_사유를_내려준다() {
+        // given: 득점(31, 도움 32) → 교체(31 OUT, 33 IN) → 득점(33)
+        registerGoal(starter1Id, starter2Id);
+        registerReplacement(starter1Id, candidate1Id);
+        registerGoal(candidate1Id, null);
+
+        // when
+        List<RecordResponse> records = recordsOrderedById(replayGameId);
+
+        // then: [QUARTER_START, 득점1, 교체, 득점2(마지막)]
+        RecordResponse quarterStart = records.get(0);
+        RecordResponse firstGoal = records.get(1);
+        RecordResponse replacement = records.get(2);
+        RecordResponse lastGoal = records.get(3);
+        assertAll(
+                () -> assertThat(records).hasSize(4),
+                () -> assertThat(quarterStart.deletable()).isFalse(),
+                () -> assertThat(quarterStart.undeletableReason())
+                        .isEqualTo(TimelineErrorMessage.PROGRESS_TIMELINE_NOT_LAST),
+                () -> assertThat(firstGoal.deletable()).isTrue(),
+                () -> assertThat(firstGoal.undeletableReason()).isNull(),
+                () -> assertThat(replacement.deletable()).isFalse(),
+                () -> assertThat(replacement.undeletableReason())
+                        .isEqualTo(TimelineErrorMessage.REPLACEMENT_PLAYER_HAS_LATER_RECORDS),
+                () -> assertThat(lastGoal.deletable()).isTrue(),
+                () -> assertThat(lastGoal.undeletableReason()).isNull()
+        );
+    }
+
+    @Test
+    void 종료된_경기는_마지막_기록만_삭제_가능으로_내려준다() {
+        // given: game 2 는 FINISHED
+        Long finishedGameId = 2L;
+
+        // when
+        List<RecordResponse> records = recordsOrderedById(finishedGameId);
+
+        // then
+        RecordResponse last = records.get(records.size() - 1);
+        List<RecordResponse> middles = records.subList(0, records.size() - 1);
+        assertAll(
+                () -> assertThat(middles).isNotEmpty(),
+                () -> assertThat(last.deletable()).isTrue(),
+                () -> assertThat(last.undeletableReason()).isNull(),
+                () -> assertThat(middles).allSatisfy(record -> {
+                    assertThat(record.deletable()).isFalse();
+                    assertThat(record.undeletableReason())
+                            .isEqualTo(TimelineErrorMessage.MIDDLE_DELETE_ONLY_WHILE_PLAYING);
+                })
+        );
+    }
+
+    private List<RecordResponse> recordsOrderedById(Long gameId) {
+        return timelineQueryService.getTimelines(gameId).timelines().stream()
+                .flatMap(timeline -> timeline.records().stream())
+                .sorted(Comparator.comparing(RecordResponse::recordId))
+                .toList();
+    }
+
+    private void registerGoal(Long scorerLineupPlayerId, Long assistLineupPlayerId) {
+        timelineService.register(manager, replayGameId, new TimelineRequest.RegisterSoccerScore(
+                replayGameTeamId, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
+                scorerLineupPlayerId, 10, assistLineupPlayerId));
+    }
+
+    private void registerReplacement(Long originLineupPlayerId, Long replacementLineupPlayerId) {
+        timelineService.register(manager, replayGameId, new TimelineRequest.RegisterReplacement(
+                replayGameTeamId, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
+                originLineupPlayerId, replacementLineupPlayerId, 20, null));
+    }
+}

--- a/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
@@ -11,6 +11,7 @@ import com.sports.server.command.league.domain.BasketballQuarter;
 import com.sports.server.command.league.domain.SoccerQuarter;
 import com.sports.server.command.timeline.domain.GameProgressType;
 import com.sports.server.command.timeline.domain.WarningCardType;
+import com.sports.server.command.timeline.exception.TimelineErrorMessage;
 import com.sports.server.query.dto.response.*;
 import com.sports.server.query.dto.response.AvailableProgressResponse.ProgressAction;
 import com.sports.server.query.dto.response.QuarterResponse;
@@ -63,7 +64,9 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                                 new ReplacementRecordResponse(1L, "선수3", null),
                                                 new ProgressRecordResponse(GameProgressType.QUARTER_START),
                                                 new PkRecordResponse(1L, true),
-                                                new WarningCardRecordResponse(WarningCardType.YELLOW)
+                                                new WarningCardRecordResponse(WarningCardType.YELLOW),
+                                                true,
+                                                null
                                         ),
                                         new RecordResponse(
                                                 null, 1L, SOCCER_REPLACEMENT_TYPE,
@@ -81,7 +84,9 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                                 new ReplacementRecordResponse(1L, "선수3", null),
                                                 new ProgressRecordResponse(GameProgressType.QUARTER_END),
                                                 new PkRecordResponse(4L, false),
-                                                new WarningCardRecordResponse(WarningCardType.RED)
+                                                new WarningCardRecordResponse(WarningCardType.RED),
+                                                false,
+                                                TimelineErrorMessage.REPLACEMENT_PLAYER_HAS_LATER_RECORDS
                                         ),
                                         new RecordResponse(
                                                 null, 1L, BASKETBALL_REPLACEMENT_TYPE,
@@ -99,7 +104,9 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                                 new ReplacementRecordResponse(2L, "선수5", true),
                                                 new ProgressRecordResponse(GameProgressType.QUARTER_END),
                                                 new PkRecordResponse(4L, false),
-                                                new WarningCardRecordResponse(WarningCardType.RED)
+                                                new WarningCardRecordResponse(WarningCardType.RED),
+                                                true,
+                                                null
                                         )
                                 ))
                         )
@@ -169,7 +176,12 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                         .description("승부차기 득점 성공 여부"),
                                 fieldWithPath("timelines[].records[].warningCardRecord.warningCardType").type(
                                                 JsonFieldType.STRING)
-                                        .description("WARNING_CARD 타입일 때 경고 카드 타입(YELLOW, RED)")
+                                        .description("WARNING_CARD 타입일 때 경고 카드 타입(YELLOW, RED)"),
+                                fieldWithPath("timelines[].records[].deletable").type(JsonFieldType.BOOLEAN)
+                                        .description("현재 시점 기준 이 기록의 삭제 가능 여부"),
+                                fieldWithPath("timelines[].records[].undeletableReason").type(JsonFieldType.VARIES)
+                                        .description("삭제 불가 사유 (삭제 가능하면 null, DELETE 실패 message와 동일 문구)")
+                                        .optional()
                         )
                 ));
     }


### PR DESCRIPTION
## 이슈

- closes #698

## 변경 내용

- `GET /games/{gameId}/timeline` 응답의 record마다 `deletable`(boolean) / `undeletableReason`(string|null) 추가
- 삭제 가능 판정을 `TimelineDeletabilityEvaluator`(timeline domain)로 추출
  - 조회는 전 기록을 id 역방향 1패스로 일괄 판정(O(n)), 삭제 검증(`TimelineService.validateMiddleDeletable`)은 같은 평가기의 단건 판정에 위임 — **정책 소스가 한 곳**이 되어 조회 표기와 실제 삭제 결과가 어긋날 수 없음
  - 판정 규칙은 #695 그대로: 마지막 기록은 항상 가능 / 중간은 PLAYING 한정 / 쿼터 진행 기록은 마지막만 / 교체는 두 선수가 이후 기록에 미등장할 때만
- 불가 사유는 `TimelineErrorMessage` 상수를 DELETE 에러와 공용 — 잠금 사유 토스트와 삭제 실패 message가 항상 같은 문구
- 상태 코드 매핑(정합 오류 500, 그 외 400)은 서비스에 남겨 도메인은 HTTP 무관 유지

## 테스트

- `TimelineQueryServiceTest` 신규 2케이스
  - 진행 중 경기(game 6에 register로 시나리오 구축): 쿼터 시작=불가(마지막 아님) / 중간 득점=가능 / 이후 등장 선수가 있는 교체=불가 / 마지막 기록=가능
  - 종료 경기(game 2): 마지막 기록만 가능, 나머지 전부 불가 + 사유 일치
- `TimelineQueryControllerTest` REST Docs 필드 2개 추가 (`deletable`, `undeletableReason` optional)
- `TimelineServiceTest` 전 케이스 무수정 통과 — 검증 위임 리팩터가 기존 동작(메시지·상태 코드) 보존함을 확인

## 영향 API

- `GET /games/{gameId}/timeline` — 필드 추가만, 기존 필드 무변경. 관중 화면은 새 필드를 무시하면 됨
- `DELETE /games/{gameId}/timelines/{timelineId}` — 동작 무변경 (검증 로직 위치만 도메인으로 이동)

## 프론트 참고

- 삭제 모드 UI: `record.deletable`로 버튼 활성/잠금을 그리고, 잠금 탭 시 `undeletableReason`을 토스트로 출력하면 됨 (별도 계산 불필요)
- `deletable`은 조회 시점 기준 — 이후 다른 매니저가 기록을 추가하면 달라질 수 있으므로 최종 판정은 DELETE 응답(4xx message 동일 문구)
- 스택 PR: base가 `feature/694-timeline-middle-delete`이며 #695 머지 후 develop으로 리타깃 예정. 이 PR의 실질 diff는 마지막 커밋 참고


## 설계 노트

- "마지막 기록은 항상 삭제 가능" 규칙은 조회(`evaluate`)에서는 평가기가 캡슐화하지만, 삭제 쪽은 기존 `deleteTimeline`의 `subsequents.isEmpty()` 분기가 그 규칙을 담당한다. 삭제 경로는 락을 잡고 target과 subsequents를 이미 확보한 구조라, 일괄 평가로 바꾸지 않고 단건 위임(`evaluateMiddle`)으로 맞췄다
- `Reason` enum이 `TimelineErrorMessage` 상수를 감싸는 한 단계 간접화는 의도적이다. 서비스가 문자열 비교 없이 enum으로 상태 코드(정합 오류 500 / 그 외 400)를 매핑하고, 문구 자체는 상수 한 곳에 남는다
- 조회에서 경기 상태를 `EntityUtils`로 직접 조회하지 않고 첫 타임라인의 `getGame()`으로 얻는 것도 의도적이다. 직접 조회하면 존재하지 않는 gameId의 응답이 기존 "빈 타임라인 200"에서 404로 바뀌는 공개 API 행동 변화가 생긴다
- instanceof 정책 분기가 서비스에서 도메인(`TimelineDeletabilityEvaluator`)으로 이동했다 — #695 리뷰에서 나온 "타입별 삭제 로직의 분리" 제안과 방향이 닿아 있다

## 참고

- Gemini의 null/empty 방어 2건은 반영하지 않고 resolve 처리 (#695·#697과 동일 기준)
  - `evaluate(timelines)`: Spring Data 파생 쿼리는 계약상 null 대신 빈 컬렉션을 반환하므로 null 경로가 없고, 빈 리스트는 현재 코드로도 NPE 없이 빈 맵을 반환한다(루프 미진입). 유일한 호출부(`TimelineQueryService`)는 GameState 확보를 위해 어차피 빈 리스트를 선-가드해야 해서 내부 가드는 죽은 코드가 된다
  - `evaluateMiddle(subsequents)`: 유일한 호출 경로가 `deleteTimeline`의 `subsequents.isEmpty()` 분기 이후라 구조적으로 비어 있지 않으며, null은 위와 같은 이유로 불가. 가드를 넣으면 그 상태가 정상적으로 발생할 수 있다는 잘못된 신호가 된다


