### PR TITLE
feat: 자책골 타임라인 기능 추가 (#700)

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -245,6 +245,11 @@ operation::timeline-controller-test/농구_득점_타임라인을_생성한다[s
 
 === 자책골 타임라인 생성
 
+등록 요청의 `gameTeamId`/`scorerLineupPlayerId`는 자책골을 넣은 선수가 소속된 팀("우리 팀") 기준이다.
+반면 게임의 타임라인 조회(`GET /games/{gameId}/timeline`) 응답에서는 자책골 기록이 실제로 점수를 얻은
+상대 팀 기준(`gameTeamId`/`teamName`/`teamImageUrl`)으로 표시된다. `playerName`은 등록 시와 동일하게
+자책골을 넣은 선수 이름을 유지한다.
+
 operation::timeline-controller-test/자책골_타임라인을_생성한다[snippets='http-request,path-parameters,request-fields,http-response']
 
 

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -243,6 +243,10 @@ operation::timeline-controller-test/득점_타임라인을_생성한다[snippets
 
 operation::timeline-controller-test/농구_득점_타임라인을_생성한다[snippets='http-request,path-parameters,request-fields,http-response']
 
+=== 자책골 타임라인 생성
+
+operation::timeline-controller-test/자책골_타임라인을_생성한다[snippets='http-request,path-parameters,request-fields,http-response']
+
 
 === 축구 교체 타임라인 생성
 

--- a/src/main/java/com/sports/server/command/cheertalk/application/AiSeedService.java
+++ b/src/main/java/com/sports/server/command/cheertalk/application/AiSeedService.java
@@ -82,7 +82,7 @@ private boolean canPublish(Game game) {
         if (isTooSoonSinceLastSeed(gameTeamIds)) {
             return false;
         }
-        return triggerType == AiSeedTriggerType.GOAL || !hasRecentUserCheerTalk(gameTeamIds);
+        return isGoalLike(triggerType) || !hasRecentUserCheerTalk(gameTeamIds);
     }
 
     private boolean hasReachedMaxSeeds(List<Long> gameTeamIds) {
@@ -105,13 +105,17 @@ private boolean canPublish(Game game) {
     }
 
     private GameTeam selectTeam(AiSeedTriggerType triggerType, Long scoringGameTeamId, List<GameTeam> gameTeams) {
-        if (triggerType == AiSeedTriggerType.GOAL && scoringGameTeamId != null) {
+        if (isGoalLike(triggerType) && scoringGameTeamId != null) {
             return gameTeams.stream()
                     .filter(gt -> gt.getId().equals(scoringGameTeamId))
                     .findFirst()
                     .orElse(randomTeam(gameTeams));
         }
         return randomTeam(gameTeams);
+    }
+
+    private boolean isGoalLike(AiSeedTriggerType triggerType) {
+        return triggerType == AiSeedTriggerType.GOAL || triggerType == AiSeedTriggerType.OWN_GOAL;
     }
 
     private GameTeam randomTeam(List<GameTeam> gameTeams) {

--- a/src/main/java/com/sports/server/command/cheertalk/application/AiSeedService.java
+++ b/src/main/java/com/sports/server/command/cheertalk/application/AiSeedService.java
@@ -82,7 +82,7 @@ private boolean canPublish(Game game) {
         if (isTooSoonSinceLastSeed(gameTeamIds)) {
             return false;
         }
-        return isGoalLike(triggerType) || !hasRecentUserCheerTalk(gameTeamIds);
+        return isMandatoryTrigger(triggerType) || !hasRecentUserCheerTalk(gameTeamIds);
     }
 
     private boolean hasReachedMaxSeeds(List<Long> gameTeamIds) {
@@ -105,7 +105,7 @@ private boolean canPublish(Game game) {
     }
 
     private GameTeam selectTeam(AiSeedTriggerType triggerType, Long scoringGameTeamId, List<GameTeam> gameTeams) {
-        if (isGoalLike(triggerType) && scoringGameTeamId != null) {
+        if (isMandatoryTrigger(triggerType) && scoringGameTeamId != null) {
             return gameTeams.stream()
                     .filter(gt -> gt.getId().equals(scoringGameTeamId))
                     .findFirst()
@@ -114,7 +114,7 @@ private boolean canPublish(Game game) {
         return randomTeam(gameTeams);
     }
 
-    private boolean isGoalLike(AiSeedTriggerType triggerType) {
+    private boolean isMandatoryTrigger(AiSeedTriggerType triggerType) {
         return triggerType == AiSeedTriggerType.GOAL || triggerType == AiSeedTriggerType.OWN_GOAL;
     }
 

--- a/src/main/java/com/sports/server/command/cheertalk/domain/AiSeedTriggerType.java
+++ b/src/main/java/com/sports/server/command/cheertalk/domain/AiSeedTriggerType.java
@@ -3,5 +3,6 @@ package com.sports.server.command.cheertalk.domain;
 public enum AiSeedTriggerType {
     SCHEDULED,
     SECOND_HALF_START,
-    GOAL
+    GOAL,
+    OWN_GOAL
 }

--- a/src/main/java/com/sports/server/command/cheertalk/infra/AiSeedMessageGenerator.java
+++ b/src/main/java/com/sports/server/command/cheertalk/infra/AiSeedMessageGenerator.java
@@ -29,6 +29,7 @@ public class AiSeedMessageGenerator {
     private final String scheduledPrompt;
     private final String secondHalfPrompt;
     private final String goalPrompt;
+    private final String ownGoalPrompt;
 
     public AiSeedMessageGenerator(
             OpenRouterChatCaller chatCaller,
@@ -37,7 +38,8 @@ public class AiSeedMessageGenerator {
             @Value("${ai-seed.banned-solo-reactions:ㅋㅋ,ㅋㅋㅋ,ㅋㅋㅋㅋ,ㄷㄷ,ㄷㄷㄷ,와,ㅎㅎ,ㅎㅎㅎ,ㄹㅇ}") String bannedSoloReactions,
             @Value("${ai-seed.prompt.scheduled}") String scheduledPrompt,
             @Value("${ai-seed.prompt.second-half}") String secondHalfPrompt,
-            @Value("${ai-seed.prompt.goal}") String goalPrompt
+            @Value("${ai-seed.prompt.goal}") String goalPrompt,
+            @Value("${ai-seed.prompt.own-goal}") String ownGoalPrompt
     ) {
         this.chatCaller = chatCaller;
         this.model = model;
@@ -48,6 +50,7 @@ public class AiSeedMessageGenerator {
         this.scheduledPrompt = scheduledPrompt;
         this.secondHalfPrompt = secondHalfPrompt;
         this.goalPrompt = goalPrompt;
+        this.ownGoalPrompt = ownGoalPrompt;
     }
 
     public String generate(AiSeedTriggerType triggerType, String teamName, String scorerName) {
@@ -112,6 +115,9 @@ public class AiSeedMessageGenerator {
         if (triggerType == AiSeedTriggerType.GOAL && scorerName != null) {
             return scorerName + " 좋았다";
         }
+        if (triggerType == AiSeedTriggerType.OWN_GOAL) {
+            return "이건 예상 못했네";
+        }
         return teamName + " 가자";
     }
 
@@ -120,6 +126,7 @@ public class AiSeedMessageGenerator {
             case SCHEDULED -> scheduledPrompt;
             case SECOND_HALF_START -> secondHalfPrompt;
             case GOAL -> goalPrompt;
+            case OWN_GOAL -> ownGoalPrompt;
         };
 
         String result = template.replace("{team_name}", teamName);

--- a/src/main/java/com/sports/server/command/cheertalk/presentation/AiSeedEventListener.java
+++ b/src/main/java/com/sports/server/command/cheertalk/presentation/AiSeedEventListener.java
@@ -5,6 +5,7 @@ import com.sports.server.command.cheertalk.domain.AiSeedTriggerType;
 import com.sports.server.command.league.domain.SoccerQuarter;
 import com.sports.server.command.timeline.domain.GameProgressTimeline;
 import com.sports.server.command.timeline.domain.GameProgressType;
+import com.sports.server.command.timeline.domain.OwnGoalTimeline;
 import com.sports.server.command.timeline.domain.ScoreTimeline;
 import com.sports.server.command.timeline.domain.Timeline;
 import com.sports.server.command.timeline.domain.TimelineCreatedEvent;
@@ -40,6 +41,7 @@ public class AiSeedEventListener {
     public void handle(TimelineCreatedEvent event) {
         switch (event.type()) {
             case SCORE -> handleGoal(event);
+            case OWN_GOAL -> handleOwnGoal(event);
             case GAME_PROGRESS -> handleGameProgress(event);
             default -> { }
         }
@@ -57,6 +59,21 @@ public class AiSeedEventListener {
         int delay = randomDelay(GOAL_DELAY_MIN_SECONDS, GOAL_DELAY_MAX_SECONDS);
         taskScheduler.schedule(
                 () -> aiSeedService.publish(event.gameId(), AiSeedTriggerType.GOAL, scoringGameTeamId, scorerName),
+                Instant.now().plusSeconds(delay)
+        );
+    }
+
+    private void handleOwnGoal(TimelineCreatedEvent event) {
+        Timeline timeline = timelineRepository.findById(event.timelineId()).orElse(null);
+        if (!(timeline instanceof OwnGoalTimeline ownGoalTimeline)) {
+            return;
+        }
+
+        Long creditedGameTeamId = ownGoalTimeline.getOpponentGameTeam().getId();
+
+        int delay = randomDelay(GOAL_DELAY_MIN_SECONDS, GOAL_DELAY_MAX_SECONDS);
+        taskScheduler.schedule(
+                () -> aiSeedService.publish(event.gameId(), AiSeedTriggerType.OWN_GOAL, creditedGameTeamId, null),
                 Instant.now().plusSeconds(delay)
         );
     }

--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -129,6 +129,26 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
         findTeamOf(scorer, GameErrorMessages.PLAYER_NOT_PARTICIPANT_CANCEL_SCORE_EXCEPTION).cancelScore(scoreValue);
     }
 
+    public void scoreOwnGoal(LineupPlayer scorer, int scoreValue) {
+        if (!league.getSportType().canRecordOwnGoal()) {
+            throw new BadRequestException(GameErrorMessages.OWN_GOAL_NOT_ALLOWED_FOR_NON_SOCCER);
+        }
+        GameTeam ownTeam = findTeamOf(scorer, GameErrorMessages.PLAYER_NOT_PARTICIPANT_OWN_GOAL_EXCEPTION);
+        opponentOf(ownTeam).score(scoreValue);
+    }
+
+    public void cancelOwnGoalScore(LineupPlayer scorer, int scoreValue) {
+        GameTeam ownTeam = findTeamOf(scorer, GameErrorMessages.PLAYER_NOT_PARTICIPANT_CANCEL_OWN_GOAL_EXCEPTION);
+        opponentOf(ownTeam).cancelScore(scoreValue);
+    }
+
+    private GameTeam opponentOf(GameTeam team) {
+        return gameTeams.stream()
+                .filter(gameTeam -> !gameTeam.equals(team))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException(GameErrorMessages.GAME_TEAM_NOT_PARTICIPANT_EXCEPTION));
+    }
+
     public void cancelPkScore(LineupPlayer scorer) {
         findTeamOf(scorer, GameErrorMessages.PLAYER_NOT_PARTICIPANT_CANCEL_SCORE_EXCEPTION).cancelPkScore();
     }

--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -142,11 +142,11 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
         opponentOf(ownTeam).cancelScore(scoreValue);
     }
 
-    private GameTeam opponentOf(GameTeam team) {
+    public GameTeam opponentOf(GameTeam team) {
         return gameTeams.stream()
                 .filter(gameTeam -> !gameTeam.equals(team))
                 .findAny()
-                .orElseThrow(() -> new IllegalArgumentException(GameErrorMessages.GAME_TEAM_NOT_PARTICIPANT_EXCEPTION));
+                .orElseThrow(() -> new BadRequestException(GameErrorMessages.GAME_TEAM_NOT_PARTICIPANT_EXCEPTION));
     }
 
     public void cancelPkScore(LineupPlayer scorer) {

--- a/src/main/java/com/sports/server/command/game/exception/GameErrorMessages.java
+++ b/src/main/java/com/sports/server/command/game/exception/GameErrorMessages.java
@@ -10,6 +10,9 @@ public class GameErrorMessages {
     public static final String PLAYER_NOT_PARTICIPANT_SCORE_EXCEPTION = "참여하지 않는 선수는 득점할 수 없습니다.";
     public static final String PLAYER_NOT_PARTICIPANT_PK_SCORE_EXCEPTION = "참여하지 않는 선수는 승부차기에서 득점할 수 없습니다.";
     public static final String PLAYER_NOT_PARTICIPANT_CANCEL_SCORE_EXCEPTION = "참여하지 않는 선수는 득점을 취소할 수 없습니다.";
+    public static final String OWN_GOAL_NOT_ALLOWED_FOR_NON_SOCCER = "자책골은 축구 경기에서만 등록할 수 있습니다.";
+    public static final String PLAYER_NOT_PARTICIPANT_OWN_GOAL_EXCEPTION = "참여하지 않는 선수는 자책골을 기록할 수 없습니다.";
+    public static final String PLAYER_NOT_PARTICIPANT_CANCEL_OWN_GOAL_EXCEPTION = "참여하지 않는 선수는 자책골 기록을 취소할 수 없습니다.";
     public static final String PLAYER_NOT_PARTICIPANT_ISSUE_WARNING_CARD_EXCEPTION = "참여하지 않는 선수는 경고카드를 받을 수 없습니다.";
     public static final String PLAYER_NOT_PARTICIPANT_CANCEL_WARNING_CARD_EXCEPTION = "참여하지 않는 선수는 경고카드를 취소할 수 없습니다.";
     public static final String BASKETBALL_REPLACEMENT_NOT_ALLOWED_FOR_NON_BASKETBALL = "농구 교체는 농구 경기에서만 등록할 수 있습니다.";

--- a/src/main/java/com/sports/server/command/league/domain/Quarter.java
+++ b/src/main/java/com/sports/server/command/league/domain/Quarter.java
@@ -24,4 +24,8 @@ public interface Quarter {
     default boolean canEndGameAfterQuarterEnd() {
         return false;
     }
+
+    default boolean canRecordOwnGoal() {
+        return false;
+    }
 }

--- a/src/main/java/com/sports/server/command/league/domain/SoccerQuarter.java
+++ b/src/main/java/com/sports/server/command/league/domain/SoccerQuarter.java
@@ -41,6 +41,11 @@ public enum SoccerQuarter implements Quarter {
         return this != SECOND_HALF && canEndGame();
     }
 
+    @Override
+    public boolean canRecordOwnGoal() {
+        return this != PENALTY_SHOOTOUT;
+    }
+
     public static Optional<SoccerQuarter> tryResolve(String value) {
         for (SoccerQuarter quarter : values()) {
             if (quarter.name().equals(value) || quarter.getDisplayName().equals(value)) {

--- a/src/main/java/com/sports/server/command/league/domain/SportType.java
+++ b/src/main/java/com/sports/server/command/league/domain/SportType.java
@@ -35,6 +35,11 @@ public enum SportType {
         public Quarter nextQuarter(Quarter current) {
             return quarterByOrder(current.getOrder() + 1);
         }
+
+        @Override
+        public boolean canRecordOwnGoal() {
+            return true;
+        }
     },
     BASKETBALL {
         @Override
@@ -82,4 +87,8 @@ public enum SportType {
     public abstract Quarter quarterByOrder(int order);
 
     public abstract Quarter nextQuarter(Quarter current);
+
+    public boolean canRecordOwnGoal() {
+        return false;
+    }
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/OwnGoalTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/OwnGoalTimeline.java
@@ -124,10 +124,6 @@ public class OwnGoalTimeline extends Timeline {
     }
 
     public GameTeam getOpponentGameTeam() {
-        GameTeam ownTeam = scorer.getGameTeam();
-        if (ownTeam.equals(gameTeam1)) {
-            return gameTeam2;
-        }
-        return gameTeam1;
+        return game.opponentOf(scorer.getGameTeam());
     }
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/OwnGoalTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/OwnGoalTimeline.java
@@ -6,6 +6,7 @@ import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.league.domain.Quarter;
 import com.sports.server.common.exception.BadRequestException;
 import com.sports.server.common.exception.ExceptionMessages;
+import java.util.List;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
@@ -115,6 +116,11 @@ public class OwnGoalTimeline extends Timeline {
     @Override
     public void rollback() {
         game.cancelOwnGoalScore(scorer, score);
+    }
+
+    @Override
+    public List<LineupPlayer> getRelatedLineupPlayers() {
+        return List.of(scorer);
     }
 
     public GameTeam getOpponentGameTeam() {

--- a/src/main/java/com/sports/server/command/timeline/domain/OwnGoalTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/OwnGoalTimeline.java
@@ -116,4 +116,12 @@ public class OwnGoalTimeline extends Timeline {
     public void rollback() {
         game.cancelOwnGoalScore(scorer, score);
     }
+
+    public GameTeam getOpponentGameTeam() {
+        GameTeam ownTeam = scorer.getGameTeam();
+        if (ownTeam.equals(gameTeam1)) {
+            return gameTeam2;
+        }
+        return gameTeam1;
+    }
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/OwnGoalTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/OwnGoalTimeline.java
@@ -1,0 +1,119 @@
+package com.sports.server.command.timeline.domain;
+
+import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.GameTeam;
+import com.sports.server.command.game.domain.LineupPlayer;
+import com.sports.server.command.league.domain.Quarter;
+import com.sports.server.common.exception.BadRequestException;
+import com.sports.server.common.exception.ExceptionMessages;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@DiscriminatorValue("OWN_GOAL")
+@Getter
+@NoArgsConstructor
+public class OwnGoalTimeline extends Timeline {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "scorer_id")
+    private LineupPlayer scorer;
+
+    @Column(name = "score")
+    private Integer score;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "game_team1_id")
+    private GameTeam gameTeam1;
+
+    @Column(name = "snapshot_score1")
+    private Integer snapshotScore1;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "game_team2_id")
+    private GameTeam gameTeam2;
+
+    @Column(name = "snapshot_score2")
+    private Integer snapshotScore2;
+
+    @Override
+    public TimelineType getType() {
+        return TimelineType.OWN_GOAL;
+    }
+
+    public static OwnGoalTimeline of(
+            Game game,
+            Quarter recordedQuarter,
+            Integer recordedAt,
+            LineupPlayer scorer,
+            GameTeam requestedTeam,
+            int scoreValue
+    ) {
+        if (!recordedQuarter.canRecordOwnGoal()) {
+            throw new BadRequestException(ExceptionMessages.INVALID_OWN_GOAL_QUARTER);
+        }
+        if (!scorer.isInTeam(requestedTeam)) {
+            throw new BadRequestException(ExceptionMessages.INVALID_OWN_GOAL_PLAYER);
+        }
+
+        GameTeam team1 = game.getTeam1();
+        GameTeam team2 = game.getTeam2();
+
+        return new OwnGoalTimeline(
+                game,
+                recordedQuarter,
+                recordedAt,
+                scorer,
+                scoreValue,
+                team1,
+                team1.getScore(),
+                team2,
+                team2.getScore()
+        );
+    }
+
+    private OwnGoalTimeline(
+            Game game,
+            Quarter recordedQuarter,
+            Integer recordedAt,
+            LineupPlayer scorer,
+            Integer score,
+            GameTeam gameTeam1,
+            Integer snapshotScore1,
+            GameTeam gameTeam2,
+            Integer snapshotScore2
+    ) {
+        super(game, recordedQuarter, recordedAt);
+
+        this.scorer = scorer;
+        this.score = score;
+        this.gameTeam1 = gameTeam1;
+        this.snapshotScore1 = snapshotScore1;
+        this.gameTeam2 = gameTeam2;
+        this.snapshotScore2 = snapshotScore2;
+    }
+
+    @Override
+    public void apply() {
+        game.scoreOwnGoal(scorer, score);
+
+        snapshotScore1 = gameTeam1.getScore();
+        snapshotScore2 = gameTeam2.getScore();
+    }
+
+    @Override
+    public void rollback() {
+        game.cancelOwnGoalScore(scorer, score);
+    }
+}

--- a/src/main/java/com/sports/server/command/timeline/domain/TimelineType.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/TimelineType.java
@@ -2,6 +2,7 @@ package com.sports.server.command.timeline.domain;
 
 public enum TimelineType {
     SCORE,
+    OWN_GOAL,
     SOCCER_REPLACEMENT,
     BASKETBALL_REPLACEMENT,
     GAME_PROGRESS,

--- a/src/main/java/com/sports/server/command/timeline/dto/TimelineRequest.java
+++ b/src/main/java/com/sports/server/command/timeline/dto/TimelineRequest.java
@@ -108,6 +108,29 @@ public abstract class TimelineRequest {
     }
 
     @Getter
+    public static class RegisterOwnGoal extends TimelineRequest {
+        private final Long gameTeamId;
+        private final Long scorerLineupPlayerId;
+
+        public RegisterOwnGoal(
+                Integer recordedAt,
+                SportType sportType,
+                String recordedQuarter,
+                Long gameTeamId,
+                Long scorerLineupPlayerId
+        ) {
+            super(sportType, recordedQuarter, recordedAt);
+            this.gameTeamId = gameTeamId;
+            this.scorerLineupPlayerId = scorerLineupPlayerId;
+        }
+
+        @Override
+        public TimelineType getType() {
+            return TimelineType.OWN_GOAL;
+        }
+    }
+
+    @Getter
     public static class RegisterReplacement extends TimelineRequest {
         private final Long gameTeamId;
         private final Long originLineupPlayerId;

--- a/src/main/java/com/sports/server/command/timeline/mapper/TimelineMapper.java
+++ b/src/main/java/com/sports/server/command/timeline/mapper/TimelineMapper.java
@@ -20,6 +20,8 @@ public class TimelineMapper {
     private final Map<TimelineType, TimelineSupplier> suppliers = Map.of(
             TimelineType.SCORE,
             (game, request) -> toScoreTimeline(game, (TimelineRequest.RegisterScore) request),
+            TimelineType.OWN_GOAL,
+            (game, request) -> toOwnGoalTimeline(game, (TimelineRequest.RegisterOwnGoal) request),
             TimelineType.SOCCER_REPLACEMENT,
             (game, request) -> toReplacementTimeline(game, (TimelineRequest.RegisterReplacement) request),
             TimelineType.BASKETBALL_REPLACEMENT,
@@ -52,6 +54,20 @@ public class TimelineMapper {
                 getPlayer(scoreRequest.getScoreLineupPlayerId()),
                 assist,
                 scoreRequest.getScoreValue()
+        );
+    }
+
+    private OwnGoalTimeline toOwnGoalTimeline(Game game,
+                                              TimelineRequest.RegisterOwnGoal ownGoalRequest) {
+        GameTeam requestedTeam = entityUtils.getEntity(ownGoalRequest.getGameTeamId(), GameTeam.class);
+
+        return OwnGoalTimeline.of(
+                game,
+                ownGoalRequest.resolveQuarter(),
+                ownGoalRequest.getRecordedAt(),
+                getPlayer(ownGoalRequest.getScorerLineupPlayerId()),
+                requestedTeam,
+                SoccerScore.GOAL.getValue()
         );
     }
 

--- a/src/main/java/com/sports/server/command/timeline/presentation/TimelineController.java
+++ b/src/main/java/com/sports/server/command/timeline/presentation/TimelineController.java
@@ -20,6 +20,13 @@ public class TimelineController {
         timelineService.register(member, gameId, request);
     }
 
+    @PostMapping("/own-goal")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createOwnGoalTimeline(@PathVariable Long gameId,
+                                      @RequestBody TimelineRequest.RegisterOwnGoal request, Member member) {
+        timelineService.register(member, gameId, request);
+    }
+
     @PostMapping("/replacement")
     @ResponseStatus(HttpStatus.CREATED)
     public void createReplacementTimeline(@PathVariable Long gameId,

--- a/src/main/java/com/sports/server/common/exception/ExceptionMessages.java
+++ b/src/main/java/com/sports/server/common/exception/ExceptionMessages.java
@@ -16,6 +16,8 @@ public class ExceptionMessages {
     public static final String REPLACEMENT_ORIGIN_NOT_IN_GAME = "이미 코트에 없는 선수는 교체할 수 없습니다.";
     public static final String REPLACEMENT_TARGET_ALREADY_IN_GAME = "이미 코트에 있는 선수는 교체 투입할 수 없습니다.";
     public static final String INVALID_ASSIST_PLAYER = "어시스트 선수는 득점 선수와 같은 팀이어야 하며, 본인일 수 없습니다.";
+    public static final String INVALID_OWN_GOAL_QUARTER = "자책골은 승부차기에서 기록할 수 없습니다.";
+    public static final String INVALID_OWN_GOAL_PLAYER = "자책골 선수는 요청한 팀 소속이어야 합니다.";
 
     // CheerTalk 관련
     public static final String CHEERTALK_SERIALIZATION_FAILED = "CheerTalk을 JSON으로 변환하는데 실패했습니다.";

--- a/src/main/java/com/sports/server/query/application/TimelineQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TimelineQueryService.java
@@ -13,7 +13,6 @@ import com.sports.server.command.league.domain.SportType;
 import com.sports.server.command.timeline.domain.GameProgressTimeline;
 import com.sports.server.command.timeline.domain.GameProgressTimelineRepository;
 import com.sports.server.command.timeline.domain.GameProgressType;
-import com.sports.server.command.timeline.domain.ScoreTimeline;
 import com.sports.server.command.timeline.domain.Timeline;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.query.dto.response.AvailableProgressResponse;
@@ -29,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -117,16 +117,7 @@ public class TimelineQueryService {
                 .sorted(comparingInt(Quarter::getOrder))
                 .toList();
 
-        Map<Quarter, Map<Long, Integer>> scoreByQuarterAndTeam = timelineQueryRepository
-                .findScoreTimelinesByGameId(gameId)
-                .stream()
-                .collect(groupingBy(
-                        Timeline::getRecordedQuarter,
-                        groupingBy(
-                                st -> st.getScorer().getGameTeam().getId(),
-                                summingInt(ScoreTimeline::getScore)
-                        )
-                ));
+        Map<Quarter, Map<Long, Integer>> scoreByQuarterAndTeam = collectScoreByQuarterAndTeam(gameId);
 
         return completedQuarters.stream()
                 .map(quarter -> QuarterScoreResponse.of(
@@ -135,6 +126,25 @@ public class TimelineQueryService {
                         scoreByQuarterAndTeam.getOrDefault(quarter, Map.of())
                 ))
                 .toList();
+    }
+
+    private record QuarterTeamScore(Quarter quarter, Long gameTeamId, int score) {
+    }
+
+    private Map<Quarter, Map<Long, Integer>> collectScoreByQuarterAndTeam(Long gameId) {
+        Stream<QuarterTeamScore> scoreContributions = timelineQueryRepository.findScoreTimelinesByGameId(gameId)
+                .stream()
+                .map(st -> new QuarterTeamScore(st.getRecordedQuarter(), st.getScorer().getGameTeam().getId(), st.getScore()));
+
+        Stream<QuarterTeamScore> ownGoalContributions = timelineQueryRepository.findOwnGoalTimelinesByGameId(gameId)
+                .stream()
+                .map(ogt -> new QuarterTeamScore(ogt.getRecordedQuarter(), ogt.getOpponentGameTeam().getId(), ogt.getScore()));
+
+        return Stream.concat(scoreContributions, ownGoalContributions)
+                .collect(groupingBy(
+                        QuarterTeamScore::quarter,
+                        groupingBy(QuarterTeamScore::gameTeamId, summingInt(QuarterTeamScore::score))
+                ));
     }
 
     private List<ProgressAction> actionsFromQuarterEnd(Quarter lastQuarter, SportType sportType) {

--- a/src/main/java/com/sports/server/query/application/TimelineQueryService.java
+++ b/src/main/java/com/sports/server/query/application/TimelineQueryService.java
@@ -125,13 +125,13 @@ public class TimelineQueryService {
                 .sorted(comparingInt(Quarter::getOrder))
                 .toList();
 
-        Map<Quarter, Map<Long, Integer>> scoreByQuarterAndTeam = collectScoreByQuarterAndTeam(gameId);
+        QuarterTeamScores scoreByQuarterAndTeam = collectScoreByQuarterAndTeam(gameId);
 
         return completedQuarters.stream()
                 .map(quarter -> QuarterScoreResponse.of(
                         quarter,
                         gameTeamIds,
-                        scoreByQuarterAndTeam.getOrDefault(quarter, Map.of())
+                        scoreByQuarterAndTeam.scoresOf(quarter)
                 ))
                 .toList();
     }
@@ -139,7 +139,22 @@ public class TimelineQueryService {
     private record QuarterTeamScore(Quarter quarter, Long gameTeamId, int score) {
     }
 
-    private Map<Quarter, Map<Long, Integer>> collectScoreByQuarterAndTeam(Long gameId) {
+    private record QuarterTeamScores(Map<Quarter, Map<Long, Integer>> scoresByQuarter) {
+
+        static QuarterTeamScores from(Stream<QuarterTeamScore> contributions) {
+            Map<Quarter, Map<Long, Integer>> scoresByQuarter = contributions.collect(groupingBy(
+                    QuarterTeamScore::quarter,
+                    groupingBy(QuarterTeamScore::gameTeamId, summingInt(QuarterTeamScore::score))
+            ));
+            return new QuarterTeamScores(scoresByQuarter);
+        }
+
+        Map<Long, Integer> scoresOf(Quarter quarter) {
+            return scoresByQuarter.getOrDefault(quarter, Map.of());
+        }
+    }
+
+    private QuarterTeamScores collectScoreByQuarterAndTeam(Long gameId) {
         Stream<QuarterTeamScore> scoreContributions = timelineQueryRepository.findScoreTimelinesByGameId(gameId)
                 .stream()
                 .map(st -> new QuarterTeamScore(st.getRecordedQuarter(), st.getScorer().getGameTeam().getId(), st.getScore()));
@@ -148,11 +163,7 @@ public class TimelineQueryService {
                 .stream()
                 .map(ogt -> new QuarterTeamScore(ogt.getRecordedQuarter(), ogt.getOpponentGameTeam().getId(), ogt.getScore()));
 
-        return Stream.concat(scoreContributions, ownGoalContributions)
-                .collect(groupingBy(
-                        QuarterTeamScore::quarter,
-                        groupingBy(QuarterTeamScore::gameTeamId, summingInt(QuarterTeamScore::score))
-                ));
+        return QuarterTeamScores.from(Stream.concat(scoreContributions, ownGoalContributions));
     }
 
     private List<ProgressAction> actionsFromQuarterEnd(Quarter lastQuarter, SportType sportType) {

--- a/src/main/java/com/sports/server/query/dto/response/OwnGoalRecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/OwnGoalRecordResponse.java
@@ -1,0 +1,22 @@
+package com.sports.server.query.dto.response;
+
+import com.sports.server.command.timeline.domain.OwnGoalTimeline;
+import java.util.List;
+
+public record OwnGoalRecordResponse(
+        Long ownGoalRecordId,
+        Integer score,
+        List<ScoreRecordResponse.Snapshot> snapshot
+) {
+
+    public static OwnGoalRecordResponse from(OwnGoalTimeline ownGoalTimeline) {
+        return new OwnGoalRecordResponse(
+                ownGoalTimeline.getId(),
+                ownGoalTimeline.getScore(),
+                List.of(
+                        ScoreRecordResponse.Snapshot.of(ownGoalTimeline.getGameTeam1(), ownGoalTimeline.getSnapshotScore1()),
+                        ScoreRecordResponse.Snapshot.of(ownGoalTimeline.getGameTeam2(), ownGoalTimeline.getSnapshotScore2())
+                )
+        );
+    }
+}

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -20,6 +20,7 @@ public record RecordResponse(
         String teamName,
         String teamImageUrl,
         ScoreRecordResponse scoreRecord,
+        OwnGoalRecordResponse ownGoalRecord,
         ReplacementRecordResponse replacementRecord,
         ProgressRecordResponse progressRecord,
         PkRecordResponse pkRecord,
@@ -27,7 +28,7 @@ public record RecordResponse(
 ) {
     public static RecordResponse from(Timeline timeline) {
         Optional<LineupPlayer> lineupPlayer = getPlayer(timeline);
-        Optional<GameTeam> gameTeam = lineupPlayer.map(LineupPlayer::getGameTeam);
+        Optional<GameTeam> gameTeam = getCreditedGameTeam(timeline, lineupPlayer);
         Optional<Team> team = gameTeam.map(GameTeam::getTeam);
 
         return new RecordResponse(
@@ -41,6 +42,8 @@ public record RecordResponse(
                 team.map(Team::getLogoImageUrl).orElse(null),
                 timeline instanceof ScoreTimeline scoreTimeline
                         ? ScoreRecordResponse.from(scoreTimeline) : null,
+                timeline instanceof OwnGoalTimeline ownGoalTimeline
+                        ? OwnGoalRecordResponse.from(ownGoalTimeline) : null,
                 timeline instanceof ReplacementTimeline replacementTimeline
                         ? new ReplacementRecordResponse(
                                 replacementTimeline.getId(),
@@ -55,9 +58,27 @@ public record RecordResponse(
         );
     }
 
+    private static Optional<GameTeam> getCreditedGameTeam(Timeline timeline, Optional<LineupPlayer> lineupPlayer) {
+        if (timeline instanceof OwnGoalTimeline ownGoalTimeline) {
+            return Optional.of(resolveOpponentTeam(ownGoalTimeline));
+        }
+        return lineupPlayer.map(LineupPlayer::getGameTeam);
+    }
+
+    // 자책골의 경우에는 타임라인이 등록 주체의 상대 팀으로 표기됨
+    private static GameTeam resolveOpponentTeam(OwnGoalTimeline ownGoalTimeline) {
+        GameTeam ownTeam = ownGoalTimeline.getScorer().getGameTeam();
+        if (ownTeam.equals(ownGoalTimeline.getGameTeam1())) {
+            return ownGoalTimeline.getGameTeam2();
+        }
+        return ownGoalTimeline.getGameTeam1();
+    }
+
     private static Optional<LineupPlayer> getPlayer(Timeline timeline) {
         if (timeline instanceof ScoreTimeline scoreTimeline) {
             return Optional.of(scoreTimeline.getScorer());
+        } else if (timeline instanceof OwnGoalTimeline ownGoalTimeline) {
+            return Optional.of(ownGoalTimeline.getScorer());
         } else if (timeline instanceof ReplacementTimeline replacementTimeline) {
             return Optional.of(replacementTimeline.getOriginLineupPlayer());
         } else if (timeline instanceof PKTimeline pkTimeline) {

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -60,18 +60,9 @@ public record RecordResponse(
 
     private static Optional<GameTeam> getCreditedGameTeam(Timeline timeline, Optional<LineupPlayer> lineupPlayer) {
         if (timeline instanceof OwnGoalTimeline ownGoalTimeline) {
-            return Optional.of(resolveOpponentTeam(ownGoalTimeline));
+            return Optional.of(ownGoalTimeline.getOpponentGameTeam());
         }
         return lineupPlayer.map(LineupPlayer::getGameTeam);
-    }
-
-    // 자책골의 경우에는 타임라인이 등록 주체의 상대 팀으로 표기됨
-    private static GameTeam resolveOpponentTeam(OwnGoalTimeline ownGoalTimeline) {
-        GameTeam ownTeam = ownGoalTimeline.getScorer().getGameTeam();
-        if (ownTeam.equals(ownGoalTimeline.getGameTeam1())) {
-            return ownGoalTimeline.getGameTeam2();
-        }
-        return ownGoalTimeline.getGameTeam1();
     }
 
     private static Optional<LineupPlayer> getPlayer(Timeline timeline) {

--- a/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
+++ b/src/main/java/com/sports/server/query/repository/TimelineQueryRepository.java
@@ -2,6 +2,7 @@ package com.sports.server.query.repository;
 
 import com.sports.server.command.team.domain.PlayerGoalCount;
 import com.sports.server.command.team.domain.PlayerGoalCountWithRank;
+import com.sports.server.command.timeline.domain.OwnGoalTimeline;
 import com.sports.server.command.timeline.domain.ScoreTimeline;
 import com.sports.server.command.timeline.domain.Timeline;
 import com.sports.server.query.dto.TeamTopScorerResult;
@@ -22,6 +23,9 @@ public interface TimelineQueryRepository extends Repository<Timeline, Long> {
 
     @Query("SELECT st FROM ScoreTimeline st JOIN FETCH st.scorer sc JOIN FETCH sc.gameTeam WHERE st.game.id = :gameId")
     List<ScoreTimeline> findScoreTimelinesByGameId(@Param("gameId") Long gameId);
+
+    @Query("SELECT ogt FROM OwnGoalTimeline ogt JOIN FETCH ogt.scorer sc JOIN FETCH sc.gameTeam WHERE ogt.game.id = :gameId")
+    List<OwnGoalTimeline> findOwnGoalTimelinesByGameId(@Param("gameId") Long gameId);
 
     @Query("SELECT COALESCE(SUM(st.score), 0) FROM ScoreTimeline st WHERE st.scorer.player.id = :playerId")
     int countTotalGoalsByPlayerId(@Param("playerId") Long playerId);

--- a/src/test/java/com/sports/server/command/cheertalk/application/AiSeedServiceTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/application/AiSeedServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -23,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
@@ -154,6 +156,25 @@ class AiSeedServiceTest {
 
             verify(cheerTalkRepository).save(any(CheerTalk.class));
             verify(eventPublisher).publishEvent(any(Object.class));
+        }
+
+        @Test
+        @DisplayName("OWN_GOAL 트리거는 유저 발화 여부와 무관하게 발화하고, 지정된 팀(상대팀)에 귀속된다")
+        void OWN_GOAL_무조건_발화() {
+            when(gameRepository.findByIdWithLeague(1L)).thenReturn(Optional.of(soccerGame));
+            when(gameTeamRepository.findAllByGameIdWithTeamOrderByAsc(1L)).thenReturn(gameTeams);
+            when(cheerTalkRepository.countAiSeedsByGameTeamIds(anyList())).thenReturn(0L);
+            when(cheerTalkRepository.findLastAiSeed(anyList())).thenReturn(Optional.empty());
+            when(cheerTalkRepository.existsUserCheerTalkAfter(anyList(), any(LocalDateTime.class)))
+                    .thenReturn(true);
+            when(messageGenerator.generate(any(), any(), any())).thenReturn("어...?");
+
+            aiSeedService.publish(1L, AiSeedTriggerType.OWN_GOAL, 2L, null);
+
+            ArgumentCaptor<CheerTalk> cheerTalkCaptor = ArgumentCaptor.forClass(CheerTalk.class);
+            verify(cheerTalkRepository).save(cheerTalkCaptor.capture());
+            verify(eventPublisher).publishEvent(any(Object.class));
+            assertThat(cheerTalkCaptor.getValue().getGameTeamId()).isEqualTo(2L);
         }
 
         @Test

--- a/src/test/java/com/sports/server/command/cheertalk/infra/AiSeedMessageGeneratorTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/infra/AiSeedMessageGeneratorTest.java
@@ -31,7 +31,8 @@ class AiSeedMessageGeneratorTest {
                 "ㅋㅋ,ㅋㅋㅋ,ㅋㅋㅋㅋ,ㄷㄷ,ㄷㄷㄷ,와,ㅎㅎ,ㅎㅎㅎ,ㄹㅇ",
                 "경기 시작 전 프롬프트 {team_name}",
                 "후반전 프롬프트 {team_name}",
-                "골 프롬프트 {team_name} {scorer_name}"
+                "골 프롬프트 {team_name} {scorer_name}",
+                "자책골 프롬프트 {team_name}"
         );
     }
 
@@ -59,6 +60,17 @@ class AiSeedMessageGeneratorTest {
             String result = generator.generate(AiSeedTriggerType.SCHEDULED, "경영", null);
 
             assertThat(result).isEqualTo("경영 간다");
+        }
+
+        @Test
+        @DisplayName("OWN_GOAL 트리거는 선수명 없이도 정상 응답을 반환한다")
+        void OWN_GOAL_정상_응답() {
+            when(chatCaller.call(any(), any(Duration.class)))
+                    .thenReturn(responseOf("어...?"));
+
+            String result = generator.generate(AiSeedTriggerType.OWN_GOAL, "경영", null);
+
+            assertThat(result).isEqualTo("어...?");
         }
 
         @Test
@@ -124,6 +136,17 @@ class AiSeedMessageGeneratorTest {
             String result = generator.generate(AiSeedTriggerType.GOAL, "경영", "민준");
 
             assertThat(result).isEqualTo("민준 좋았다");
+        }
+
+        @Test
+        @DisplayName("LLM 호출 실패 시 OWN_GOAL fallback은 선수명을 포함하지 않는다")
+        void LLM_실패_OWN_GOAL_fallback() {
+            when(chatCaller.call(any(), any(Duration.class)))
+                    .thenThrow(new RuntimeException("network error"));
+
+            String result = generator.generate(AiSeedTriggerType.OWN_GOAL, "경영", null);
+
+            assertThat(result).isEqualTo("이건 예상 못했네");
         }
 
         @Test

--- a/src/test/java/com/sports/server/command/cheertalk/presentation/AiSeedEventListenerTest.java
+++ b/src/test/java/com/sports/server/command/cheertalk/presentation/AiSeedEventListenerTest.java
@@ -1,12 +1,14 @@
 package com.sports.server.command.cheertalk.presentation;
 
 import com.sports.server.command.cheertalk.application.AiSeedService;
+import com.sports.server.command.cheertalk.domain.AiSeedTriggerType;
 import com.sports.server.command.game.domain.GameTeam;
 import com.sports.server.command.game.domain.LineupPlayer;
 import com.sports.server.command.league.domain.SoccerQuarter;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.timeline.domain.GameProgressTimeline;
 import com.sports.server.command.timeline.domain.GameProgressType;
+import com.sports.server.command.timeline.domain.OwnGoalTimeline;
 import com.sports.server.command.timeline.domain.ScoreTimeline;
 import com.sports.server.command.timeline.domain.TimelineCreatedEvent;
 import com.sports.server.command.timeline.domain.TimelineRepository;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.scheduling.TaskScheduler;
 
 import java.time.Instant;
@@ -60,6 +63,38 @@ class AiSeedEventListenerTest {
             when(timelineRepository.findById(10L)).thenReturn(Optional.empty());
 
             TimelineCreatedEvent event = new TimelineCreatedEvent(10L, 100L, TimelineType.SCORE);
+            listener.handle(event);
+
+            verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("OWN_GOAL 타임라인 이벤트")
+    class OwnGoalEvent {
+
+        @Test
+        @DisplayName("OWN_GOAL 이벤트면 OWN_GOAL 트리거로 상대팀에 예약한다")
+        void OWN_GOAL_이벤트_상대팀_예약() {
+            OwnGoalTimeline ownGoalTimeline = mockOwnGoalTimeline(2L);
+            when(timelineRepository.findById(10L)).thenReturn(Optional.of(ownGoalTimeline));
+
+            TimelineCreatedEvent event = new TimelineCreatedEvent(10L, 100L, TimelineType.OWN_GOAL);
+            listener.handle(event);
+
+            ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+            verify(taskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+
+            runnableCaptor.getValue().run();
+            verify(aiSeedService).publish(100L, AiSeedTriggerType.OWN_GOAL, 2L, null);
+        }
+
+        @Test
+        @DisplayName("timeline이 존재하지 않으면 무시한다")
+        void timeline_없으면_무시() {
+            when(timelineRepository.findById(10L)).thenReturn(Optional.empty());
+
+            TimelineCreatedEvent event = new TimelineCreatedEvent(10L, 100L, TimelineType.OWN_GOAL);
             listener.handle(event);
 
             verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
@@ -135,6 +170,14 @@ class AiSeedEventListenerTest {
         when(player.getName()).thenReturn(scorerName);
         when(scorer.getGameTeam()).thenReturn(gameTeam);
         when(gameTeam.getId()).thenReturn(gameTeamId);
+        return timeline;
+    }
+
+    private OwnGoalTimeline mockOwnGoalTimeline(Long opponentGameTeamId) {
+        OwnGoalTimeline timeline = mock(OwnGoalTimeline.class);
+        GameTeam opponentGameTeam = mock(GameTeam.class);
+        when(opponentGameTeam.getId()).thenReturn(opponentGameTeamId);
+        when(timeline.getOpponentGameTeam()).thenReturn(opponentGameTeam);
         return timeline;
     }
 

--- a/src/test/java/com/sports/server/command/game/domain/GameTest.java
+++ b/src/test/java/com/sports/server/command/game/domain/GameTest.java
@@ -231,6 +231,32 @@ class GameTest {
             assertThatThrownBy(() -> basketballGame.scoreOwnGoal(scorer, 1))
                     .isInstanceOf(BadRequestException.class);
         }
+
+        @Test
+        void 상대_팀이_없으면_자책골을_기록할_수_없다() {
+            // given
+            League soloTeamLeague = entityBuilder(League.class)
+                    .set("sportType", SportType.SOCCER)
+                    .sample();
+            Game soloTeamGame = entityBuilder(Game.class)
+                    .set("id", 4L)
+                    .set("league", soloTeamLeague)
+                    .set("gameTeams", new ArrayList<>())
+                    .sample();
+            GameTeam onlyTeam = entityBuilder(GameTeam.class)
+                    .set("id", 5L)
+                    .set("game", soloTeamGame)
+                    .sample();
+            soloTeamGame.addGameTeam(onlyTeam);
+
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", onlyTeam)
+                    .sample();
+
+            // when then
+            assertThatThrownBy(() -> soloTeamGame.scoreOwnGoal(scorer, 1))
+                    .isInstanceOf(BadRequestException.class);
+        }
     }
 
     @Nested

--- a/src/test/java/com/sports/server/command/game/domain/GameTest.java
+++ b/src/test/java/com/sports/server/command/game/domain/GameTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.SportType;
+import com.sports.server.common.exception.BadRequestException;
 import com.sports.server.common.exception.CustomException;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,13 +23,19 @@ class GameTest {
 
     @BeforeEach
     public void setUp() {
+        League soccerLeague = entityBuilder(League.class)
+                .set("sportType", SportType.SOCCER)
+                .sample();
+
         game = entityBuilder(Game.class)
                 .set("id", 1L)
+                .set("league", soccerLeague)
                 .set("gameTeams", new ArrayList<>())
                 .sample();
 
         game2 = entityBuilder(Game.class)
                 .set("id", 2L)
+                .set("league", soccerLeague)
                 .set("gameTeams", new ArrayList<>())
                 .sample();
 
@@ -139,6 +148,93 @@ class GameTest {
 
     @Nested
     @DisplayName("Game에서")
+    class OwnGoalScoreTest {
+
+        @Test
+        void team1_선수의_자책골이면_team2가_득점한다() {
+            // given
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", team1)
+                    .sample();
+
+            // when
+            game.scoreOwnGoal(scorer, 1);
+
+            // then
+            assertAll(
+                    () -> assertThat(team1.getScore()).isEqualTo(0),
+                    () -> assertThat(team2.getScore()).isEqualTo(1)
+            );
+        }
+
+        @Test
+        void team2_선수의_자책골이면_team1이_득점한다() {
+            // given
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", team2)
+                    .sample();
+
+            // when
+            game.scoreOwnGoal(scorer, 1);
+
+            // then
+            assertAll(
+                    () -> assertThat(team1.getScore()).isEqualTo(1),
+                    () -> assertThat(team2.getScore()).isEqualTo(0)
+            );
+        }
+
+        @Test
+        void 참여하지_않는_선수는_자책골을_기록할_수_없다() {
+            // given
+            GameTeam otherTeam = entityBuilder(GameTeam.class)
+                    .set("id", 999L)
+                    .set("game", game2)
+                    .sample();
+
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", otherTeam)
+                    .sample();
+
+            // when then
+            assertThatThrownBy(() -> game.scoreOwnGoal(scorer, 1))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void 축구가_아닌_경기에서는_자책골을_기록할_수_없다() {
+            // given
+            League basketballLeague = entityBuilder(League.class)
+                    .set("sportType", SportType.BASKETBALL)
+                    .sample();
+            Game basketballGame = entityBuilder(Game.class)
+                    .set("id", 3L)
+                    .set("league", basketballLeague)
+                    .set("gameTeams", new ArrayList<>())
+                    .sample();
+            GameTeam basketballTeam1 = entityBuilder(GameTeam.class)
+                    .set("id", 3L)
+                    .set("game", basketballGame)
+                    .sample();
+            GameTeam basketballTeam2 = entityBuilder(GameTeam.class)
+                    .set("id", 4L)
+                    .set("game", basketballGame)
+                    .sample();
+            basketballGame.addGameTeam(basketballTeam1);
+            basketballGame.addGameTeam(basketballTeam2);
+
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", basketballTeam1)
+                    .sample();
+
+            // when then
+            assertThatThrownBy(() -> basketballGame.scoreOwnGoal(scorer, 1))
+                    .isInstanceOf(BadRequestException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Game에서")
     class CancelScoreTest {
 
         private LineupPlayer team1Player;
@@ -167,6 +263,38 @@ class GameTest {
                     () -> assertThat(team1.getScore()).isEqualTo(0),
                     () -> assertThat(team2.getScore()).isEqualTo(0)
             );
+        }
+
+        @Test
+        void team1_선수의_자책골로_인한_team2의_득점을_취소한다() {
+            // given
+            game.scoreOwnGoal(team1Player, 1);
+
+            // when
+            game.cancelOwnGoalScore(team1Player, 1);
+
+            // then
+            assertAll(
+                    () -> assertThat(team1.getScore()).isEqualTo(0),
+                    () -> assertThat(team2.getScore()).isEqualTo(0)
+            );
+        }
+
+        @Test
+        void 참여하지_않는_선수는_자책골_득점을_취소할_수_없다() {
+            // given
+            GameTeam otherTeam = entityBuilder(GameTeam.class)
+                    .set("id", 999L)
+                    .set("game", game2)
+                    .sample();
+
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", otherTeam)
+                    .sample();
+
+            // when then
+            assertThatThrownBy(() -> game.cancelOwnGoalScore(scorer, 1))
+                    .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test

--- a/src/test/java/com/sports/server/command/league/application/LeagueTopScorerServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueTopScorerServiceTest.java
@@ -6,6 +6,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.sports.server.command.league.domain.League;
 import com.sports.server.command.league.domain.LeagueTopScorer;
 import com.sports.server.command.league.domain.LeagueTopScorerRepository;
+import com.sports.server.command.league.domain.SoccerQuarter;
+import com.sports.server.command.league.domain.SportType;
+import com.sports.server.command.member.domain.Member;
+import com.sports.server.command.member.domain.MemberRepository;
+import com.sports.server.command.timeline.application.TimelineService;
+import com.sports.server.command.timeline.dto.TimelineRequest;
 import com.sports.server.common.application.EntityUtils;
 import com.sports.server.common.exception.NotFoundException;
 import com.sports.server.support.ServiceTest;
@@ -25,6 +31,12 @@ public class LeagueTopScorerServiceTest extends ServiceTest {
 
     @Autowired
     private LeagueTopScorerRepository leagueTopScorerRepository;
+
+    @Autowired
+    private TimelineService timelineService;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
     private EntityUtils entityUtils;
@@ -110,6 +122,31 @@ public class LeagueTopScorerServiceTest extends ServiceTest {
                     .findFirst()
                     .orElseThrow(() -> new AssertionError("선수2가 득점왕 목록에 없습니다."));
             assertThat(player2TopScorer.getGoalCount()).isEqualTo(2); // 리그1에서만 2골
+        }
+
+        @Test
+        void 자책골은_득점왕_집계에_포함되지_않는다() {
+            // given
+            Long leagueId = 1L;
+            Long gameId = 1L;
+            Long team1Id = 1L;
+            Long team1PlayerId = 1L; // 선수1: 리그1(game1, game2)에서 이미 2골
+
+            Member manager = memberRepository.findMemberByEmail("john.doe@example.com").orElseThrow();
+            TimelineRequest.RegisterOwnGoal ownGoalRequest = new TimelineRequest.RegisterOwnGoal(
+                    50, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team1Id, team1PlayerId);
+            timelineService.register(manager, gameId, ownGoalRequest);
+
+            // when
+            leagueTopScorerService.updateTopScorersForLeague(leagueId);
+
+            // then
+            List<LeagueTopScorer> topScorers = leagueTopScorerRepository.findByLeagueId(leagueId);
+            LeagueTopScorer player1TopScorer = topScorers.stream()
+                    .filter(scorer -> scorer.getPlayer().getId().equals(1L))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("선수1이 득점왕 목록에 없습니다."));
+            assertThat(player1TopScorer.getGoalCount()).isEqualTo(2); // 자책골은 반영되지 않아 그대로 2골
         }
     }
 }

--- a/src/test/java/com/sports/server/command/league/domain/BasketballQuarterTest.java
+++ b/src/test/java/com/sports/server/command/league/domain/BasketballQuarterTest.java
@@ -71,4 +71,11 @@ class BasketballQuarterTest {
             assertThat(quarters[i].getOrder()).isLessThan(quarters[i + 1].getOrder());
         }
     }
+
+    @Test
+    void 농구_쿼터는_자책골을_기록할_수_없다() {
+        for (BasketballQuarter quarter : BasketballQuarter.values()) {
+            assertThat(quarter.canRecordOwnGoal()).isFalse();
+        }
+    }
 }

--- a/src/test/java/com/sports/server/command/league/domain/SoccerQuarterTest.java
+++ b/src/test/java/com/sports/server/command/league/domain/SoccerQuarterTest.java
@@ -62,4 +62,15 @@ class SoccerQuarterTest {
             assertThat(quarters[i].getOrder()).isLessThan(quarters[i + 1].getOrder());
         }
     }
+
+    @ParameterizedTest
+    @CsvSource({
+            "FIRST_HALF, true",
+            "SECOND_HALF, true",
+            "EXTRA_TIME, true",
+            "PENALTY_SHOOTOUT, false"
+    })
+    void 승부차기를_제외한_쿼터에서만_자책골을_기록할_수_있다(SoccerQuarter quarter, boolean expected) {
+        assertThat(quarter.canRecordOwnGoal()).isEqualTo(expected);
+    }
 }

--- a/src/test/java/com/sports/server/command/league/domain/SportTypeTest.java
+++ b/src/test/java/com/sports/server/command/league/domain/SportTypeTest.java
@@ -59,4 +59,10 @@ class SportTypeTest {
         assertThat(SportType.SOCCER.resolveQuarter("PRE_GAME")).isInstanceOf(CommonQuarter.class);
         assertThat(SportType.BASKETBALL.resolveQuarter("PRE_GAME")).isInstanceOf(CommonQuarter.class);
     }
+
+    @Test
+    void 축구만_자책골을_기록할_수_있다() {
+        assertThat(SportType.SOCCER.canRecordOwnGoal()).isTrue();
+        assertThat(SportType.BASKETBALL.canRecordOwnGoal()).isFalse();
+    }
 }

--- a/src/test/java/com/sports/server/command/timeline/acceptance/TimelineAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/acceptance/TimelineAcceptanceTest.java
@@ -80,6 +80,77 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void 자책골_타임라인을_생성한다() {
+        // given
+        TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
+                3, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
+                team1Id,
+                team1PlayerId
+        );
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .cookie(COOKIE_NAME, mockToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .post("/games/{gameId}/timelines/own-goal", gameId)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 요청한_팀과_다른_팀_선수를_자책골_선수로_등록하면_400을_반환한다() {
+        // given
+        long team2PlayerId = 6L; // 팀2 소속 선수 (팀1 자책골 타임라인에 등록 시도)
+
+        TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
+                3, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
+                team1Id,
+                team2PlayerId
+        );
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .cookie(COOKIE_NAME, mockToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .post("/games/{gameId}/timelines/own-goal", gameId)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void 승부차기에서_자책골_타임라인을_등록하면_400을_반환한다() {
+        // given
+        TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
+                3, SportType.SOCCER, SoccerQuarter.PENALTY_SHOOTOUT.name(),
+                team1Id,
+                team1PlayerId
+        );
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .cookie(COOKIE_NAME, mockToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .post("/games/{gameId}/timelines/own-goal", gameId)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
     void 다른_팀_선수를_어시스트로_등록하면_400을_반환한다() {
         // given
         long team2PlayerId = 6L; // 팀2 소속 선수 (팀1 득점 타임라인에 어시스트로 등록 시도)

--- a/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
@@ -172,6 +172,73 @@ class TimelineServiceTest extends ServiceTest {
         }
     }
 
+    @DisplayName("자책골 타임라인을")
+    @Nested
+    class CreateOwnGoalTest {
+        @Test
+        void team1_선수의_자책골이면_team2가_득점한다() {
+            // given
+            Long team1Id = 1L;
+            Long team1PlayerId = 1L;
+
+            TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
+                    3, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team1Id, team1PlayerId);
+
+            // when
+            timelineService.register(manager, gameId, request);
+
+            // then
+            OwnGoalTimeline actual = (OwnGoalTimeline) timelineFixtureRepository.findAllLatest(gameId).get(0);
+
+            assertAll(() -> assertThat(actual.getScorer().getId()).isEqualTo(team1PlayerId),
+                    () -> assertThat(actual.getSnapshotScore1()).isEqualTo(15),
+                    () -> assertThat(actual.getSnapshotScore2()).isEqualTo(11));
+        }
+
+        @Test
+        void 승부차기에서는_등록할_수_없다() {
+            // given
+            Long team1Id = 1L;
+            Long team1PlayerId = 1L;
+
+            TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
+                    3, SportType.SOCCER, SoccerQuarter.PENALTY_SHOOTOUT.name(), team1Id, team1PlayerId);
+
+            // when then
+            assertThatThrownBy(() -> timelineService.register(manager, gameId, request))
+                    .isInstanceOf(BadRequestException.class);
+        }
+
+        @Test
+        void 요청한_팀과_다른_팀_선수는_자책골_선수로_등록할_수_없다() {
+            // given
+            Long team1Id = 1L;
+            Long team2PlayerId = 6L; // 팀2 소속 선수
+
+            TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
+                    3, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team1Id, team2PlayerId);
+
+            // when then
+            assertThatThrownBy(() -> timelineService.register(manager, gameId, request))
+                    .isInstanceOf(BadRequestException.class);
+        }
+
+        @Test
+        void 농구_경기에서는_등록할_수_없다() {
+            // given: 농구 경기(game 5)에 자책골 등록 시도
+            Long basketballGameId = 5L;
+            Long basketballTeamId = 7L;
+            Long basketballPlayerId = 17L;
+
+            TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
+                    3, SportType.BASKETBALL, BasketballQuarter.FIRST_QUARTER.name(), basketballTeamId, basketballPlayerId);
+
+            // when then
+            assertThatThrownBy(() -> timelineService.register(manager, basketballGameId, request))
+                    .isInstanceOf(BadRequestException.class);
+        }
+    }
+
     @DisplayName("교체 타임라인을")
     @Nested
     class CreateReplacementTest {

--- a/src/test/java/com/sports/server/command/timeline/domain/OwnGoalTimelineTest.java
+++ b/src/test/java/com/sports/server/command/timeline/domain/OwnGoalTimelineTest.java
@@ -1,0 +1,156 @@
+package com.sports.server.command.timeline.domain;
+
+import static com.sports.server.support.fixture.FixtureMonkeyUtils.entityBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.GameTeam;
+import com.sports.server.command.game.domain.LineupPlayer;
+import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.SoccerQuarter;
+import com.sports.server.command.league.domain.SportType;
+import com.sports.server.common.exception.BadRequestException;
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class OwnGoalTimelineTest {
+
+    private Game game;
+    private GameTeam team1;
+    private GameTeam team2;
+
+    @BeforeEach
+    void setUp() {
+        League league = entityBuilder(League.class)
+                .set("sportType", SportType.SOCCER)
+                .sample();
+
+        game = entityBuilder(Game.class)
+                .set("league", league)
+                .set("gameTeams", new ArrayList<>())
+                .sample();
+
+        team1 = entityBuilder(GameTeam.class)
+                .set("id", 1L)
+                .set("game", game)
+                .set("score", 1)
+                .sample();
+
+        team2 = entityBuilder(GameTeam.class)
+                .set("id", 2L)
+                .set("game", game)
+                .set("score", 2)
+                .sample();
+
+        game.addGameTeam(team1);
+        game.addGameTeam(team2);
+    }
+
+    @Nested
+    @DisplayName("자책골 타임라인을")
+    class CreateTest {
+
+        @Test
+        void 자책골_선수가_요청한_팀_소속이면_생성된다() {
+            // given
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", team1)
+                    .sample();
+
+            // when
+            OwnGoalTimeline timeline = OwnGoalTimeline.of(
+                    game, SoccerQuarter.FIRST_HALF, 10, scorer, team1, 1
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(timeline.getScorer()).isEqualTo(scorer),
+                    () -> assertThat(timeline.getType()).isEqualTo(TimelineType.OWN_GOAL)
+            );
+        }
+
+        @Test
+        void 승부차기에서는_생성할_수_없다() {
+            // given
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", team1)
+                    .sample();
+
+            // when then
+            assertThatThrownBy(() -> OwnGoalTimeline.of(
+                    game, SoccerQuarter.PENALTY_SHOOTOUT, 10, scorer, team1, 1
+            )).isInstanceOf(BadRequestException.class);
+        }
+
+        @Test
+        void 요청한_팀과_실제_소속_팀이_다르면_생성할_수_없다() {
+            // given
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", team1)
+                    .sample();
+
+            // when then
+            assertThatThrownBy(() -> OwnGoalTimeline.of(
+                    game, SoccerQuarter.FIRST_HALF, 10, scorer, team2, 1
+            )).isInstanceOf(BadRequestException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("자책골 타임라인을 적용하면")
+    class ApplyTest {
+
+        @Test
+        void team1_선수의_자책골이면_team2가_득점하고_스냅샷이_반영된다() {
+            // given
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", team1)
+                    .sample();
+            OwnGoalTimeline timeline = OwnGoalTimeline.of(
+                    game, SoccerQuarter.FIRST_HALF, 10, scorer, team1, 1
+            );
+
+            // when
+            timeline.apply();
+
+            // then
+            assertAll(
+                    () -> assertThat(team1.getScore()).isEqualTo(1),
+                    () -> assertThat(team2.getScore()).isEqualTo(3),
+                    () -> assertThat(timeline.getSnapshotScore1()).isEqualTo(1),
+                    () -> assertThat(timeline.getSnapshotScore2()).isEqualTo(3)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("자책골 타임라인을 롤백하면")
+    class RollbackTest {
+
+        @Test
+        void team1_선수의_자책골로_인한_team2의_득점이_취소된다() {
+            // given
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", team1)
+                    .sample();
+            OwnGoalTimeline timeline = OwnGoalTimeline.of(
+                    game, SoccerQuarter.FIRST_HALF, 10, scorer, team1, 1
+            );
+            timeline.apply();
+
+            // when
+            timeline.rollback();
+
+            // then
+            assertAll(
+                    () -> assertThat(team1.getScore()).isEqualTo(1),
+                    () -> assertThat(team2.getScore()).isEqualTo(2)
+            );
+        }
+    }
+}

--- a/src/test/java/com/sports/server/command/timeline/presentation/TimelineControllerTest.java
+++ b/src/test/java/com/sports/server/command/timeline/presentation/TimelineControllerTest.java
@@ -99,6 +99,41 @@ public class TimelineControllerTest extends DocumentationTest {
     }
 
     @Test
+    void 자책골_타임라인을_생성한다() throws Exception {
+        // given
+        TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
+                10, SportType.SOCCER, SoccerQuarter.FIRST_HALF.name(),
+                1L,
+                1L
+        );
+
+        // when
+        ResultActions result = mockMvc.perform(post("/games/{gameId}/timelines/own-goal", 1)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .cookie(new Cookie(COOKIE_NAME, "temp-cookie"))
+        );
+
+        // then
+        result.andExpect(status().isCreated())
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("gameId").description("경기의 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("sportType").type(JsonFieldType.STRING).description("스포츠 종류 (SOCCER)"),
+                                fieldWithPath("gameTeamId").type(JsonFieldType.NUMBER).description("자책골 선수가 소속된(우리) 팀의 Id"),
+                                fieldWithPath("recordedQuarter").type(JsonFieldType.STRING).description("쿼터 (FIRST_HALF, SECOND_HALF, EXTRA_TIME. 승부차기는 불가)"),
+                                fieldWithPath("scorerLineupPlayerId").type(JsonFieldType.NUMBER).description("자책골 선수 Id"),
+                                fieldWithPath("recordedAt").type(JsonFieldType.NUMBER).description("기록 시간")
+                        ),
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        )
+                ));
+    }
+
+    @Test
     void 축구_교체_타임라인을_생성한다() throws Exception {
         // given
         TimelineRequest.RegisterReplacement request = new TimelineRequest.RegisterReplacement(

--- a/src/test/java/com/sports/server/query/application/AvailableProgressQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/AvailableProgressQueryServiceTest.java
@@ -372,4 +372,31 @@ class AvailableProgressQueryServiceTest extends ServiceTest {
             assertThat(responses).isEmpty();
         }
     }
+
+    @Nested
+    @DisplayName("쿼터별 득점 조회 시 자책골이 포함되면")
+    @Sql(scripts = "/own-goal-quarter-score-fixture.sql")
+    class 쿼터별_득점_조회_자책골_포함 {
+
+        private static final long SOCCER_GAME_ID = 1L;
+        private static final long TEAM_A_GAME_TEAM_ID = 1L;
+        private static final long TEAM_B_GAME_TEAM_ID = 2L;
+
+        @Test
+        void 자책골로_상대팀이_얻은_점수가_쿼터_득점에_반영된다() {
+            List<QuarterScoreResponse> responses = timelineQueryService.getQuarterScores(SOCCER_GAME_ID);
+
+            assertThat(responses).hasSize(1);
+
+            QuarterScoreResponse firstHalfScore = responses.get(0);
+            Map<Long, Integer> scoreMap = firstHalfScore.scores().stream()
+                    .collect(Collectors.toMap(QuarterScoreResponse.TeamScore::gameTeamId, QuarterScoreResponse.TeamScore::score));
+
+            assertAll(
+                    () -> assertThat(firstHalfScore.quarter()).isEqualTo(SoccerQuarter.FIRST_HALF.name()),
+                    () -> assertThat(scoreMap.get(TEAM_A_GAME_TEAM_ID)).isEqualTo(1), // 팀A: 정상 득점 1골
+                    () -> assertThat(scoreMap.get(TEAM_B_GAME_TEAM_ID)).isEqualTo(1)  // 팀B: 팀A의 자책골로 얻은 1점
+            );
+        }
+    }
 }

--- a/src/test/java/com/sports/server/query/dto/response/RecordResponseTest.java
+++ b/src/test/java/com/sports/server/query/dto/response/RecordResponseTest.java
@@ -1,0 +1,126 @@
+package com.sports.server.query.dto.response;
+
+import static com.sports.server.support.fixture.FixtureMonkeyUtils.entityBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.sports.server.command.game.domain.Game;
+import com.sports.server.command.game.domain.GameTeam;
+import com.sports.server.command.game.domain.LineupPlayer;
+import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.SoccerQuarter;
+import com.sports.server.command.league.domain.SportType;
+import com.sports.server.command.player.domain.Player;
+import com.sports.server.command.team.domain.Team;
+import com.sports.server.command.timeline.domain.OwnGoalTimeline;
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class RecordResponseTest {
+
+    private Game game;
+    private GameTeam team1;
+    private GameTeam team2;
+
+    @BeforeEach
+    void setUp() {
+        League league = entityBuilder(League.class)
+                .set("sportType", SportType.SOCCER)
+                .sample();
+
+        game = entityBuilder(Game.class)
+                .set("league", league)
+                .set("gameTeams", new ArrayList<>())
+                .sample();
+
+        Team teamA = entityBuilder(Team.class)
+                .set("name", "팀A")
+                .set("logoImageUrl", "http://example.com/logo_a.png")
+                .sample();
+        Team teamB = entityBuilder(Team.class)
+                .set("name", "팀B")
+                .set("logoImageUrl", "http://example.com/logo_b.png")
+                .sample();
+
+        team1 = entityBuilder(GameTeam.class)
+                .set("id", 1L)
+                .set("game", game)
+                .set("team", teamA)
+                .set("score", 1)
+                .sample();
+
+        team2 = entityBuilder(GameTeam.class)
+                .set("id", 2L)
+                .set("game", game)
+                .set("team", teamB)
+                .set("score", 2)
+                .sample();
+
+        game.addGameTeam(team1);
+        game.addGameTeam(team2);
+    }
+
+    @Nested
+    @DisplayName("자책골 타임라인을 변환하면")
+    class OwnGoalTest {
+
+        @Test
+        void 득점자_이름과_상대팀_정보를_담아_변환한다() {
+            // given
+            Player player = entityBuilder(Player.class)
+                    .set("name", "선수1")
+                    .sample();
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", team1)
+                    .set("player", player)
+                    .sample();
+            OwnGoalTimeline timeline = OwnGoalTimeline.of(
+                    game, SoccerQuarter.FIRST_HALF, 10, scorer, team1, 1
+            );
+            timeline.apply();
+
+            // when
+            RecordResponse actual = RecordResponse.from(timeline);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual.type()).isEqualTo("OWN_GOAL"),
+                    () -> assertThat(actual.playerName()).isEqualTo(scorer.getPlayer().getName()),
+                    () -> assertThat(actual.gameTeamId()).isEqualTo(team2.getId()),
+                    () -> assertThat(actual.teamName()).isEqualTo("팀B"),
+                    () -> assertThat(actual.teamImageUrl()).isEqualTo("http://example.com/logo_b.png"),
+                    () -> assertThat(actual.scoreRecord()).isNull(),
+                    () -> assertThat(actual.ownGoalRecord()).isNotNull(),
+                    () -> assertThat(actual.ownGoalRecord().score()).isEqualTo(1)
+            );
+        }
+
+        @Test
+        void team2_선수의_자책골이면_team1_정보를_담아_변환한다() {
+            // given
+            Player player = entityBuilder(Player.class)
+                    .set("name", "선수6")
+                    .sample();
+            LineupPlayer scorer = entityBuilder(LineupPlayer.class)
+                    .set("gameTeam", team2)
+                    .set("player", player)
+                    .sample();
+            OwnGoalTimeline timeline = OwnGoalTimeline.of(
+                    game, SoccerQuarter.FIRST_HALF, 10, scorer, team2, 1
+            );
+            timeline.apply();
+
+            // when
+            RecordResponse actual = RecordResponse.from(timeline);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual.gameTeamId()).isEqualTo(team1.getId()),
+                    () -> assertThat(actual.teamName()).isEqualTo("팀A")
+            );
+        }
+    }
+}

--- a/src/test/java/com/sports/server/query/dto/response/RecordResponseTest.java
+++ b/src/test/java/com/sports/server/query/dto/response/RecordResponseTest.java
@@ -13,6 +13,7 @@ import com.sports.server.command.league.domain.SportType;
 import com.sports.server.command.player.domain.Player;
 import com.sports.server.command.team.domain.Team;
 import com.sports.server.command.timeline.domain.OwnGoalTimeline;
+import com.sports.server.command.timeline.domain.TimelineDeletabilityEvaluator;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -83,7 +84,7 @@ class RecordResponseTest {
             timeline.apply();
 
             // when
-            RecordResponse actual = RecordResponse.from(timeline);
+            RecordResponse actual = RecordResponse.from(timeline, TimelineDeletabilityEvaluator.Result.allowed());
 
             // then
             assertAll(
@@ -114,7 +115,7 @@ class RecordResponseTest {
             timeline.apply();
 
             // when
-            RecordResponse actual = RecordResponse.from(timeline);
+            RecordResponse actual = RecordResponse.from(timeline, TimelineDeletabilityEvaluator.Result.allowed());
 
             // then
             assertAll(

--- a/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
@@ -60,6 +60,12 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                                         new ScoreRecordResponse.Snapshot(
                                                                 TEAM_B, TEAM_B_IMAGE_URL, 3)
                                                 ), null),
+                                                new OwnGoalRecordResponse(2L, 1, List.of(
+                                                        new ScoreRecordResponse.Snapshot(
+                                                                TEAM_A, TEAM_A_IMAGE_URL, 2),
+                                                        new ScoreRecordResponse.Snapshot(
+                                                                TEAM_B, TEAM_B_IMAGE_URL, 3)
+                                                )),
                                                 new ReplacementRecordResponse(1L, "선수3", null),
                                                 new ProgressRecordResponse(GameProgressType.QUARTER_START),
                                                 new PkRecordResponse(1L, true),
@@ -78,6 +84,12 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                                         new ScoreRecordResponse.Snapshot(
                                                                 TEAM_B, TEAM_B_IMAGE_URL, 0)
                                                 ), null),
+                                                new OwnGoalRecordResponse(2L, 1, List.of(
+                                                        new ScoreRecordResponse.Snapshot(
+                                                                TEAM_A, TEAM_A_IMAGE_URL, 2),
+                                                        new ScoreRecordResponse.Snapshot(
+                                                                TEAM_B, TEAM_B_IMAGE_URL, 0)
+                                                )),
                                                 new ReplacementRecordResponse(1L, "선수3", null),
                                                 new ProgressRecordResponse(GameProgressType.QUARTER_END),
                                                 new PkRecordResponse(4L, false),
@@ -96,6 +108,12 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                                         new ScoreRecordResponse.Snapshot(
                                                                 TEAM_B, TEAM_B_IMAGE_URL, 0)
                                                 ), null),
+                                                new OwnGoalRecordResponse(2L, 1, List.of(
+                                                        new ScoreRecordResponse.Snapshot(
+                                                                TEAM_A, TEAM_A_IMAGE_URL, 2),
+                                                        new ScoreRecordResponse.Snapshot(
+                                                                TEAM_B, TEAM_B_IMAGE_URL, 0)
+                                                )),
                                                 new ReplacementRecordResponse(2L, "선수5", true),
                                                 new ProgressRecordResponse(GameProgressType.QUARTER_END),
                                                 new PkRecordResponse(4L, false),
@@ -150,6 +168,17 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                         .description("SCORE 타입일 때 점수 스냅샷에 표시할 점수"),
                                 fieldWithPath("timelines[].records[].scoreRecord.assistPlayerName").type(JsonFieldType.NULL)
                                         .description("SCORE 타입일 때 어시스트 선수 이름 (없으면 null)").optional(),
+                                fieldWithPath("timelines[].records[].ownGoalRecord.ownGoalRecordId").type(JsonFieldType.NUMBER)
+                                        .description("OWN_GOAL 타입 기록의 ID"),
+                                fieldWithPath("timelines[].records[].ownGoalRecord.score").type(JsonFieldType.NUMBER)
+                                        .description("OWN_GOAL 타입일 때 상대 팀에 반영된 점수"),
+                                fieldWithPath("timelines[].records[].ownGoalRecord.snapshot[].teamName").type(JsonFieldType.STRING)
+                                        .description("OWN_GOAL 타입일 때 점수 스냅샷에 표시할 팀 이름"),
+                                fieldWithPath("timelines[].records[].ownGoalRecord.snapshot[].teamImageUrl").type(
+                                                JsonFieldType.STRING)
+                                        .description("OWN_GOAL 타입일 때 점수 스냅샷에 표시할 팀 이미지"),
+                                fieldWithPath("timelines[].records[].ownGoalRecord.snapshot[].score").type(JsonFieldType.NUMBER)
+                                        .description("OWN_GOAL 타입일 때 점수 스냅샷에 표시할 점수"),
                                 fieldWithPath("timelines[].records[].replacementRecord.replacementRecordId").type(
                                                 JsonFieldType.NUMBER)
                                         .description("REPLACEMENT 타입 기록의  ID"),

--- a/src/test/resources/own-goal-quarter-score-fixture.sql
+++ b/src/test/resources/own-goal-quarter-score-fixture.sql
@@ -1,0 +1,57 @@
+SET foreign_key_checks = 0;
+
+INSERT INTO organizations (id, name, student_number_digits)
+VALUES (1, '테스트 조직', 9);
+
+INSERT INTO members (id, organization_id, email, password, is_administrator, last_login)
+VALUES (1, 1, 'manager@example.com', 'password', TRUE, '2024-01-01 00:00:00');
+
+INSERT INTO units (id, name, organization_id)
+VALUES (1, '단과대', 1);
+
+INSERT INTO teams (id, unit_id, name, logo_image_url, team_color)
+VALUES (1, 1, '팀A', 'http://example.com/logo_a.png', '#FF0000'),
+       (2, 1, '팀B', 'http://example.com/logo_b.png', '#0000FF');
+
+INSERT INTO players (id, name, student_number)
+VALUES (1, '선수1', '202100001'),
+       (2, '선수2', '202100002');
+
+INSERT INTO team_players (id, team_id, player_id, jersey_number)
+VALUES (1, 1, 1, 1),
+       (2, 2, 2, 2);
+
+INSERT INTO leagues (id, organization_id, administrator_id, name, start_at, end_at, is_deleted, max_round, in_progress_round, sport_type)
+VALUES (1, 1, 1, '테스트 리그', '2024-01-01 00:00:00', '2024-12-31 23:59:59', FALSE, '결승', '4강', 'SOCCER');
+
+INSERT INTO league_teams (id, league_id, team_id, total_cheer_count, total_talk_count, ranking)
+VALUES (1, 1, 1, 0, 0, 1),
+       (2, 1, 2, 0, 0, 2);
+
+-- 전반전이 진행 중인(1쿼터 종료까지 마친) 축구 경기
+INSERT INTO games (id, administrator_id, league_id, name, start_time, video_id, quarter_changed_at, game_quarter, state, round, is_pk_taken)
+VALUES (1, 1, 1, '자책골_쿼터_득점_테스트용', '2024-01-01 10:00:00', null, '2024-01-01 10:45:00', 'FIRST_HALF', 'PLAYING', '4강', FALSE);
+
+INSERT INTO game_teams (id, game_id, team_id, cheer_count, score, pk_score, result)
+VALUES (1, 1, 1, 0, 1, 0, null), -- 팀A: 정상 득점 1골
+       (2, 1, 2, 0, 1, 0, null); -- 팀B: 팀A의 자책골로 1점 획득
+
+INSERT INTO lineup_players (id, game_team_id, player_id, jersey_number, is_captain, state, is_playing, replaced_player_id)
+VALUES (1, 1, 1, 1, TRUE, 'STARTER', TRUE, null), -- 팀A 선수1
+       (2, 2, 2, 2, TRUE, 'STARTER', TRUE, null); -- 팀B 선수2
+
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, game_progress_type, game_team1_id, game_team2_id, snapshot_score1, snapshot_score2, previous_quarter, previous_quarter_changed_at)
+VALUES ('GAME_PROGRESS', 1, 'FIRST_HALF', 0, 'QUARTER_START', 1, 2, 0, 0, 'PRE_GAME', null);
+
+-- 팀A 선수1의 정상 득점
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, score, game_team1_id, snapshot_score1, game_team2_id, snapshot_score2)
+VALUES ('SCORE', 1, 'FIRST_HALF', 10, 1, 1, 1, 1, 2, 0);
+
+-- 팀A 선수1의 자책골 (팀B가 득점)
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, scorer_id, score, game_team1_id, snapshot_score1, game_team2_id, snapshot_score2)
+VALUES ('OWN_GOAL', 1, 'FIRST_HALF', 20, 1, 1, 1, 1, 2, 1);
+
+INSERT INTO timelines (type, game_id, recorded_quarter, recorded_at, game_progress_type, game_team1_id, game_team2_id, snapshot_score1, snapshot_score2, previous_quarter, previous_quarter_changed_at)
+VALUES ('GAME_PROGRESS', 1, 'FIRST_HALF', 45, 'QUARTER_END', 1, 2, 1, 1, 'FIRST_HALF', '2024-01-01 10:00:00');
+
+SET foreign_key_checks = 1;


### PR DESCRIPTION
## 🌍 이슈 번호

- closes #700

## 📝 구현 내용

자책골 관련 정책 6가지(경기 상태 제한, 어시스트 불가, 타임라인 조회 반영, 우리 팀 선수 검증, 조회 시 상대팀 귀속, 득점왕 미반영, 삭제 시 -1)를 커밋 단위로 나눠 구현했다.

- `Quarter`에 `canRecordOwnGoal()` 추가 — 승부차기를 제외한 전반/후반/연장전만 자책골 기록 가능 (`SoccerQuarter`만 오버라이드, 농구/공통 쿼터는 기본값 `false`)
- `SportType`에도 동일 패턴으로 `canRecordOwnGoal()` 추가 — 자책골은 축구 경기에서만 등록 가능. `Game.scoreOwnGoal`/`cancelOwnGoalScore`가 판별을 직접 하지 않고 여기에 위임
- `Game`에 `scoreOwnGoal`/`cancelOwnGoalScore` 추가 — 득점 선수가 아니라 **상대 팀**의 점수를 증감 (`opponentOf` 헬퍼)
- `ScoreTimeline`과 분리된 별도 엔티티 `OwnGoalTimeline`(`TimelineType.OWN_GOAL`) 신설
  - 어시스트 필드 없음
  - 득점왕 집계 쿼리(`TimelineQueryRepository`)가 전부 `FROM ScoreTimeline` 기준이라, 별도 엔티티로 분리한 것만으로 자책골이 득점왕 기록에서 **자동으로 제외**됨 (추가 필터링 코드 불필요)
  - 정적 팩토리에서 쿼터 검증 + "자책골 선수가 요청한 팀(우리 팀) 소속인지" 검증
- `POST /games/{gameId}/timelines/own-goal` 등록 API 추가
- 타임라인 조회 응답(`RecordResponse`)에서 자책골은 **상대팀 기준**으로 `gameTeamId/teamName/teamImageUrl`을 표시(`playerName`은 자책골 선수 유지) — 등록은 우리팀 기준, 조회는 상대팀 기준이라는 정책 반영
- 삭제는 기존 `TimelineService.deleteTimeline`의 `apply()`/`rollback()` 디스패치 구조를 그대로 재사용해 별도 구현 없이 상대팀 점수 -1이 보장됨
- (추가 수정) `GET /games/{gameId}/quarter-scores`(쿼터별 득점 조회)가 `ScoreTimeline`만 합산하고 있어, 자책골이 발생한 쿼터에서는 실제 `GameTeam.score`와 쿼터별 합계가 어긋나는 걸 자체 점검 중 발견해 같이 수정함
  - 득점왕 집계와 달리 이 API는 "그 쿼터에 각 팀이 실제로 얻은 점수"를 보여줘야 하므로 자책골로 상대팀이 얻은 점수도 포함되어야 함
  - `TimelineQueryRepository.findOwnGoalTimelinesByGameId` 추가, `OwnGoalTimeline.getOpponentGameTeam()`으로 상대팀 계산 로직을 엔티티로 옮기고 `RecordResponse`의 중복 로직도 이 메서드로 교체
  - 기존 축구 픽스처에는 쿼터가 종료된 경기가 없어 검증이 불가능했어서 `own-goal-quarter-score-fixture.sql` 신규 추가 + 회귀 테스트 추가
- (추가 수정) AI Seed 응원톡이 `TimelineType.SCORE`만 처리하고 있어서, 자책골이 발생해도 AI 응원톡이 전혀 생성되지 않고 있었음. `AiSeedTriggerType.OWN_GOAL`을 추가하고 발화 대상 팀도 `OwnGoalTimeline.getOpponentGameTeam()`(상대팀)으로 지정
  - 일반 `GOAL` 프롬프트를 그대로 쓰면 상대팀 선수 이름을 `{scorer_name}`에 꽂아 칭찬하는 이상한 메시지가 나와서, 별도 프롬프트로 분리(선수 이름 언급 금지, 환호/칭찬 대신 "예상 못한 상황을 본 관객" 톤)
  - 프롬프트 실제 텍스트는 별도 저장소인 be-config 서브모듈 쪽 변경이라 hufscheer/be-config#28로 따로 PR을 냈고, 이 PR은 그 커밋을 가리키도록 서브모듈 포인터만 갱신함 → **be-config#28이 먼저(또는 함께)머지되어 배포 config에 반영되어야 함** (안 그러면 `ai-seed.prompt.own-goal` 바인딩 실패로 앱 기동 시 에러)

## 🍀 확인해야 할 부분

- 자책골을 `ScoreTimeline`에 플래그(`isOwnGoal`)로 추가하는 대신 별도 엔티티로 분리했습니다. DB 스키마 변경은 없고(기존 discriminator 컬럼 재사용), 득점왕 쿼리 수정이 필요 없어진다는 장점이 있는데 이 방향에 이견 있으면 알려주세요.
- 자책골 등록 요청의 `gameTeamId`(자책골 선수가 소속된 팀)와 실제 선수 소속 팀이 다르면 400을 반환하도록 검증을 추가했는데, 기존 일반 득점(`RegisterScore`)의 `gameTeamId`는 이런 대조 검증이 없었습니다(참고용 필드로만 존재). 자책골만 이 검증을 추가한 게 맞는 방향인지 확인 부탁드립니다.
- be-config#28 머지 순서/타이밍 조율이 필요합니다 (배포 전에 머지되어야 함).
