### PR TITLE
docs: 타임라인 삭제 API에 중간 삭제 정책과 실패 응답 문서화

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -282,7 +282,22 @@ operation::timeline-query-controller-test/가능한_경기_진행_액션을_조�
 
 === 타임라인 삭제
 
+진행 중인 경기는 마지막 기록이 아니어도 삭제할 수 있다. 삭제하면 이후 기록의 점수와 득점 시점 스코어가 다시 계산된다.
+
+다만 아래 기록은 삭제가 거부된다.
+
+* 선수 교체 — 교체로 들어오거나 나간 선수의 기록이 뒤에 남아 있는 경우
+* 쿼터 시작·종료, 경기 종료 — 마지막 기록일 때만 삭제 가능
+* 종료된 경기의 중간 기록 — 마지막 기록만 삭제 가능
+
+"뒤에 남아 있는지"는 화면 정렬(경기 시각)이 아니라 실제 입력 순서를 기준으로 판단한다.
+각 기록의 삭제 가능 여부는 타임라인 조회 응답의 `deletable`·`undeletableReason` 으로도 미리 확인할 수 있다.
+
 operation::timeline-controller-test/타임라인을_삭제한다[snippets='http-request,request-cookies,path-parameters,http-response']
+
+==== 삭제할 수 없는 기록을 삭제하려는 경우
+
+operation::timeline-controller-test/삭제할_수_없는_타임라인은_사유와_함께_거부된다[snippets='http-request,http-response,response-fields']
 
 == 사용자 API
 

--- a/src/test/java/com/sports/server/command/timeline/presentation/TimelineControllerTest.java
+++ b/src/test/java/com/sports/server/command/timeline/presentation/TimelineControllerTest.java
@@ -1,11 +1,15 @@
 package com.sports.server.command.timeline.presentation;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,6 +21,8 @@ import com.sports.server.command.league.domain.SportType;
 import com.sports.server.command.league.domain.SoccerQuarter;
 import com.sports.server.command.timeline.domain.WarningCardType;
 import com.sports.server.command.timeline.dto.TimelineRequest;
+import com.sports.server.command.timeline.exception.TimelineErrorMessage;
+import com.sports.server.common.exception.BadRequestException;
 import com.sports.server.support.DocumentationTest;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
@@ -325,10 +331,49 @@ public class TimelineControllerTest extends DocumentationTest {
                 .andDo(restDocsHandler.document(
                         pathParameters(
                                 parameterWithName("gameId").description("경기의 ID"),
+                                parameterWithName("timelineId").description("삭제할 타임라인의 ID. "
+                                        + "진행 중인 경기는 마지막 기록이 아니어도 삭제할 수 있고, "
+                                        + "삭제하면 이후 기록의 점수와 득점 시점 스코어가 다시 계산된다")
+                        ),
+                        requestCookies(
+                                cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        )
+                ));
+    }
+
+    @Test
+    void 삭제할_수_없는_타임라인은_사유와_함께_거부된다() throws Exception {
+        // given
+        willThrow(new BadRequestException(TimelineErrorMessage.REPLACEMENT_PLAYER_HAS_LATER_RECORDS))
+                .given(timelineService).deleteTimeline(any(), anyLong(), anyLong());
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/games/{gameId}/timelines/{timelineId}", 1, 1)
+                        .cookie(new Cookie(COOKIE_NAME, "temp-cookie"))
+        );
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andDo(restDocsHandler.document(
+                        pathParameters(
+                                parameterWithName("gameId").description("경기의 ID"),
                                 parameterWithName("timelineId").description("타임라인의 ID")
                         ),
                         requestCookies(
                                 cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("삭제 불가 사유. 그대로 사용자에게 노출할 수 있으며, "
+                                                + "타임라인 조회 응답의 undeletableReason 과 같은 문구다. "
+                                                + "가능한 값 — "
+                                                + "교체 선수의 이후 기록이 있어요. 해당 기록부터 삭제해 주세요. / "
+                                                + "쿼터 시작·종료 기록은 최근 기록일 때만 삭제할 수 있어요. / "
+                                                + "종료된 경기는 최근 기록만 삭제할 수 있어요. / "
+                                                + "이미 삭제되었거나 존재하지 않는 기록이에요."),
+                                fieldWithPath("fieldErrors").type(JsonFieldType.ARRAY).optional()
+                                        .description("입력값 검증 실패 상세. 삭제 실패에서는 사용하지 않는다")
                         )
                 ));
     }


### PR DESCRIPTION
## 이슈

- #694 후속 (PR #695 에서 누락된 문서 보완)

## 변경 내용

#695 로 중간 삭제가 열렸는데 API 경로와 요청 형식이 그대로라, REST Docs 에는 성공(204) 응답만 남아 있었다. 프론트 입장에서 어떤 경우에 400 이 오는지, 그 message 를 사용자에게 그대로 노출해도 되는지 문서만 봐서는 알 수 없는 상태였다.

- 삭제 실패 케이스 문서화 테스트 추가 — 400 응답과 `ErrorResponse.message` 를 snippet 으로 남긴다. message 설명에 기획 확정 문구 4종을 나열하고, 타임라인 조회 응답의 `undeletableReason` 과 같은 문구라는 점을 명시했다
- `api.adoc` 의 "타임라인 삭제" 절에 삭제 정책(교체 / 쿼터 진행 / 종료된 경기)과 판단 기준을 설명으로 추가했다. 특히 "뒤에 남아 있는지"를 화면 정렬(경기 시각)이 아니라 실제 입력 순서로 판단한다는 점은 프론트가 놓치기 쉬운 지점이라 본문에 적었다

## 테스트

- `TimelineControllerTest` green
- `./scripts/check-api-docs.sh` 통과 (엔드포인트 95개)
- `asciidoctor` 빌드 후 생성된 HTML 에서 정책 설명과 실패 응답이 모두 렌더되는 것 확인

## 영향 API

없음. 문서와 문서화 테스트만 변경했고 프로덕션 코드는 건드리지 않았다.