### PR TITLE
feat: 타임라인 삭제 불가 사유 코드 추가 및 교체 기록 null 방어

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -302,7 +302,14 @@ operation::timeline-query-controller-test/가능한_경기_진행_액션을_조�
 * 종료된 경기의 중간 기록 — 마지막 기록만 삭제 가능
 
 "뒤에 남아 있는지"는 화면 정렬(경기 시각)이 아니라 실제 입력 순서를 기준으로 판단한다.
-각 기록의 삭제 가능 여부는 타임라인 조회 응답의 `deletable`·`undeletableReason` 으로도 미리 확인할 수 있다.
+각 기록의 삭제 가능 여부는 타임라인 조회 응답의 `deletable`·`undeletableReason`·`undeletableReasonCode` 로도 미리 확인할 수 있다.
+
+삭제 아이콘 노출 여부는 기록 타입이 아니라 `deletable` 값으로 판단한다.
+쿼터 시작·종료와 경기 종료 기록도 마지막 기록이면 `deletable` 이 `true` 이고,
+오입력한 경기 종료를 되돌릴 수 있는 유일한 수단이므로 타입만 보고 아이콘을 숨기면 안 된다.
+
+문구에 따라 분기해야 할 때는 `undeletableReason`(사용자 노출용 문구) 대신
+`undeletableReasonCode` 를 쓴다. 문구는 바뀔 수 있지만 코드는 유지된다.
 
 operation::timeline-controller-test/타임라인을_삭제한다[snippets='http-request,request-cookies,path-parameters,http-response']
 

--- a/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/ReplacementTimeline.java
@@ -1,6 +1,8 @@
 package com.sports.server.command.timeline.domain;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import com.sports.server.command.game.domain.Game;
 import com.sports.server.command.game.domain.LineupPlayer;
@@ -82,6 +84,8 @@ public abstract class ReplacementTimeline extends Timeline {
 
     @Override
     public List<LineupPlayer> getRelatedLineupPlayers() {
-        return List.of(originLineupPlayer, replacedLineupPlayer);
+        return Stream.of(originLineupPlayer, replacedLineupPlayer)
+                .filter(Objects::nonNull)
+                .toList();
     }
 }

--- a/src/main/java/com/sports/server/command/timeline/domain/TimelineDeletabilityEvaluator.java
+++ b/src/main/java/com/sports/server/command/timeline/domain/TimelineDeletabilityEvaluator.java
@@ -47,6 +47,10 @@ public final class TimelineDeletabilityEvaluator {
         public String reasonMessage() {
             return reason == null ? null : reason.getMessage();
         }
+
+        public String reasonCode() {
+            return reason == null ? null : reason.name();
+        }
     }
 
     public static Map<Long, Result> evaluate(GameState gameState, List<Timeline> timelines) {

--- a/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecordResponse.java
@@ -25,7 +25,8 @@ public record RecordResponse(
         PkRecordResponse pkRecord,
         WarningCardRecordResponse warningCardRecord,
         boolean deletable,
-        String undeletableReason
+        String undeletableReason,
+        String undeletableReasonCode
 ) {
     public static RecordResponse from(Timeline timeline, TimelineDeletabilityEvaluator.Result deletability) {
         Optional<LineupPlayer> lineupPlayer = getPlayer(timeline);
@@ -55,7 +56,8 @@ public record RecordResponse(
                 timeline instanceof WarningCardTimeline warningCardTimeline
                         ? new WarningCardRecordResponse(warningCardTimeline.getWarningCardType()) : null,
                 deletability.deletable(),
-                deletability.reasonMessage()
+                deletability.reasonMessage(),
+                deletability.reasonCode()
         );
     }
 

--- a/src/test/java/com/sports/server/query/application/TimelineQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/TimelineQueryServiceTest.java
@@ -8,6 +8,7 @@ import com.sports.server.command.league.domain.SportType;
 import com.sports.server.command.member.domain.Member;
 import com.sports.server.command.member.domain.MemberRepository;
 import com.sports.server.command.timeline.application.TimelineService;
+import com.sports.server.command.timeline.domain.TimelineDeletabilityEvaluator.Reason;
 import com.sports.server.command.timeline.dto.TimelineRequest;
 import com.sports.server.command.timeline.exception.TimelineErrorMessage;
 import com.sports.server.query.dto.response.RecordResponse;
@@ -65,13 +66,19 @@ class TimelineQueryServiceTest extends ServiceTest {
                 () -> assertThat(quarterStart.deletable()).isFalse(),
                 () -> assertThat(quarterStart.undeletableReason())
                         .isEqualTo(TimelineErrorMessage.PROGRESS_TIMELINE_NOT_LAST),
+                () -> assertThat(quarterStart.undeletableReasonCode())
+                        .isEqualTo(Reason.PROGRESS_TIMELINE_NOT_LAST.name()),
                 () -> assertThat(firstGoal.deletable()).isTrue(),
                 () -> assertThat(firstGoal.undeletableReason()).isNull(),
+                () -> assertThat(firstGoal.undeletableReasonCode()).isNull(),
                 () -> assertThat(replacement.deletable()).isFalse(),
                 () -> assertThat(replacement.undeletableReason())
                         .isEqualTo(TimelineErrorMessage.REPLACEMENT_PLAYER_HAS_LATER_RECORDS),
+                () -> assertThat(replacement.undeletableReasonCode())
+                        .isEqualTo(Reason.REPLACEMENT_PLAYER_HAS_LATER_RECORDS.name()),
                 () -> assertThat(lastGoal.deletable()).isTrue(),
-                () -> assertThat(lastGoal.undeletableReason()).isNull()
+                () -> assertThat(lastGoal.undeletableReason()).isNull(),
+                () -> assertThat(lastGoal.undeletableReasonCode()).isNull()
         );
     }
 
@@ -90,10 +97,13 @@ class TimelineQueryServiceTest extends ServiceTest {
                 () -> assertThat(middles).isNotEmpty(),
                 () -> assertThat(last.deletable()).isTrue(),
                 () -> assertThat(last.undeletableReason()).isNull(),
+                () -> assertThat(last.undeletableReasonCode()).isNull(),
                 () -> assertThat(middles).allSatisfy(record -> {
                     assertThat(record.deletable()).isFalse();
                     assertThat(record.undeletableReason())
                             .isEqualTo(TimelineErrorMessage.MIDDLE_DELETE_ONLY_WHILE_PLAYING);
+                    assertThat(record.undeletableReasonCode())
+                            .isEqualTo(Reason.MIDDLE_DELETE_ONLY_WHILE_PLAYING.name());
                 })
         );
     }

--- a/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TimelineQueryControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.sports.server.command.league.domain.BasketballQuarter;
 import com.sports.server.command.league.domain.SoccerQuarter;
 import com.sports.server.command.timeline.domain.GameProgressType;
+import com.sports.server.command.timeline.domain.TimelineDeletabilityEvaluator;
 import com.sports.server.command.timeline.domain.WarningCardType;
 import com.sports.server.command.timeline.exception.TimelineErrorMessage;
 import com.sports.server.query.dto.response.*;
@@ -66,6 +67,7 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                                 new PkRecordResponse(1L, true),
                                                 new WarningCardRecordResponse(WarningCardType.YELLOW),
                                                 true,
+                                                null,
                                                 null
                                         ),
                                         new RecordResponse(
@@ -86,7 +88,8 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                                 new PkRecordResponse(4L, false),
                                                 new WarningCardRecordResponse(WarningCardType.RED),
                                                 false,
-                                                TimelineErrorMessage.REPLACEMENT_PLAYER_HAS_LATER_RECORDS
+                                                TimelineErrorMessage.REPLACEMENT_PLAYER_HAS_LATER_RECORDS,
+                                                TimelineDeletabilityEvaluator.Reason.REPLACEMENT_PLAYER_HAS_LATER_RECORDS.name()
                                         ),
                                         new RecordResponse(
                                                 null, 1L, BASKETBALL_REPLACEMENT_TYPE,
@@ -106,6 +109,7 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                                 new PkRecordResponse(4L, false),
                                                 new WarningCardRecordResponse(WarningCardType.RED),
                                                 true,
+                                                null,
                                                 null
                                         )
                                 ))
@@ -178,9 +182,20 @@ public class TimelineQueryControllerTest extends DocumentationTest {
                                                 JsonFieldType.STRING)
                                         .description("WARNING_CARD 타입일 때 경고 카드 타입(YELLOW, RED)"),
                                 fieldWithPath("timelines[].records[].deletable").type(JsonFieldType.BOOLEAN)
-                                        .description("현재 시점 기준 이 기록의 삭제 가능 여부"),
+                                        .description("현재 시점 기준 이 기록의 삭제 가능 여부. "
+                                                + "삭제 아이콘 노출 여부는 기록 타입이 아니라 이 값으로 판단한다 — "
+                                                + "쿼터 시작·종료, 경기 종료 기록도 마지막 기록이면 true 이며, "
+                                                + "이것이 오입력한 경기 종료를 되돌리는 유일한 수단이다"),
                                 fieldWithPath("timelines[].records[].undeletableReason").type(JsonFieldType.VARIES)
                                         .description("삭제 불가 사유 (삭제 가능하면 null, DELETE 실패 message와 동일 문구)")
+                                        .optional(),
+                                fieldWithPath("timelines[].records[].undeletableReasonCode").type(JsonFieldType.VARIES)
+                                        .description("삭제 불가 사유 코드 (삭제 가능하면 null). 문구 대신 이 값으로 분기한다. "
+                                                + "가능한 값 — "
+                                                + "REPLACEMENT_PLAYER_HAS_LATER_RECORDS: 교체 투입 선수의 이후 기록 존재 / "
+                                                + "PROGRESS_TIMELINE_NOT_LAST: 쿼터 시작·종료 기록의 중간 삭제 / "
+                                                + "MIDDLE_DELETE_ONLY_WHILE_PLAYING: 종료된 경기의 중간 삭제 / "
+                                                + "INCONSISTENT_PROGRESS_STATE: 경기 상태와 기록 불일치")
                                         .optional()
                         )
                 ));


### PR DESCRIPTION
## 이슈

- #694 후속 — #695 로 열린 중간 삭제에서 프론트가 사유별로 분기할 방법이 없던 것과, 조회 500 가능성을 함께 보완한다

## 변경 내용

### 삭제 불가 사유 코드 추가

지금은 프론트가 삭제 불가 사유별로 분기하려면 `undeletableReason` 한글 문구를 문자열 비교해야 한다. 문구가 바뀌면 화면이 조용히 깨진다.

`Reason` enum 이름을 `undeletableReasonCode` 로 함께 내려보내 문구와 분기 기준을 분리했다. 기존 `undeletableReason` 은 그대로 두었으므로 동작 변화가 없다.

- `REPLACEMENT_PLAYER_HAS_LATER_RECORDS` — 교체 투입 선수의 이후 기록 존재
- `PROGRESS_TIMELINE_NOT_LAST` — 쿼터 시작·종료 기록의 중간 삭제
- `MIDDLE_DELETE_ONLY_WHILE_PLAYING` — 종료된 경기의 중간 삭제
- `INCONSISTENT_PROGRESS_STATE` — 경기 상태와 기록 불일치

삭제 실패 응답(`{message, fieldErrors}`)은 공통 포맷이라 건드리지 않았다. 조회 시점에 코드로 아이콘 상태를 정하고, 실패 토스트는 지금처럼 서버 `message` 를 그대로 쓰면 된다.

### 삭제 아이콘 노출 기준을 문서에 명시

기획안에는 "쿼터 시작/종료·경기 종료 = 삭제 아이콘 미노출"로 되어 있는데, 서버는 **마지막 기록이면 진행 기록도 `deletable: true`** 로 내려준다. 오입력한 경기 종료를 되돌리는 유일한 수단이라, 기록 타입만 보고 아이콘을 숨기면 기존 기능이 사라진다. `api.adoc` 에 이 판단 기준을 적었다.

### 교체 타임라인 null 방어

`replaced_lineup_player_id` 는 nullable 인데 `getRelatedLineupPlayers` 가 `List.of` 로 감싸고 있어, NULL 행이 하나라도 있으면 해당 경기 타임라인 조회 전체가 500 이 된다. 삭제 가능 여부 계산이 전 기록을 훑기 때문에 매니저 화면뿐 아니라 관중 화면까지 같이 죽는다.

운영·개발 DB 를 확인한 결과 **현재 NULL 행은 0건**(prod 교체 기록 1,114건 / dev 44건 전부 정상)이라 실제 장애는 없었다. 컬럼이 nullable 로 남아 있는 동안의 방어다.

## 테스트

- `TimelineQueryServiceTest` — 진행 중 경기와 종료된 경기 각각에서 사유 코드가 문구와 함께 내려오는지, 삭제 가능하면 `null` 인지 검증
- `TimelineQueryControllerTest` — REST Docs 필드 문서화 추가 (가능한 코드 값 4종 설명 포함)
- 전체 848건 green / `./scripts/check-api-docs.sh` 통과 (엔드포인트 96개)

## 영향 API

- `GET /games/{gameId}/timeline` — 각 record 에 `undeletableReasonCode` 필드 추가 (삭제 가능하면 `null`). 기존 필드 변경 없음

## 프론트 참고

| 위치 | 변경 | 비고 |
|------|------|------|
| 타임라인 삭제 모드 | 삭제 아이콘 노출 여부를 기록 타입이 아니라 `deletable` 값으로 판단 | 타입으로 판단하면 오입력한 경기 종료를 되돌릴 수 없다 |
| 삭제 불가 토스트 | 사유별 분기가 필요하면 문구 대신 `undeletableReasonCode` 사용 | 문구만 그대로 노출한다면 기존 `undeletableReason` 을 써도 된다 |

## 참고

기획안에 문구가 정의되지 않은 사유가 2건 있다.

- `MIDDLE_DELETE_ONLY_WHILE_PLAYING` — 종료된 경기는 마지막 기록 외 전부 삭제 불가라 득점 기록도 회색이 된다
- `PROGRESS_TIMELINE_NOT_LAST`

현재는 서버 문구를 그대로 쓰고 있다. 확정되면 상수 한 곳만 바꾸면 되므로 알려주면 맞추겠다.