### PR TITLE
refactor: 자책골 타임라인 등록을 득점 API로 통합

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -248,20 +248,21 @@ operation::league-query-controller-test/최근_리그의_게임_목록을_조회
 
 === 득점 타임라인 생성 (축구)
 
-operation::timeline-controller-test/득점_타임라인을_생성한다[snippets='http-request,path-parameters,request-fields,http-response']
-
-=== 득점 타임라인 생성 (농구)
-
-operation::timeline-controller-test/농구_득점_타임라인을_생성한다[snippets='http-request,path-parameters,request-fields,http-response']
-
-=== 자책골 타임라인 생성
-
-등록 요청의 `gameTeamId`/`scorerLineupPlayerId`는 자책골을 넣은 선수가 소속된 팀("우리 팀") 기준이다.
+`isOwnGoal`을 `true`로 지정하면 자책골로 등록된다(SOCCER 전용). 자책골 등록 시 `gameTeamId`/`scoreLineupPlayerId`는
+자책골을 넣은 선수가 소속된 팀("우리 팀") 기준이며, `assistLineupPlayerId`는 값을 보내도 무시된다.
 반면 게임의 타임라인 조회(`GET /games/{gameId}/timeline`) 응답에서는 자책골 기록이 실제로 점수를 얻은
 상대 팀 기준(`gameTeamId`/`teamName`/`teamImageUrl`)으로 표시된다. `playerName`은 등록 시와 동일하게
 자책골을 넣은 선수 이름을 유지한다.
 
-operation::timeline-controller-test/자책골_타임라인을_생성한다[snippets='http-request,path-parameters,request-fields,http-response']
+operation::timeline-controller-test/득점_타임라인을_생성한다[snippets='http-request,path-parameters,request-fields,http-response']
+
+자책골 등록 예시:
+
+operation::timeline-controller-test/자책골_타임라인을_생성한다[snippets='http-request,request-fields']
+
+=== 득점 타임라인 생성 (농구)
+
+operation::timeline-controller-test/농구_득점_타임라인을_생성한다[snippets='http-request,path-parameters,request-fields,http-response']
 
 
 === 축구 교체 타임라인 생성

--- a/src/main/java/com/sports/server/command/timeline/dto/TimelineRequest.java
+++ b/src/main/java/com/sports/server/command/timeline/dto/TimelineRequest.java
@@ -65,6 +65,8 @@ public abstract class TimelineRequest {
 
     @Getter
     public static class RegisterSoccerScore extends RegisterScore {
+        private final Boolean isOwnGoal;
+
         @JsonCreator
         public RegisterSoccerScore(
                 @JsonProperty("gameTeamId") Long gameTeamId,
@@ -72,14 +74,21 @@ public abstract class TimelineRequest {
                 @JsonProperty("recordedQuarter") String recordedQuarter,
                 @JsonProperty("scoreLineupPlayerId") Long scoreLineupPlayerId,
                 @JsonProperty("recordedAt") Integer recordedAt,
-                @JsonProperty("assistLineupPlayerId") Long assistLineupPlayerId
+                @JsonProperty("assistLineupPlayerId") Long assistLineupPlayerId,
+                @JsonProperty("isOwnGoal") Boolean isOwnGoal
         ) {
             super(gameTeamId, sportType, recordedQuarter, scoreLineupPlayerId, recordedAt, assistLineupPlayerId);
+            this.isOwnGoal = isOwnGoal;
         }
 
         @Override
         public int getScoreValue() {
             return SoccerScore.GOAL.getValue();
+        }
+
+        @Override
+        public TimelineType getType() {
+            return Boolean.TRUE.equals(isOwnGoal) ? TimelineType.OWN_GOAL : TimelineType.SCORE;
         }
     }
 
@@ -104,29 +113,6 @@ public abstract class TimelineRequest {
         @Override
         public int getScoreValue() {
             return score.getValue();
-        }
-    }
-
-    @Getter
-    public static class RegisterOwnGoal extends TimelineRequest {
-        private final Long gameTeamId;
-        private final Long scorerLineupPlayerId;
-
-        public RegisterOwnGoal(
-                Integer recordedAt,
-                SportType sportType,
-                String recordedQuarter,
-                Long gameTeamId,
-                Long scorerLineupPlayerId
-        ) {
-            super(sportType, recordedQuarter, recordedAt);
-            this.gameTeamId = gameTeamId;
-            this.scorerLineupPlayerId = scorerLineupPlayerId;
-        }
-
-        @Override
-        public TimelineType getType() {
-            return TimelineType.OWN_GOAL;
         }
     }
 

--- a/src/main/java/com/sports/server/command/timeline/mapper/TimelineMapper.java
+++ b/src/main/java/com/sports/server/command/timeline/mapper/TimelineMapper.java
@@ -21,7 +21,7 @@ public class TimelineMapper {
             TimelineType.SCORE,
             (game, request) -> toScoreTimeline(game, (TimelineRequest.RegisterScore) request),
             TimelineType.OWN_GOAL,
-            (game, request) -> toOwnGoalTimeline(game, (TimelineRequest.RegisterOwnGoal) request),
+            (game, request) -> toOwnGoalTimeline(game, (TimelineRequest.RegisterScore) request),
             TimelineType.SOCCER_REPLACEMENT,
             (game, request) -> toReplacementTimeline(game, (TimelineRequest.RegisterReplacement) request),
             TimelineType.BASKETBALL_REPLACEMENT,
@@ -58,14 +58,14 @@ public class TimelineMapper {
     }
 
     private OwnGoalTimeline toOwnGoalTimeline(Game game,
-                                              TimelineRequest.RegisterOwnGoal ownGoalRequest) {
+                                              TimelineRequest.RegisterScore ownGoalRequest) {
         GameTeam requestedTeam = entityUtils.getEntity(ownGoalRequest.getGameTeamId(), GameTeam.class);
 
         return OwnGoalTimeline.of(
                 game,
                 ownGoalRequest.resolveQuarter(),
                 ownGoalRequest.getRecordedAt(),
-                getPlayer(ownGoalRequest.getScorerLineupPlayerId()),
+                getPlayer(ownGoalRequest.getScoreLineupPlayerId()),
                 requestedTeam,
                 SoccerScore.GOAL.getValue()
         );

--- a/src/main/java/com/sports/server/command/timeline/presentation/TimelineController.java
+++ b/src/main/java/com/sports/server/command/timeline/presentation/TimelineController.java
@@ -20,13 +20,6 @@ public class TimelineController {
         timelineService.register(member, gameId, request);
     }
 
-    @PostMapping("/own-goal")
-    @ResponseStatus(HttpStatus.CREATED)
-    public void createOwnGoalTimeline(@PathVariable Long gameId,
-                                      @RequestBody TimelineRequest.RegisterOwnGoal request, Member member) {
-        timelineService.register(member, gameId, request);
-    }
-
     @PostMapping("/replacement")
     @ResponseStatus(HttpStatus.CREATED)
     public void createReplacementTimeline(@PathVariable Long gameId,

--- a/src/test/java/com/sports/server/command/league/application/LeagueTopScorerServiceTest.java
+++ b/src/test/java/com/sports/server/command/league/application/LeagueTopScorerServiceTest.java
@@ -133,8 +133,8 @@ public class LeagueTopScorerServiceTest extends ServiceTest {
             Long team1PlayerId = 1L; // 선수1: 리그1(game1, game2)에서 이미 2골
 
             Member manager = memberRepository.findMemberByEmail("john.doe@example.com").orElseThrow();
-            TimelineRequest.RegisterOwnGoal ownGoalRequest = new TimelineRequest.RegisterOwnGoal(
-                    50, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team1Id, team1PlayerId);
+            TimelineRequest.RegisterSoccerScore ownGoalRequest = new TimelineRequest.RegisterSoccerScore(
+                    team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team1PlayerId, 50, null, true);
             timelineService.register(manager, gameId, ownGoalRequest);
 
             // when

--- a/src/test/java/com/sports/server/command/timeline/acceptance/TimelineAcceptanceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/acceptance/TimelineAcceptanceTest.java
@@ -36,6 +36,7 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
                 team1Id, SportType.SOCCER, SoccerQuarter.FIRST_HALF.name(),
                 team1PlayerId,
                 3,
+                null,
                 null
         );
 
@@ -62,7 +63,8 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
                 team1Id, SportType.SOCCER, SoccerQuarter.FIRST_HALF.name(),
                 team1PlayerId,
                 3,
-                assistPlayerId
+                assistPlayerId,
+                null
         );
 
         // when
@@ -82,10 +84,12 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
     @Test
     void 자책골_타임라인을_생성한다() {
         // given
-        TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
-                3, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                team1Id,
-                team1PlayerId
+        TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(
+                team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
+                team1PlayerId,
+                3,
+                null,
+                true
         );
 
         // when
@@ -94,7 +98,7 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
                 .cookie(COOKIE_NAME, mockToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
-                .post("/games/{gameId}/timelines/own-goal", gameId)
+                .post("/games/{gameId}/timelines/score", gameId)
                 .then().log().all()
                 .extract();
 
@@ -107,10 +111,12 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
         // given
         long team2PlayerId = 6L; // 팀2 소속 선수 (팀1 자책골 타임라인에 등록 시도)
 
-        TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
-                3, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                team1Id,
-                team2PlayerId
+        TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(
+                team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
+                team2PlayerId,
+                3,
+                null,
+                true
         );
 
         // when
@@ -119,7 +125,7 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
                 .cookie(COOKIE_NAME, mockToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
-                .post("/games/{gameId}/timelines/own-goal", gameId)
+                .post("/games/{gameId}/timelines/score", gameId)
                 .then().log().all()
                 .extract();
 
@@ -130,10 +136,12 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
     @Test
     void 승부차기에서_자책골_타임라인을_등록하면_400을_반환한다() {
         // given
-        TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
-                3, SportType.SOCCER, SoccerQuarter.PENALTY_SHOOTOUT.name(),
-                team1Id,
-                team1PlayerId
+        TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(
+                team1Id, SportType.SOCCER, SoccerQuarter.PENALTY_SHOOTOUT.name(),
+                team1PlayerId,
+                3,
+                null,
+                true
         );
 
         // when
@@ -142,7 +150,7 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
                 .cookie(COOKIE_NAME, mockToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
-                .post("/games/{gameId}/timelines/own-goal", gameId)
+                .post("/games/{gameId}/timelines/score", gameId)
                 .then().log().all()
                 .extract();
 
@@ -159,7 +167,8 @@ public class TimelineAcceptanceTest extends AcceptanceTest {
                 team1Id, SportType.SOCCER, SoccerQuarter.FIRST_HALF.name(),
                 team1PlayerId,
                 3,
-                team2PlayerId
+                team2PlayerId,
+                null
         );
 
         // when

--- a/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
+++ b/src/test/java/com/sports/server/command/timeline/application/TimelineServiceTest.java
@@ -68,7 +68,7 @@ class TimelineServiceTest extends ServiceTest {
         Long team1PlayerId = 1L;
 
         TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                team1PlayerId, 3, null);
+                team1PlayerId, 3, null, null);
 
         // when & then
         assertThatThrownBy(() -> timelineService.register(nonManager, gameId, request)).isInstanceOf(
@@ -86,7 +86,7 @@ class TimelineServiceTest extends ServiceTest {
             Long team1PlayerId = 1L;
 
             TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                    team1PlayerId, 3, null);
+                    team1PlayerId, 3, null, null);
 
             // when
             timelineService.register(manager, gameId, request);
@@ -109,7 +109,7 @@ class TimelineServiceTest extends ServiceTest {
             Long team2PlayerId = 6L;
 
             TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(team2Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                    team2PlayerId, 5, null);
+                    team2PlayerId, 5, null, null);
 
             // when
             timelineService.register(manager, gameId, request);
@@ -132,7 +132,7 @@ class TimelineServiceTest extends ServiceTest {
             Long assistId = 2L; // 같은 팀1 소속 선수
 
             TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                    scorerId, 3, assistId);
+                    scorerId, 3, assistId, null);
 
             // when
             timelineService.register(manager, gameId, request);
@@ -152,7 +152,7 @@ class TimelineServiceTest extends ServiceTest {
             Long assistId = 6L;   // 팀2 선수
 
             TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                    scorerId, 3, assistId);
+                    scorerId, 3, assistId, null);
 
             // when & then
             assertThatThrownBy(() -> timelineService.register(manager, gameId, request))
@@ -166,7 +166,7 @@ class TimelineServiceTest extends ServiceTest {
             Long scorerId = 1L;
 
             TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                    scorerId, 3, scorerId);
+                    scorerId, 3, scorerId, null);
 
             // when & then
             assertThatThrownBy(() -> timelineService.register(manager, gameId, request))
@@ -183,8 +183,8 @@ class TimelineServiceTest extends ServiceTest {
             Long team1Id = 1L;
             Long team1PlayerId = 1L;
 
-            TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
-                    3, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team1Id, team1PlayerId);
+            TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(
+                    team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team1PlayerId, 3, null, true);
 
             // when
             timelineService.register(manager, gameId, request);
@@ -203,8 +203,8 @@ class TimelineServiceTest extends ServiceTest {
             Long team1Id = 1L;
             Long team1PlayerId = 1L;
 
-            TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
-                    3, SportType.SOCCER, SoccerQuarter.PENALTY_SHOOTOUT.name(), team1Id, team1PlayerId);
+            TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(
+                    team1Id, SportType.SOCCER, SoccerQuarter.PENALTY_SHOOTOUT.name(), team1PlayerId, 3, null, true);
 
             // when then
             assertThatThrownBy(() -> timelineService.register(manager, gameId, request))
@@ -217,8 +217,8 @@ class TimelineServiceTest extends ServiceTest {
             Long team1Id = 1L;
             Long team2PlayerId = 6L; // 팀2 소속 선수
 
-            TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
-                    3, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team1Id, team2PlayerId);
+            TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(
+                    team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team2PlayerId, 3, null, true);
 
             // when then
             assertThatThrownBy(() -> timelineService.register(manager, gameId, request))
@@ -232,8 +232,8 @@ class TimelineServiceTest extends ServiceTest {
             Long basketballTeamId = 7L;
             Long basketballPlayerId = 17L;
 
-            TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
-                    3, SportType.BASKETBALL, BasketballQuarter.FIRST_QUARTER.name(), basketballTeamId, basketballPlayerId);
+            TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(
+                    basketballTeamId, SportType.SOCCER, SoccerQuarter.FIRST_HALF.name(), basketballPlayerId, 3, null, true);
 
             // when then
             assertThatThrownBy(() -> timelineService.register(manager, basketballGameId, request))
@@ -402,7 +402,7 @@ class TimelineServiceTest extends ServiceTest {
             Long team1Id = 1L;
             Long team1PlayerId = 1L;
             TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(
-                    team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team1PlayerId, 3, null
+                    team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), team1PlayerId, 3, null, null
             );
 
             // when
@@ -723,7 +723,7 @@ class TimelineServiceTest extends ServiceTest {
         private void registerGoal(Long scorerLineupPlayerId, Long assistLineupPlayerId) {
             timelineService.register(manager, replayGameId, new TimelineRequest.RegisterSoccerScore(
                     replayGameTeamId, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                    scorerLineupPlayerId, 10, assistLineupPlayerId));
+                    scorerLineupPlayerId, 10, assistLineupPlayerId, null));
         }
 
         private void registerReplacement(Long originLineupPlayerId, Long replacementLineupPlayerId) {
@@ -751,7 +751,7 @@ class TimelineServiceTest extends ServiceTest {
         Long finishedGameId = 2L;
 
         TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(team1Id, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                team1PlayerId, 3, null);
+                team1PlayerId, 3, null, null);
 
         // when & then
         assertThatThrownBy(() -> timelineService.register(manager, finishedGameId, request)).isInstanceOf(
@@ -775,7 +775,7 @@ class TimelineServiceTest extends ServiceTest {
             // given
             AtomicInteger successCount = new AtomicInteger(0);
 
-            TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(1L, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), 1L, 1, null);
+            TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(1L, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(), 1L, 1, null, null);
 
             int initialScore1 = 15;
             int initialScore2 = 10;

--- a/src/test/java/com/sports/server/command/timeline/presentation/TimelineControllerTest.java
+++ b/src/test/java/com/sports/server/command/timeline/presentation/TimelineControllerTest.java
@@ -38,6 +38,7 @@ public class TimelineControllerTest extends DocumentationTest {
                 1L, SportType.SOCCER, SoccerQuarter.FIRST_HALF.name(),
                 1L,
                 10,
+                null,
                 null
         );
 
@@ -60,7 +61,8 @@ public class TimelineControllerTest extends DocumentationTest {
                                 fieldWithPath("recordedQuarter").type(JsonFieldType.STRING).description("쿼터 (PRE_GAME, FIRST_HALF, SECOND_HALF, EXTRA_TIME, PENALTY_SHOOTOUT, POST_GAME)"),
                                 fieldWithPath("scoreLineupPlayerId").type(JsonFieldType.NUMBER).description("득점 선수 Id"),
                                 fieldWithPath("recordedAt").type(JsonFieldType.NUMBER).description("득점 시간"),
-                                fieldWithPath("assistLineupPlayerId").type(JsonFieldType.NULL).description("어시스트 선수 Id (없으면 null)").optional()
+                                fieldWithPath("assistLineupPlayerId").type(JsonFieldType.NULL).description("어시스트 선수 Id (없으면 null)").optional(),
+                                fieldWithPath("isOwnGoal").type(JsonFieldType.NULL).description("자책골 여부 (SOCCER 전용, 없으면 일반 득점으로 처리)").optional()
                         ),
                         requestCookies(
                                 cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")
@@ -107,14 +109,16 @@ public class TimelineControllerTest extends DocumentationTest {
     @Test
     void 자책골_타임라인을_생성한다() throws Exception {
         // given
-        TimelineRequest.RegisterOwnGoal request = new TimelineRequest.RegisterOwnGoal(
-                10, SportType.SOCCER, SoccerQuarter.FIRST_HALF.name(),
+        TimelineRequest.RegisterSoccerScore request = new TimelineRequest.RegisterSoccerScore(
+                1L, SportType.SOCCER, SoccerQuarter.FIRST_HALF.name(),
                 1L,
-                1L
+                10,
+                null,
+                true
         );
 
         // when
-        ResultActions result = mockMvc.perform(post("/games/{gameId}/timelines/own-goal", 1)
+        ResultActions result = mockMvc.perform(post("/games/{gameId}/timelines/score", 1)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .cookie(new Cookie(COOKIE_NAME, "temp-cookie"))
@@ -130,8 +134,10 @@ public class TimelineControllerTest extends DocumentationTest {
                                 fieldWithPath("sportType").type(JsonFieldType.STRING).description("스포츠 종류 (SOCCER)"),
                                 fieldWithPath("gameTeamId").type(JsonFieldType.NUMBER).description("자책골 선수가 소속된(우리) 팀의 Id"),
                                 fieldWithPath("recordedQuarter").type(JsonFieldType.STRING).description("쿼터 (FIRST_HALF, SECOND_HALF, EXTRA_TIME. 승부차기는 불가)"),
-                                fieldWithPath("scorerLineupPlayerId").type(JsonFieldType.NUMBER).description("자책골 선수 Id"),
-                                fieldWithPath("recordedAt").type(JsonFieldType.NUMBER).description("기록 시간")
+                                fieldWithPath("scoreLineupPlayerId").type(JsonFieldType.NUMBER).description("자책골 선수 Id"),
+                                fieldWithPath("recordedAt").type(JsonFieldType.NUMBER).description("기록 시간"),
+                                fieldWithPath("assistLineupPlayerId").type(JsonFieldType.NULL).description("어시스트 선수 Id (자책골에서는 무시됨)").optional(),
+                                fieldWithPath("isOwnGoal").type(JsonFieldType.BOOLEAN).description("true로 지정하면 자책골로 등록")
                         ),
                         requestCookies(
                                 cookieWithName(COOKIE_NAME).description("로그인을 통해 얻은 토큰")

--- a/src/test/java/com/sports/server/query/application/TimelineQueryServiceTest.java
+++ b/src/test/java/com/sports/server/query/application/TimelineQueryServiceTest.java
@@ -108,7 +108,7 @@ class TimelineQueryServiceTest extends ServiceTest {
     private void registerGoal(Long scorerLineupPlayerId, Long assistLineupPlayerId) {
         timelineService.register(manager, replayGameId, new TimelineRequest.RegisterSoccerScore(
                 replayGameTeamId, SportType.SOCCER, SoccerQuarter.SECOND_HALF.name(),
-                scorerLineupPlayerId, 10, assistLineupPlayerId));
+                scorerLineupPlayerId, 10, assistLineupPlayerId, null));
     }
 
     private void registerReplacement(Long originLineupPlayerId, Long replacementLineupPlayerId) {


### PR DESCRIPTION
## 🌍 이슈 번호

- 관련 이슈 없음 (#701에서 신설된 `POST /own-goal` 엔드포인트를 팀 논의 후 정리하는 후속 작업)

## 📝 구현 내용

- 기존의 득점 타임라인 등록 API 를 토대로 수정
   - boolean 필드 기반으로 자책골 여부를 받음