### PR TITLE
fix: 리그 조회 응답에 3·4위전 진행 여부 노출

### DIFF
--- a/src/main/java/com/sports/server/query/dto/response/LeagueDetailResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueDetailResponse.java
@@ -13,7 +13,8 @@ public record LeagueDetailResponse(
         int inProgressRound,
         String leagueProgress,
         Integer leagueTeamCount,
-        String sportType
+        String sportType,
+        boolean thirdPlaceMatchEnabled
 ) {
     public static LeagueDetailResponse of(League league, Integer leagueTeamCount) {
         return new LeagueDetailResponse(
@@ -24,7 +25,8 @@ public record LeagueDetailResponse(
                 league.getInProgressRound().getNumber(),
                 LeagueProgress.fromDate(LocalDateTime.now(), league).getDescription(),
                 leagueTeamCount,
-                league.getSportType().name()
+                league.getSportType().name(),
+                league.isThirdPlaceMatchEnabled()
         );
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueResponseToManage.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueResponseToManage.java
@@ -13,7 +13,8 @@ public record LeagueResponseToManage(
         int maxRound,
         LocalDateTime startAt,
         LocalDateTime endAt,
-        String sportType
+        String sportType,
+        boolean thirdPlaceMatchEnabled
 ) {
     public static LeagueResponseToManage of(League league) {
         return new LeagueResponseToManage(
@@ -24,7 +25,8 @@ public record LeagueResponseToManage(
                 league.getMaxRound().getNumber(),
                 league.getStartAt(),
                 league.getEndAt(),
-                league.getSportType().name()
+                league.getSportType().name(),
+                league.isThirdPlaceMatchEnabled()
         );
     }
 }

--- a/src/main/java/com/sports/server/query/dto/response/LeagueResponseWithGames.java
+++ b/src/main/java/com/sports/server/query/dto/response/LeagueResponseWithGames.java
@@ -14,6 +14,7 @@ public record LeagueResponseWithGames(
         LocalDateTime startAt,
         LocalDateTime endAt,
         String sportType,
+        boolean thirdPlaceMatchEnabled,
         List<GameDetail> playingGames,
         List<GameDetail> scheduledGames,
         List<GameDetail> finishedGames
@@ -33,6 +34,7 @@ public record LeagueResponseWithGames(
                 league.getId(), league.getName(), league.getLeagueTeams().size(),
                 league.getMaxRound().getNumber(), league.getStartAt(), league.getEndAt(),
                 league.getSportType().name(),
+                league.isThirdPlaceMatchEnabled(),
                 playingGames, scheduledGames, finishedGames
         );
     }

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -335,7 +335,8 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                         4,
                         "진행 중",
                         3,
-                        "SOCCER"
+                        "SOCCER",
+                        true
                 ));
 
         // when
@@ -357,7 +358,8 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("maxRound").type(JsonFieldType.NUMBER).description("리그 총 라운드"),
                                 fieldWithPath("leagueProgress").type(JsonFieldType.STRING).description("현재 대회 진행 상태"),
                                 fieldWithPath("leagueTeamCount").type(JsonFieldType.NUMBER).description("대회에 참여중인 팀의 수"),
-                                fieldWithPath("sportType").type(JsonFieldType.STRING).description("종목 (SOCCER, BASKETBALL)")
+                                fieldWithPath("sportType").type(JsonFieldType.STRING).description("종목 (SOCCER, BASKETBALL)"),
+                                fieldWithPath("thirdPlaceMatchEnabled").type(JsonFieldType.BOOLEAN).description("3·4위전 진행 여부")
                         )
                 ));
     }
@@ -469,9 +471,9 @@ public class LeagueQueryControllerTest extends DocumentationTest {
         LocalDateTime fixedDateTime = LocalDateTime.of(2024, 9, 11, 12, 0, 0);
         List<LeagueResponseToManage> responses = List.of(
                 new LeagueResponseToManage(1L, "삼건물 대회", "진행 중", 2, 16, fixedDateTime,
-                        fixedDateTime, "SOCCER"),
+                        fixedDateTime, "SOCCER", true),
                 new LeagueResponseToManage(2L, "탁구 대회", "시작 전", 2, 16, fixedDateTime,
-                        fixedDateTime, "SOCCER"));
+                        fixedDateTime, "SOCCER", false));
 
         Cookie cookie = new Cookie(COOKIE_NAME, "temp-cookie");
 
@@ -498,7 +500,8 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].maxRound").type(JsonFieldType.NUMBER).description("리그의 최대 라운드"),
                                 fieldWithPath("[].startAt").type(JsonFieldType.STRING).description("리그 시작 날짜"),
                                 fieldWithPath("[].endAt").type(JsonFieldType.STRING).description("리그 종료 날짜"),
-                                fieldWithPath("[].sportType").type(JsonFieldType.STRING).description("종목 (SOCCER, BASKETBALL)")
+                                fieldWithPath("[].sportType").type(JsonFieldType.STRING).description("종목 (SOCCER, BASKETBALL)"),
+                                fieldWithPath("[].thirdPlaceMatchEnabled").type(JsonFieldType.BOOLEAN).description("3·4위전 진행 여부")
                         )
                 ));
     }
@@ -534,7 +537,7 @@ public class LeagueQueryControllerTest extends DocumentationTest {
         );
         LeagueResponseWithGames response = new LeagueResponseWithGames(
                 1L, "첫번째 리그", 6, 16, LocalDateTime.of(2024, 8, 11, 13, 30), LocalDateTime.of(2024, 8, 30, 13, 30),
-                "SOCCER", playingGames, scheduledGames, finishedGames
+                "SOCCER", true, playingGames, scheduledGames, finishedGames
         );
 
         given(leagueQueryService.findLeagueAndGames(leagueId))
@@ -558,6 +561,7 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("startAt").type(JsonFieldType.STRING).description("리그 시작 시간"),
                                 fieldWithPath("endAt").type(JsonFieldType.STRING).description("리그 종료 시간"),
                                 fieldWithPath("sportType").type(JsonFieldType.STRING).description("종목 (SOCCER, BASKETBALL)"),
+                                fieldWithPath("thirdPlaceMatchEnabled").type(JsonFieldType.BOOLEAN).description("3·4위전 진행 여부"),
                                 fieldWithPath("playingGames").type(JsonFieldType.ARRAY).description("진행 중인 경기 목록"),
                                 fieldWithPath("playingGames[].id").type(JsonFieldType.NUMBER).description("경기 ID"),
                                 fieldWithPath("playingGames[].state").type(JsonFieldType.STRING).description("경기 상태"),


### PR DESCRIPTION
## 이슈

3·4위전 작업(#702, #703)에서 쓰기 경로만 반영하고 조회 응답을 빠뜨렸습니다. 프론트에서 `GET /leagues/{leagueId}` 응답에 `thirdPlaceMatchEnabled` 가 없다는 제보를 받았습니다.

단순 필드 누락이 아니라 설정이 뒤집히는 결함입니다.

`LeagueRequest.Update` 의 `thirdPlaceMatchEnabled` 는 primitive `boolean` 이라, 현재 값을 읽을 수 없는 프론트가 리그를 수정하면 `false` 로 전송됩니다.

- 경기가 이미 등록된 리그 → `LeagueService.update()` 의 `validateThirdPlaceChangeable` 에 걸려 400. 리그 이름만 바꾸려 해도 수정 자체가 막힘
- 경기가 없는 리그 → 검증을 통과하고 3·4위전 설정이 조용히 해제

## 변경 내용

조회 응답 DTO 3종에 `thirdPlaceMatchEnabled` 를 추가했습니다.

| DTO | 엔드포인트 |
|---|---|
| `LeagueDetailResponse` | `GET /leagues/{leagueId}` |
| `LeagueResponseToManage` | `GET /leagues/manager/manage` |
| `LeagueResponseWithGames` | `GET /leagues/{leagueId}/games` |

DB 컬럼(`V20`)과 도메인 필드는 이미 있어 스키마 변경은 없습니다.

## 테스트

- `LeagueQueryControllerTest` / `LeagueQueryServiceTest` / `LeagueQueryAcceptanceTest` 통과
- REST Docs 3개 스니펫에 필드 반영 확인
- `scripts/check-api-docs.sh` 통과 (97개 엔드포인트)

## 영향 API

응답에 필드가 추가되기만 하므로 하위 호환입니다.

- `GET /leagues/{leagueId}`
- `GET /leagues/manager/manage`
- `GET /leagues/{leagueId}/games`

## 프론트 참고

- 세 응답 모두 `thirdPlaceMatchEnabled: boolean` 이 내려갑니다.
- **리그 수정(`PATCH /leagues/{leagueId}`) 시 이 값을 그대로 실어 보내주세요.** 생략하면 `false` 로 처리되어 3·4위전 설정이 해제됩니다.
