### PR TITLE
fix: 경기 조회 응답에 3·4위전 여부 노출

### DIFF
--- a/src/main/java/com/sports/server/command/game/domain/Game.java
+++ b/src/main/java/com/sports/server/command/game/domain/Game.java
@@ -353,6 +353,14 @@ public class Game extends BaseEntity<Game> implements ManagedEntity {
         }
     }
 
+    /**
+     * 3·4위전 경기인지. {@code round} 를 숫자로만 내보내면 결승과 구분되지 않는다 —
+     * 두 라운드 모두 참가 팀 수가 2라 number 가 같기 때문이다.
+     */
+    public boolean isThirdPlaceMatch() {
+        return this.round == Round.THIRD_PLACE_MATCH;
+    }
+
     @Override
     public boolean isManagedBy(Member administrator) {
         return administrator.getId() == 1 || this.administrator.equals(administrator);

--- a/src/main/java/com/sports/server/query/dto/response/GameDetailResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/GameDetailResponse.java
@@ -15,6 +15,7 @@ public record GameDetailResponse(
         List<TeamResponse> gameTeams,
         String state,
         int round,
+        boolean thirdPlaceMatch,
         boolean isPkTaken,
         Long leagueId,
         String leagueName
@@ -33,6 +34,7 @@ public record GameDetailResponse(
                         .toList(),
                 game.getState().name(),
                 game.getRound().getNumber(),
+                game.isThirdPlaceMatch(),
                 game.getIsPkTaken(),
                 game.getLeague().getId(),
                 game.getLeague().getName()

--- a/src/main/java/com/sports/server/query/dto/response/GameResponseDto.java
+++ b/src/main/java/com/sports/server/query/dto/response/GameResponseDto.java
@@ -13,6 +13,7 @@ public record GameResponseDto(
         QuarterResponse gameQuarter,
         String gameName,
         int round,
+        boolean thirdPlaceMatch,
         String videoId,
         List<TeamResponse> gameTeams,
         boolean isPkTaken
@@ -24,6 +25,7 @@ public record GameResponseDto(
                 QuarterResponse.from(game.getQuarter()),
                 game.getName(),
                 game.getRound().getNumber(),
+                game.isThirdPlaceMatch(),
                 game.getVideoId(),
                 gameTeams.stream()
                         .sorted(Comparator.comparingLong(GameTeam::getId))

--- a/src/main/java/com/sports/server/query/dto/response/RecentLeagueGamesResponse.java
+++ b/src/main/java/com/sports/server/query/dto/response/RecentLeagueGamesResponse.java
@@ -25,6 +25,7 @@ public record RecentLeagueGamesResponse(
             QuarterResponse gameQuarter,
             String gameName,
             int round,
+            boolean thirdPlaceMatch,
             String videoId,
             String gameState,
             List<TeamResponse> gameTeams,
@@ -37,6 +38,7 @@ public record RecentLeagueGamesResponse(
                     QuarterResponse.from(game.getQuarter()),
                     game.getName(),
                     game.getRound().getNumber(),
+                    game.isThirdPlaceMatch(),
                     game.getVideoId(),
                     game.getState().name(),
                     gameTeams.stream()

--- a/src/test/java/com/sports/server/command/game/domain/GameTest.java
+++ b/src/test/java/com/sports/server/command/game/domain/GameTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.sports.server.command.league.domain.League;
+import com.sports.server.command.league.domain.Round;
 import com.sports.server.command.league.domain.SportType;
 import com.sports.server.common.exception.BadRequestException;
 import com.sports.server.common.exception.CustomException;
@@ -557,5 +558,35 @@ class GameTest {
         assertThatThrownBy(() -> game.changePlayerToCaptain(lineupPlayer))
                 .hasMessage("해당 게임팀은 이 게임에 포함되지 않습니다.")
                 .isInstanceOf(CustomException.class);
+    }
+
+    @Nested
+    @DisplayName("3·4위전 판정은")
+    class ThirdPlaceMatch {
+
+        @Test
+        void 라운드가_3_4위전이면_참이다() {
+            Game thirdPlace = entityBuilder(Game.class)
+                    .set("round", Round.THIRD_PLACE_MATCH)
+                    .set("gameTeams", new ArrayList<>())
+                    .sample();
+
+            assertThat(thirdPlace.isThirdPlaceMatch()).isTrue();
+        }
+
+        @Test
+        void 결승은_참가_팀_수가_같아도_거짓이다() {
+            // 두 라운드 모두 number 가 2라 숫자만으로는 구분되지 않는다
+            Game aFinal = entityBuilder(Game.class)
+                    .set("round", Round.FINAL)
+                    .set("gameTeams", new ArrayList<>())
+                    .sample();
+
+            assertAll(
+                    () -> assertThat(aFinal.isThirdPlaceMatch()).isFalse(),
+                    () -> assertThat(Round.FINAL.getNumber())
+                            .isEqualTo(Round.THIRD_PLACE_MATCH.getNumber())
+            );
+        }
     }
 }

--- a/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
+++ b/src/test/java/com/sports/server/query/acceptance/GameQueryAcceptanceTest.java
@@ -99,7 +99,7 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                         .containsExactly(
                                 new GameResponseDto(
                                         1L, LocalDateTime.of(2023, 11, 12, 10, 0, 0),
-                                        new QuarterResponse("PRE_GAME", "경기전"), "축구 대전", 4, "abc123",
+                                        new QuarterResponse("PRE_GAME", "경기전"), "축구 대전", 4, false, "abc123",
                                         List.of(new GameResponseDto.TeamResponse(
                                                         1L, "팀 A", "http://example.com/logo_a.png", 1, 0
                                                 ),
@@ -113,7 +113,7 @@ public class GameQueryAcceptanceTest extends AcceptanceTest {
                         .containsExactly(
                                 new GameResponseDto(
                                         2L, LocalDateTime.of(2023, 11, 12, 10, 10, 0),
-                                        new QuarterResponse("PRE_GAME", "경기전"), "두번째로 빠른 경기", 4, "abc123",
+                                        new QuarterResponse("PRE_GAME", "경기전"), "두번째로 빠른 경기", 4, false, "abc123",
                                         List.of(new GameResponseDto.TeamResponse(
                                                         3L, "팀 B", "http://example.com/logo_b.png", 0, 0),
                                                 new GameResponseDto.TeamResponse(

--- a/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/GameQueryControllerTest.java
@@ -36,7 +36,7 @@ class GameQueryControllerTest extends DocumentationTest {
         );
         LocalDateTime startTime = LocalDateTime.of(2024, 1, 19, 13, 0, 0);
         GameDetailResponse response = new GameDetailResponse(gameId,
-                startTime, "videoId", new QuarterResponse("FIRST_HALF", "전반전"), "여름축구", gameTeams, "PLAYING", 4, false, 1L, "외대 월드컵"
+                startTime, "videoId", new QuarterResponse("FIRST_HALF", "전반전"), "여름축구", gameTeams, "PLAYING", 4, false, false, 1L, "외대 월드컵"
         );
         given(gameQueryService.getGameDetail(gameId))
                 .willReturn(response);
@@ -61,6 +61,8 @@ class GameQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("gameQuarter.label").type(JsonFieldType.STRING).description("게임 쿼터 표시명"),
                                 fieldWithPath("gameName").type(JsonFieldType.STRING).description("게임 이름"),
                                 fieldWithPath("round").type(JsonFieldType.NUMBER).description("게임의 라운드"),
+                                fieldWithPath("thirdPlaceMatch").type(JsonFieldType.BOOLEAN)
+                                        .description("3·4위전 여부. 3·4위전과 결승은 참가 팀 수가 같아 round 값이 둘 다 2 라, 이 값으로 구분한다"),
                                 fieldWithPath("gameTeams[].gameTeamId").type(JsonFieldType.NUMBER)
                                         .description("게임팀의 ID"),
                                 fieldWithPath("gameTeams[].gameTeamName").type(JsonFieldType.STRING)
@@ -117,8 +119,8 @@ class GameQueryControllerTest extends DocumentationTest {
                 new GameResponseDto.TeamResponse(4L, "D팀", "logo.com", 2, 0)
         );
         List<GameResponseDto> responses = List.of(
-                new GameResponseDto(1L, startTime, new QuarterResponse("FIRST_HALF", "전반전"), "4강", 4, "abc123", gameTeams1, false),
-                new GameResponseDto(2L, startTime, new QuarterResponse("FIRST_HALF", "전반전"), "결승전", 2, "abc123", gameTeams2, false)
+                new GameResponseDto(1L, startTime, new QuarterResponse("FIRST_HALF", "전반전"), "4강", 4, false, "abc123", gameTeams1, false),
+                new GameResponseDto(2L, startTime, new QuarterResponse("FIRST_HALF", "전반전"), "결승전", 2, false, "abc123", gameTeams2, false)
         );
         List<LeagueWithGamesResponse> finalResponse = List.of(
                 new LeagueWithGamesResponse(1L, "2025 외대월드컵", responses)
@@ -167,6 +169,8 @@ class GameQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("content[].games[].gameName").type(JsonFieldType.STRING).description("게임 이름"),
                                 fieldWithPath("content[].games[].round").type(JsonFieldType.NUMBER)
                                         .description("라운드의 이름 ex. 4강->4, 결승->2"),
+                                fieldWithPath("content[].games[].thirdPlaceMatch").type(JsonFieldType.BOOLEAN)
+                                        .description("3·4위전 여부. 3·4위전과 결승은 참가 팀 수가 같아 round 값이 둘 다 2 라, 이 값으로 구분한다"),
                                 fieldWithPath("content[].games[].videoId").type(JsonFieldType.STRING).description("경기 영상 ID"),
                                 fieldWithPath("content[].games[].isPkTaken").type(JsonFieldType.BOOLEAN)
                                         .description("승부차기 진출 여부"),
@@ -424,8 +428,8 @@ class GameQueryControllerTest extends DocumentationTest {
         );
         
         List<GameDetailResponse> responses = List.of(
-                new GameDetailResponse(1L, startTime1, "video1", new QuarterResponse("FIRST_HALF", "전반전"), "4강", gameTeams1, "FINISHED", 4, false, 1L, "춘계리그"),
-                new GameDetailResponse(2L, startTime2, "video2", new QuarterResponse("SECOND_HALF", "후반전"), "결승", gameTeams2, "PLAYING", 2, false, 1L, "춘계리그")
+                new GameDetailResponse(1L, startTime1, "video1", new QuarterResponse("FIRST_HALF", "전반전"), "4강", gameTeams1, "FINISHED", 4, false, false, 1L, "춘계리그"),
+                new GameDetailResponse(2L, startTime2, "video2", new QuarterResponse("SECOND_HALF", "후반전"), "결승", gameTeams2, "PLAYING", 2, false, false, 1L, "춘계리그")
         );
 
         given(gameQueryService.getGamesByYearAndMonth(year, month))
@@ -454,6 +458,8 @@ class GameQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].gameQuarter.label").type(JsonFieldType.STRING).description("게임 쿼터 표시명"),
                                 fieldWithPath("[].gameName").type(JsonFieldType.STRING).description("게임 이름"),
                                 fieldWithPath("[].round").type(JsonFieldType.NUMBER).description("게임의 라운드"),
+                                fieldWithPath("[].thirdPlaceMatch").type(JsonFieldType.BOOLEAN)
+                                        .description("3·4위전 여부. 3·4위전과 결승은 참가 팀 수가 같아 round 값이 둘 다 2 라, 이 값으로 구분한다"),
                                 fieldWithPath("[].gameTeams[].gameTeamId").type(JsonFieldType.NUMBER)
                                         .description("게임팀의 ID"),
                                 fieldWithPath("[].gameTeams[].gameTeamName").type(JsonFieldType.STRING)

--- a/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/LeagueQueryControllerTest.java
@@ -728,6 +728,7 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                                         new QuarterResponse("FIRST_HALF", "전반전"),
                                         "결승전",
                                         2,
+                                        false,
                                         "abc123",
                                         "PLAYING",
                                         List.of(
@@ -767,6 +768,8 @@ public class LeagueQueryControllerTest extends DocumentationTest {
                                 fieldWithPath("[].games[].gameQuarter.label").type(JsonFieldType.STRING).description("경기 쿼터 표시명"),
                                 fieldWithPath("[].games[].gameName").type(JsonFieldType.STRING).description("경기 이름"),
                                 fieldWithPath("[].games[].round").type(JsonFieldType.NUMBER).description("경기 라운드"),
+                                fieldWithPath("[].games[].thirdPlaceMatch").type(JsonFieldType.BOOLEAN)
+                                        .description("3·4위전 여부. 3·4위전과 결승은 참가 팀 수가 같아 round 값이 둘 다 2 라, 이 값으로 구분한다"),
                                 fieldWithPath("[].games[].videoId").type(JsonFieldType.STRING).description("경기 영상 ID").optional(),
                                 fieldWithPath("[].games[].gameState").type(JsonFieldType.STRING).description("경기 상태 (PLAYING, FINISHED, SCHEDULED)"),
                                 fieldWithPath("[].games[].isPkTaken").type(JsonFieldType.BOOLEAN).description("승부차기 진출 여부"),

--- a/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
+++ b/src/test/java/com/sports/server/query/presentation/TeamQueryControllerTest.java
@@ -205,9 +205,9 @@ public class TeamQueryControllerTest extends DocumentationTest {
 
         List<GameDetailResponse> response = List.of(
                 new GameDetailResponse(1L, LocalDateTime.of(2025, 8, 21, 19, 30, 0), "video-id", new QuarterResponse("SECOND_HALF", "후반전"), "혁명 대전 결승",
-                        gameTeams1, "PLAYING", 2, false,1L, "혁명 대전"),
+                        gameTeams1, "PLAYING", 2, false, false,1L, "혁명 대전"),
                 new GameDetailResponse(2L, LocalDateTime.of(2024, 10, 10, 13, 0, 0), "video-id", new QuarterResponse("PENALTY_SHOOTOUT", "승부차기"), "외교 대전 4강",
-                        gameTeams2, "FINISHED", 4, true, 2L,"외교 대전")
+                        gameTeams2, "FINISHED", 4, false, true, 2L,"외교 대전")
         );
 
         given(gameQueryService.getAllGamesDetailByTeam(teamId)).willReturn(response);
@@ -256,9 +256,9 @@ public class TeamQueryControllerTest extends DocumentationTest {
         );
         List<GameDetailResponse> recentGames = List.of(
                 new GameDetailResponse(1L, LocalDateTime.of(2025, 8, 21, 19, 30, 0), "video-id", new QuarterResponse("SECOND_HALF", "후반전"), "혁명 대전 결승",
-                        gameTeams1, "PLAYING", 2, false,1L, "혁명 대전"),
+                        gameTeams1, "PLAYING", 2, false, false,1L, "혁명 대전"),
                 new GameDetailResponse(2L, LocalDateTime.of(2024, 10, 10, 13, 0, 0), "video-id", new QuarterResponse("PENALTY_SHOOTOUT", "승부차기"), "외교 대전 4강",
-                        gameTeams2, "FINISHED", 4, true, 2L,"외교 대전")
+                        gameTeams2, "FINISHED", 4, false, true, 2L,"외교 대전")
         );
 
         List<TeamSummaryResponse> teamSummaryResponses = List.of(new TeamSummaryResponse(teamDetail, recentGames));
@@ -350,6 +350,8 @@ public class TeamQueryControllerTest extends DocumentationTest {
                 fieldWithPath(prefix + "gameName").type(JsonFieldType.STRING).description("경기 이름"),
                 fieldWithPath(prefix + "state").type(JsonFieldType.STRING).description("경기 상태 (SCHEDULED, PLAYING, FINISHED)"),
                 fieldWithPath(prefix + "round").type(JsonFieldType.NUMBER).description("현재 라운드"),
+                fieldWithPath(prefix + "thirdPlaceMatch").type(JsonFieldType.BOOLEAN)
+                        .description("3·4위전 여부. 3·4위전과 결승은 참가 팀 수가 같아 round 값이 둘 다 2 라, 이 값으로 구분한다"),
                 fieldWithPath(prefix + "isPkTaken").type(JsonFieldType.BOOLEAN).description("승부차기 진행 여부"),
 
                 fieldWithPath(prefix + "gameTeams").type(JsonFieldType.ARRAY).description("경기에 참여하는 두 팀의 정보"),


### PR DESCRIPTION
## 이슈

프론트에서 `GET /leagues/{leagueId}` 의 `thirdPlaceMatchEnabled` 누락(#709)을 제보받고 3·4위전 관련 조회 응답을 점검하다 발견했다.

`Round.FINAL` 과 `Round.THIRD_PLACE_MATCH` 는 **number 가 둘 다 2** 다.

```java
FINAL("결승", 2, true),
THIRD_PLACE_MATCH("3·4위전", 2, false),
```

number 의 의미가 "참가 팀 수" 라 3·4위전도 두 팀이어서 같은 값이고, 실제 구분은 `inBracketTree` 플래그가 한다. 그런데 조회 응답은 `getRound().getNumber()` 만 내보내므로 **프론트는 3·4위전 경기와 결승 경기를 구분할 수 없다.** `round == 2` 를 "결승" 으로 표시하고 있다면 3·4위전이 결승으로 잘못 보인다.

## 변경 내용

`Game.isThirdPlaceMatch()` 를 도메인에 두고, `round` 를 노출하는 조회 응답 3종에 `thirdPlaceMatch` 를 추가했다.

| DTO | 엔드포인트 |
|---|---|
| `GameDetailResponse` | `GET /games/{gameId}`, `GET /games` (연월 검색), `GET /teams/{teamId}/games`, 팀별보기 |
| `GameResponseDto` | `GET /games` (리그별 그룹) |
| `RecentLeagueGamesResponse.GameResponse` | `GET /leagues/recent/games` |

`round` 자체는 그대로 둔다. 라운드 숫자가 전 API 공통 계약이라 한 곳만 표현을 바꾸면 갈라지기 때문이고, 이 판단의 배경은 #703 에 정리돼 있다.

## 테스트

- `GameTest` (신규) — 3·4위전이면 `true`, **결승은 number 가 같아도 `false`** (두 라운드의 number 가 실제로 같다는 것도 함께 단언해 회귀를 고정)
- `GameQueryControllerTest` / `TeamQueryControllerTest` / `LeagueQueryControllerTest` / `GameQueryAcceptanceTest` — 응답 필드 반영
- 로컬 관련 테스트 58건 green (전체 회귀는 CI 기준)
- REST Docs 조회 스니펫 6개 반영 / `check-api-docs.sh` 97개 통과
- 스키마 변경 없음

## 영향 API

응답에 필드가 추가되기만 하므로 하위 호환이다.

- `GET /games/{gameId}`
- `GET /games`
- `GET /teams/{teamId}/games`
- `GET /leagues/recent/games`

## 프론트 참고

- 위 응답들에 `thirdPlaceMatch: boolean` 이 내려간다.
- **`round` 만으로 결승을 판단하면 안 된다.** `round === 2 && !thirdPlaceMatch` 여야 결승이고, `round === 2 && thirdPlaceMatch` 가 3·4위전이다.
- 이미 `round === 2` 를 결승으로 표시하고 있었다면 3·4위전 경기가 결승으로 보이던 상태이므로, 표시 로직을 함께 확인해 주세요.
